### PR TITLE
Add API implementation for Infra Alert Config

### DIFF
--- a/instana/restapi/Instana-api.go
+++ b/instana/restapi/Instana-api.go
@@ -36,7 +36,6 @@ type InstanaAPI interface {
 	SliConfigs() RestResource[*SliConfig]
 	WebsiteMonitoringConfig() RestResource[*WebsiteMonitoringConfig]
 	WebsiteAlertConfig() RestResource[*WebsiteAlertConfig]
-	InfraAlertConfig() RestResource[*InfraAlertConfig]
 	Groups() RestResource[*Group]
 	CustomDashboards() RestResource[*CustomDashboard]
 	SyntheticTest() RestResource[*SyntheticTest]

--- a/instana/restapi/Instana-api.go
+++ b/instana/restapi/Instana-api.go
@@ -36,6 +36,7 @@ type InstanaAPI interface {
 	SliConfigs() RestResource[*SliConfig]
 	WebsiteMonitoringConfig() RestResource[*WebsiteMonitoringConfig]
 	WebsiteAlertConfig() RestResource[*WebsiteAlertConfig]
+	InfraAlertConfig() RestResource[*InfraAlertConfig]
 	Groups() RestResource[*Group]
 	CustomDashboards() RestResource[*CustomDashboard]
 	SyntheticTest() RestResource[*SyntheticTest]
@@ -102,6 +103,10 @@ func (api *baseInstanaAPI) WebsiteMonitoringConfig() RestResource[*WebsiteMonito
 
 func (api *baseInstanaAPI) WebsiteAlertConfig() RestResource[*WebsiteAlertConfig] {
 	return NewCreatePOSTUpdatePOSTRestResource(WebsiteAlertConfigResourcePath, NewCustomPayloadFieldsUnmarshallerAdapter(NewDefaultJSONUnmarshaller(&WebsiteAlertConfig{})), api.client)
+}
+
+func (api *baseInstanaAPI) InfraAlertConfig() RestResource[*InfraAlertConfig] {
+	return NewCreatePOSTUpdatePOSTRestResource(InfraAlertConfigResourcePath, NewCustomPayloadFieldsUnmarshallerAdapter(NewDefaultJSONUnmarshaller(&InfraAlertConfig{})), api.client)
 }
 
 func (api *baseInstanaAPI) Groups() RestResource[*Group] {

--- a/instana/restapi/aggregation.go
+++ b/instana/restapi/aggregation.go
@@ -48,7 +48,12 @@ const (
 	DistinctCountAggregation = Aggregation("DISTINCT_COUNT")
 	//SumPositiveAggregation constant value for the sum positive aggregation type
 	SumPositiveAggregation = Aggregation("SUM_POSITIVE")
+	PerSecondAggregation   = Aggregation("PER_SECOND")
+	IncreaseAggregation    = Aggregation("INCREASE")
 )
 
 // SupportedAggregations list of all supported Aggregation
-var SupportedAggregations = Aggregations{SumAggregation, MeanAggregation, MaxAggregation, MinAggregation, Percentile25Aggregation, Percentile50Aggregation, Percentile75Aggregation, Percentile90Aggregation, Percentile95Aggregation, Percentile98Aggregation, Percentile99Aggregation, Percentile99_9Aggregation, Percentile99_99Aggregation, DistributionAggregation, DistinctCountAggregation, SumPositiveAggregation}
+var SupportedAggregations = Aggregations{SumAggregation, MeanAggregation, MaxAggregation, MinAggregation, Percentile25Aggregation,
+	Percentile50Aggregation, Percentile75Aggregation, Percentile90Aggregation, Percentile95Aggregation, Percentile98Aggregation,
+	Percentile99Aggregation, Percentile99_9Aggregation, Percentile99_99Aggregation, DistributionAggregation,
+	DistinctCountAggregation, SumPositiveAggregation, PerSecondAggregation, IncreaseAggregation}

--- a/instana/restapi/aggregation_test.go
+++ b/instana/restapi/aggregation_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestShouldReturnSupportedAggregationsAsStringSlice(t *testing.T) {
-	expected := []string{"SUM", "MEAN", "MAX", "MIN", "P25", "P50", "P75", "P90", "P95", "P98", "P99", "P99_9", "P99_99", "DISTRIBUTION", "DISTINCT_COUNT", "SUM_POSITIVE"}
+	expected := []string{"SUM", "MEAN", "MAX", "MIN", "P25", "P50", "P75", "P90", "P95", "P98", "P99", "P99_9", "P99_99",
+		"DISTRIBUTION", "DISTINCT_COUNT", "SUM_POSITIVE", "PER_SECOND", "INCREASE"}
 	require.Equal(t, expected, SupportedAggregations.ToStringSlice())
 }

--- a/instana/restapi/infra-alert-configs.go
+++ b/instana/restapi/infra-alert-configs.go
@@ -1,0 +1,28 @@
+package restapi
+
+const InfraAlertConfigResourcePath = EventSettingsBasePath + "/infra-alert-configs"
+
+type InfraAlertConfig struct {
+	ID                    string                              `json:"id"`
+	Name                  string                              `json:"name"`
+	Description           string                              `json:"description"`
+	TagFilterExpression   *TagFilter                          `json:"tagFilterExpression"`
+	GroupBy               []string                            `json:"groupBy"`
+	AlertChannelIDs       []string                            `json:"alertChannelIds"`
+	Granularity           Granularity                         `json:"granularity"`
+	TimeThreshold         InfraTimeThreshold                  `json:"timeThreshold"`
+	CustomerPayloadFields []CustomPayloadField[any]           `json:"customPayloadFields"`
+	Rules                 []RuleWithThreshold[InfraAlertRule] `json:"rules"`
+}
+
+func (config *InfraAlertConfig) GetIDForResourcePath() string {
+	return config.ID
+}
+
+func (config *InfraAlertConfig) GetCustomerPayloadFields() []CustomPayloadField[any] {
+	return config.CustomerPayloadFields
+}
+
+func (config *InfraAlertConfig) SetCustomerPayloadFields(fields []CustomPayloadField[any]) {
+	config.CustomerPayloadFields = fields
+}

--- a/instana/restapi/infra-alert-rule.go
+++ b/instana/restapi/infra-alert-rule.go
@@ -1,0 +1,10 @@
+package restapi
+
+type InfraAlertRule struct {
+	AlertType              string       `json:"alertType"`
+	MetricName             string       `json:"metricName"`
+	EntityType             string       `json:"entityType"`
+	Aggregation            *Aggregation `json:"aggregation"`
+	CrossSeriesAggregation *Aggregation `json:"crossSeriesAggregation"`
+	Regex                  bool         `json:"regex"`
+}

--- a/instana/restapi/infra-time-threshold.go
+++ b/instana/restapi/infra-time-threshold.go
@@ -1,0 +1,6 @@
+package restapi
+
+type InfraTimeThreshold struct {
+	Type       string `json:"type"`
+	TimeWindow *int64 `json:"timeWindow"`
+}

--- a/instana/restapi/rule-with-threshold.go
+++ b/instana/restapi/rule-with-threshold.go
@@ -1,0 +1,18 @@
+package restapi
+
+type RuleWithThreshold[R InfraAlertRule | ApplicationAlertRule | WebsiteAlertRule] struct {
+	ThresholdOperator ThresholdOperator               `json:"thresholdOperator"`
+	Rule              R                               `json:"rule"`
+	Thresholds        map[AlertSeverity]ThresholdRule `json:"thresholds"`
+}
+
+type AlertSeverity string
+type AlertSeverities []AlertSeverity
+
+const (
+	WarningSeverity  = AlertSeverity("WARNING")
+	CriticalSeverity = AlertSeverity("CRITICAL")
+)
+
+// SupportedAlertSeverities : will be used as part of validation in a follow-up.
+var SupportedAlertSeverities = AlertSeverities{WarningSeverity, CriticalSeverity}

--- a/instana/restapi/threshold.go
+++ b/instana/restapi/threshold.go
@@ -72,3 +72,11 @@ type TimeThreshold struct {
 	Requests   *int32 `json:"requests"`
 	Violations *int32 `json:"violations"`
 }
+
+type ThresholdRule struct {
+	Type            string                `json:"type"`
+	Value           *float64              `json:"value"`
+	Seasonality     *ThresholdSeasonality `json:"seasonality"`
+	Baseline        *[][]float64          `json:"baseline"`
+	DeviationFactor *float32              `json:"deviationFactor"`
+}


### PR DESCRIPTION
We want to add support for **Infrastructure Smart Alerts**.

This PR adds API implementation for Infra Alert Config.
In a follow-up PR, I'll add resource changes with the required TF schema.