### PR TITLE
Allowed "Managed" type in validation function for Synthetic Location Type

### DIFF
--- a/instana/data-source-synthetic-location.go
+++ b/instana/data-source-synthetic-location.go
@@ -49,8 +49,8 @@ func (ds *syntheticLocationDataSource) CreateResource() *schema.Resource {
 			SyntheticLocationFieldLocationType: {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Description:  "Indicates if the location is public or private",
-				ValidateFunc: validation.StringInSlice([]string{"Public", "Private"}, true),
+				Description:  "Indicates if the location is public, private or managed",
+				ValidateFunc: validation.StringInSlice([]string{"Public", "Private", "Managed"}, true),
 			},
 		},
 	}


### PR DESCRIPTION
Currently supported values for Synthetic Location Type fields are "Public" and "Private"
Refer to [Instana hosted PoPs](https://www.ibm.com/docs/en/instana-observability/current?topic=monitoring-using-instana-hosted-pop ) , the location type "Managed" refer to PoP hosted by Instana. Refer to related [terminology](https://www.ibm.com/docs/en/instana-observability/current?topic=instana-synthetic-monitoring#terminology )


