### PR TITLE
Add infra alert config resource

### DIFF
--- a/docs/resources/infra_alert_config.md
+++ b/docs/resources/infra_alert_config.md
@@ -1,0 +1,162 @@
+# Infrastructure Alert Configuration Resource
+
+Management of Infrastructure alert configurations (Infrastructure Smart Alerts).
+
+API Documentation: <https://instana.github.io/openapi/#tag/Infrastructure-Alert-Configuration>
+
+The ID of the resource which is also used as unique identifier in Instana is auto generated!
+
+## Example Usage
+
+```hcl
+resource "instana_infra_alert_config" "example" {
+  name = "test-alert"
+  description = "test-alert-description"
+  alert_channels {
+    warning = ["alert-channel-id-1"]
+    critical = ["alert-channel-id-2"]
+  }
+  group_by = ["metricId"]
+  granularity = 600000
+  tag_filter = "host.fqdn@na STARTS_WITH 'fooBar'"
+
+  rules {
+    generic_rule {
+      metric_name = "cpu\\.(nice|user|sys|wait)"
+      entity_type = "host"
+      aggregation = "MEAN"
+      cross_series_aggregation = "SUM"
+      regex = true
+      threshold_operator = ">="
+
+      threshold {
+        
+        critical {
+          static {
+            value = 5.0
+          }
+        }
+        
+        warning {
+          static {
+            value = 3.0
+          }
+        }
+        
+      }
+    }
+  }
+
+  time_threshold {
+    violations_in_sequence {
+      time_window = 600000
+    }
+  }
+
+  custom_payload_field {
+    key = "test1"
+    value = "foo"
+  }
+
+  custom_payload_field {
+    key = "test2"
+    dynamic_value {
+      key = "dynamic-value-key"
+      tag_name = "dynamic-value-tag-name"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+* `name` - Required - The name for the infrastructure alert configuration
+* `description` - Required - The description text of the infrastructure alert config
+* `alert_channels` - Optional - Set of alert channel IDs associated with the severity. [Details](#alert-channels-reference)
+* `group_by` - Optional - The grouping tags used to group the metric results.
+* `granularity` - Optional - default `600000` - The evaluation granularity used for detection of violations of the defined threshold. In other words, it defines the size of the tumbling window used. Allowed values: `300000`, `600000`, `900000`, `1200000`, `800000`
+* `tag_filter` - Optional - The tag filter of the global application alert config. [Details](#tag-filter-argument-reference)
+* `rules` - Required - A list of rules where each rule is associated with multiple thresholds and their corresponding severity levels. This enables more complex alert configurations with validations to ensure consistent and logical threshold-severity combinations. [Details](#rules-argument-reference)
+* `time_threshold` - Required - Indicates the type of violation of the defined threshold.  [Details](#time-threshold-argument-reference)
+* `custom_payload_filed` - Optional - An optional list of custom payload fields (static key/value pairs added to the event).  [Details](#custom-payload-field-argument-reference)
+
+### Alert Channels Reference
+
+* `warning` - Optional - List of alert channel IDs associated with the warning severity 
+* `critical` - Optional - List of alert channel IDs associated with the critical severity
+
+### Tag Filter Argument Reference
+The **tag_filter** defines which entities should be included into the application. It supports:
+
+* logical AND and/or logical OR conjunctions whereas AND has higher precedence then OR
+* comparison operators EQUALS, NOT_EQUAL, CONTAINS | NOT_CONTAIN, STARTS_WITH, ENDS_WITH, NOT_STARTS_WITH, NOT_ENDS_WITH, GREATER_OR_EQUAL_THAN, LESS_OR_EQUAL_THAN, LESS_THAN, GREATER_THAN
+* unary operators IS_EMPTY, NOT_EMPTY, IS_BLANK, NOT_BLANK.
+
+The **tag_filter** is defined by the following eBNF:
+
+```plain
+tag_filter                := logical_or
+logical_or                := logical_and OR logical_or | logical_and
+logical_and               := primary_expression AND logical_and | primary_expression
+primary_expression        := comparison | unary_operator_expression
+comparison                := identifier comparison_operator value | identifier@entity_origin comparison_operator value | identifier:tag_key comparison_operator value | identifier:tag_key@entity_origin comparison_operator value
+comparison_operator       := EQUALS | NOT_EQUAL | CONTAINS | NOT_CONTAIN | STARTS_WITH | ENDS_WITH | NOT_STARTS_WITH | NOT_ENDS_WITH | GREATER_OR_EQUAL_THAN | LESS_OR_EQUAL_THAN | LESS_THAN | GREATER_THAN
+unary_operator_expression := identifier unary_operator | identifier@entity_origin unary_operator
+unary_operator            := IS_EMPTY | NOT_EMPTY | IS_BLANK | NOT_BLANK
+tag_key                   := identifier | string_value
+entity_origin             := src | dest | na
+value                     := string_value | number_value | boolean_value
+string_value              := "'" <string> "'"
+number_value              := (+-)?[0-9]+
+boolean_value             := TRUE | FALSE
+identifier                := [a-zA-Z_][\.a-zA-Z0-9_\-/]*
+```
+
+### Rules Argument Reference
+
+* `generic_rule` - Required - A generic rule based on custom aggregated metric [Details](#generic-rule-argument-reference)
+
+#### Generic Rule Argument Reference 
+
+* `metric_name` - Required - The metric name of the infrastructure alert rule
+* `entity_type` - Required - The entity type of the infrastructure alert rule
+* `aggregation` - Required - The aggregation function of the infra alert rule. Supported values `MEAN`, `MAX`, `MIN`, `P25`, `P50`, `P75`, `P90`, `P95`, `P98`, `P99`, `SUM`, `PER_SECOND`
+* `cross_series_aggregation` - Required - Cross-series aggregation function of the infra alert rule. Supported values `MEAN`, `MAX`, `MIN`, `P25`, `P50`, `P75`, `P90`, `P95`, `P98`, `P99`, `SUM`
+* `regex` - Optional - Indicates if the given metric name follows regex pattern or not
+* `threshold_operator` - Required - The operator which will be applied to evaluate the threshold
+* `threshold` - Required - Indicates the type of threshold associated with given severity this alert rule is evaluated on.  [Details](#threshold-rule-argument-reference)
+* `time_threshold` - Required - Indicates the type of violation of the defined threshold.  [Details](#time-threshold-argument-reference)
+
+#### Threshold Rule Argument Reference
+
+At least one of the elements below must be configured
+
+* `warning` - Optional - Threshold associated with the warning severity [Details](#threshold-argument-reference)
+* `critical` - Optional - Threshold associated with the critical severity [Details](#threshold-argument-reference)
+
+##### Threshold Argument Reference
+
+* `static` - Required - Static threshold definition. [Details](#static-threshold-argument-reference)
+
+###### Static Threshold Argument Reference
+
+* `operator` - Required - The operator which will be applied to evaluate the threshold. Supported values: `>`, `>=`, `<`, `<=`
+* `value` - Optional - The value of the static threshold
+
+### Time Threshold Argument Reference
+
+* `violations_in_sequence` - Required - Time threshold base on violations in sequence. [Details](#violations-in-sequence-time-threshold-argument-reference)
+
+#### Violations In Sequence Time Threshold Argument Reference
+
+* `time_window` - Required - The time window if the time threshold
+
+### Custom Payload Field Argument Reference
+
+* `key` - Required - The key of the custom payload field
+* `value` - Optional - The static string value of the custom payload field. Either `value` or `dynamic_value` must be defined.
+* `dynamic_value` - Optional - The dynamic value of the custom payload field [Details](#dynamic-custom-payload-field-value). Either `value` or `dynamic_value` must be defined.
+
+#### Dynamic Custom Payload Field Value
+* `key` - Optional - The key of the tag which should be added to the payload
+* `tag_name` - Required - The name of the tag which should be added to the payload

--- a/instana/provider.go
+++ b/instana/provider.go
@@ -68,6 +68,7 @@ func providerResources() map[string]*schema.Resource {
 	bindResourceHandle(resources, NewAlertingConfigResourceHandle())
 	bindResourceHandle(resources, NewSliConfigResourceHandle())
 	bindResourceHandle(resources, NewWebsiteMonitoringConfigResourceHandle())
+	bindResourceHandle(resources, NewInfraAlertConfigResourceHandle())
 	bindResourceHandle(resources, NewWebsiteAlertConfigResourceHandle())
 	bindResourceHandle(resources, NewGroupResourceHandle())
 	bindResourceHandle(resources, NewCustomDashboardResourceHandle())

--- a/instana/provider_test.go
+++ b/instana/provider_test.go
@@ -29,7 +29,7 @@ func TestProviderShouldContainValidSchemaDefinition(t *testing.T) {
 func TestProviderShouldContainValidResourceDefinitions(t *testing.T) {
 	config := Provider()
 
-	assert.Equal(t, 13, len(config.ResourcesMap))
+	assert.Equal(t, 14, len(config.ResourcesMap))
 
 	assert.NotNil(t, config.ResourcesMap[ResourceInstanaAPIToken])
 	assert.NotNil(t, config.ResourcesMap[ResourceInstanaApplicationConfig])
@@ -38,6 +38,7 @@ func TestProviderShouldContainValidResourceDefinitions(t *testing.T) {
 	assert.NotNil(t, config.ResourcesMap[ResourceInstanaSliConfig])
 	assert.NotNil(t, config.ResourcesMap[ResourceInstanaWebsiteMonitoringConfig])
 	assert.NotNil(t, config.ResourcesMap[ResourceInstanaWebsiteAlertConfig])
+	assert.NotNil(t, config.ResourcesMap[ResourceInstanaInfraAlertConfig])
 	assert.NotNil(t, config.ResourcesMap[ResourceInstanaGroup])
 	assert.NotNil(t, config.ResourcesMap[ResourceInstanaCustomDashboard])
 	assert.NotNil(t, config.ResourcesMap[ResourceInstanaSyntheticTest])
@@ -54,5 +55,4 @@ func TestProviderShouldContainValidDataSourceDefinitions(t *testing.T) {
 	assert.NotNil(t, config.DataSourcesMap[DataSourceBuiltinEvent])
 	assert.NotNil(t, config.DataSourcesMap[DataSourceSyntheticLocation])
 	assert.NotNil(t, config.DataSourcesMap[DataSourceAlertingChannel])
-
 }

--- a/instana/resource-infra-alert-config.go
+++ b/instana/resource-infra-alert-config.go
@@ -1,0 +1,528 @@
+package instana
+
+import (
+	"context"
+	"github.com/gessnerfl/terraform-provider-instana/instana/restapi"
+	"github.com/gessnerfl/terraform-provider-instana/instana/tagfilter"
+	"github.com/gessnerfl/terraform-provider-instana/tfutils"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+const ResourceInstanaInfraAlertConfig = "instana_infra_alert_config"
+
+const (
+	InfraAlertConfigFieldName                  = "name"
+	InfraAlertConfigFieldFullName              = "full_name"
+	InfraAlertConfigFieldDescription           = "description"
+	InfraAlertConfigFieldAlertChannels         = "alert_channels"
+	ResourceFieldThresholdRuleWarningSeverity  = "warning"
+	ResourceFieldThresholdRuleCriticalSeverity = "critical"
+	InfraAlertConfigFieldGroupBy               = "group_by"
+	InfraAlertConfigFieldGranularity           = "granularity"
+	InfraAlertConfigFieldTagFilter             = "tag_filter"
+
+	InfraAlertConfigFieldRules       = "rules"
+	InfraAlertConfigFieldGenericRule = "generic_rule"
+
+	InfraAlertConfigFieldMetricName             = "metric_name"
+	InfraAlertConfigFieldEntityType             = "entity_type"
+	InfraAlertConfigFieldAggregation            = "aggregation"
+	InfraAlertConfigFieldCrossSeriesAggregation = "cross_series_aggregation"
+	InfraAlertConfigFieldRegex                  = "regex"
+	InfraAlertConfigFieldThresholdOperator      = "threshold_operator"
+
+	InfraAlertConfigFieldTimeThreshold                     = "time_threshold"
+	InfraAlertConfigFieldTimeThresholdTimeWindow           = "time_window"
+	InfraAlertConfigFieldTimeThresholdViolationsInSequence = "violations_in_sequence"
+)
+
+var (
+	infraAlertConfigSchemaAlertChannels = &schema.Schema{
+		Type:     schema.TypeList,
+		MinItems: 0,
+		MaxItems: 1,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				ResourceFieldThresholdRuleWarningSeverity: {
+					Type:     schema.TypeList,
+					MinItems: 0,
+					MaxItems: 1024,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+					Optional:    true,
+					Description: "List of IDs of alert channels defined in Instana.",
+				},
+				ResourceFieldThresholdRuleCriticalSeverity: {
+					Type:     schema.TypeList,
+					MinItems: 0,
+					MaxItems: 1024,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+					Optional:    true,
+					Description: "List of IDs of alert channels defined in Instana.",
+				},
+			},
+		},
+		Description: "Set of alert channel IDs associated with the severity.",
+	}
+	infraAlertConfigSchemaGroupBy = &schema.Schema{
+		Type:     schema.TypeList,
+		MinItems: 0,
+		MaxItems: 5,
+		Elem: &schema.Schema{
+			Type: schema.TypeString,
+		},
+		Optional:    true,
+		Description: "The grouping tags used to group the metric results.",
+	}
+	infraAlertConfigSchemaRules = &schema.Schema{
+		Type:        schema.TypeList,
+		MinItems:    1,
+		MaxItems:    1,
+		Required:    true,
+		Description: "A list of rules where each rule is associated with multiple thresholds and their corresponding severity levels. This enables more complex alert configurations with validations to ensure consistent and logical threshold-severity combinations.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				InfraAlertConfigFieldGenericRule: {
+					Type:        schema.TypeList,
+					MinItems:    1,
+					MaxItems:    1,
+					Required:    true,
+					Description: "",
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							InfraAlertConfigFieldMetricName: {
+								Type:        schema.TypeString,
+								Required:    true,
+								Description: "The metric name of the infrastructure alert rule",
+							},
+							InfraAlertConfigFieldEntityType: {
+								Type:        schema.TypeString,
+								Required:    true,
+								Description: "The entity type of the infrastructure alert rule",
+							},
+							InfraAlertConfigFieldAggregation: {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringInSlice(restapi.InfraExploreAggregations.ToStringSlice(), false),
+							},
+							InfraAlertConfigFieldCrossSeriesAggregation: {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringInSlice(restapi.TimeAggregations.ToStringSlice(), false),
+							},
+							InfraAlertConfigFieldRegex: {
+								Type:        schema.TypeBool,
+								Optional:    true,
+								Description: "Indicates if the given metric name follows regex pattern or not",
+							},
+							InfraAlertConfigFieldThresholdOperator: {
+								Type:         schema.TypeString,
+								Required:     true,
+								Description:  "The operator which will be applied to evaluate the threshold",
+								ValidateFunc: validation.StringInSlice(restapi.SupportedThresholdOperators.ToStringSlice(), true),
+							},
+
+							ResourceFieldThresholdRule: {
+								Type:        schema.TypeList,
+								MinItems:    1,
+								MaxItems:    1,
+								Required:    true,
+								Description: "",
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										ResourceFieldThresholdRuleWarningSeverity:  thresholdRuleSchema,
+										ResourceFieldThresholdRuleCriticalSeverity: thresholdRuleSchema,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	infraAlertConfigSchemaName = &schema.Schema{
+		Type:         schema.TypeString,
+		Required:     true,
+		Description:  "Name for the Infrastructure alert configuration",
+		ValidateFunc: validation.StringLenBetween(0, 256),
+	}
+	infraAlertConfigSchemaDescription = &schema.Schema{
+		Type:         schema.TypeString,
+		Required:     true,
+		Description:  "The description text of the Infrastructure alert config",
+		ValidateFunc: validation.StringLenBetween(0, 65536),
+	}
+	infraAlertConfigSchemaGranularity = &schema.Schema{
+		Type:         schema.TypeInt,
+		Optional:     true,
+		Default:      restapi.Granularity600000,
+		ValidateFunc: validation.IntInSlice(restapi.SupportedGranularities.ToIntSlice()),
+		Description:  "The evaluation granularity used for detection of violations of the defined threshold. In other words, it defines the size of the tumbling window used",
+	}
+	infraAlertConfigSchemaTimeThreshold = &schema.Schema{
+		Type:        schema.TypeList,
+		MinItems:    1,
+		MaxItems:    1,
+		Required:    true,
+		Description: "Indicates the type of violation of the defined threshold.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				InfraAlertConfigFieldTimeThresholdViolationsInSequence: {
+					Type:        schema.TypeList,
+					MinItems:    1,
+					MaxItems:    1,
+					Required:    true,
+					Description: "Time threshold base on violations in sequence",
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							InfraAlertConfigFieldTimeThresholdTimeWindow: {
+								Type:     schema.TypeInt,
+								Optional: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+)
+
+var infraAlertConfigResourceSchema = map[string]*schema.Schema{
+	InfraAlertConfigFieldName:          infraAlertConfigSchemaName,
+	InfraAlertConfigFieldDescription:   infraAlertConfigSchemaDescription,
+	InfraAlertConfigFieldAlertChannels: infraAlertConfigSchemaAlertChannels,
+	InfraAlertConfigFieldGroupBy:       infraAlertConfigSchemaGroupBy,
+	InfraAlertConfigFieldGranularity:   infraAlertConfigSchemaGranularity,
+	InfraAlertConfigFieldTagFilter:     OptionalTagFilterExpressionSchema,
+	InfraAlertConfigFieldRules:         infraAlertConfigSchemaRules,
+	DefaultCustomPayloadFieldsName:     buildCustomPayloadFields(),
+	InfraAlertConfigFieldTimeThreshold: infraAlertConfigSchemaTimeThreshold,
+}
+
+func (c *infraAlertConfigResource) stateUpgradeV0(_ context.Context, state map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
+	if _, ok := state[InfraAlertConfigFieldFullName]; ok {
+		state[InfraAlertConfigFieldName] = state[InfraAlertConfigFieldFullName]
+		delete(state, InfraAlertConfigFieldFullName)
+	}
+	return state, nil
+}
+
+func (c *infraAlertConfigResource) schemaV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			InfraAlertConfigFieldName:          infraAlertConfigSchemaName,
+			InfraAlertConfigFieldDescription:   infraAlertConfigSchemaDescription,
+			InfraAlertConfigFieldAlertChannels: infraAlertConfigSchemaAlertChannels,
+			InfraAlertConfigFieldGranularity:   infraAlertConfigSchemaGranularity,
+			InfraAlertConfigFieldTagFilter:     OptionalTagFilterExpressionSchema,
+			InfraAlertConfigFieldRules:         infraAlertConfigSchemaRules,
+			DefaultCustomPayloadFieldsName:     buildCustomPayloadFields(),
+			InfraAlertConfigFieldTimeThreshold: infraAlertConfigSchemaTimeThreshold,
+		},
+	}
+}
+
+// NewInfraAlertConfigResourceHandle creates the resource handle for Website Alert Configs
+func NewInfraAlertConfigResourceHandle() ResourceHandle[*restapi.InfraAlertConfig] {
+	return &infraAlertConfigResource{
+		metaData: ResourceMetaData{
+			ResourceName:     ResourceInstanaInfraAlertConfig,
+			Schema:           infraAlertConfigResourceSchema,
+			SkipIDGeneration: true,
+			SchemaVersion:    1,
+		},
+	}
+}
+
+type infraAlertConfigResource struct {
+	metaData ResourceMetaData
+}
+
+func (c *infraAlertConfigResource) MetaData() *ResourceMetaData {
+	return &c.metaData
+}
+
+func (c *infraAlertConfigResource) StateUpgraders() []schema.StateUpgrader {
+	return []schema.StateUpgrader{
+		{
+			Type:    c.schemaV0().CoreConfigSchema().ImpliedType(),
+			Upgrade: c.stateUpgradeV0,
+			Version: 0,
+		},
+	}
+}
+
+func (c *infraAlertConfigResource) UpdateState(d *schema.ResourceData, config *restapi.InfraAlertConfig) error {
+	var normalizedTagFilterString *string
+	var err error
+	if config.TagFilterExpression != nil {
+		normalizedTagFilterString, err = tagfilter.MapTagFilterToNormalizedString(config.TagFilterExpression)
+		if err != nil {
+			return err
+		}
+	}
+
+	d.SetId(config.ID)
+
+	return tfutils.UpdateState(d, map[string]interface{}{
+		InfraAlertConfigFieldName:          config.Name,
+		InfraAlertConfigFieldDescription:   config.Description,
+		InfraAlertConfigFieldTagFilter:     normalizedTagFilterString,
+		InfraAlertConfigFieldGroupBy:       config.GroupBy,
+		InfraAlertConfigFieldAlertChannels: c.mapAlertChannelsToSchema(config),
+		InfraAlertConfigFieldGranularity:   config.Granularity,
+		InfraAlertConfigFieldTimeThreshold: c.mapTimeThresholdToSchema(config),
+		DefaultCustomPayloadFieldsName:     mapCustomPayloadFieldsToSchema(config),
+		InfraAlertConfigFieldRules:         c.mapRulesToSchema(config),
+	})
+}
+
+func (c *infraAlertConfigResource) mapAlertChannelsToSchema(config *restapi.InfraAlertConfig) []map[string]interface{} {
+	alertChannels := config.AlertChannels
+
+	result := make([]map[string]interface{}, 1)
+	alertChannelsMap := make(map[string]interface{})
+
+	if v, ok := alertChannels[restapi.WarningSeverity]; ok {
+		alertChannelsMap[ResourceFieldThresholdRuleWarningSeverity] = v
+	}
+
+	if v, ok := alertChannels[restapi.CriticalSeverity]; ok {
+		alertChannelsMap[ResourceFieldThresholdRuleCriticalSeverity] = v
+	}
+
+	result[0] = alertChannelsMap
+
+	return result
+}
+
+func (c *infraAlertConfigResource) mapTimeThresholdToSchema(config *restapi.InfraAlertConfig) []map[string]interface{} {
+	timeThresholdConfig := make(map[string]interface{})
+	timeThresholdConfig[InfraAlertConfigFieldTimeThresholdTimeWindow] = config.TimeThreshold.TimeWindow
+
+	timeThresholdType := c.mapTimeThresholdTypeToSchema(config.TimeThreshold.Type)
+	timeThreshold := make(map[string]interface{})
+	timeThreshold[timeThresholdType] = []interface{}{timeThresholdConfig}
+	result := make([]map[string]interface{}, 1)
+	result[0] = timeThreshold
+
+	return result
+}
+
+func (c *infraAlertConfigResource) mapTimeThresholdTypeToSchema(input string) string {
+	if input == "violationsInSequence" {
+		return InfraAlertConfigFieldTimeThresholdViolationsInSequence
+	}
+
+	return input
+}
+
+func (c *infraAlertConfigResource) mapRulesToSchema(config *restapi.InfraAlertConfig) []map[string]interface{} {
+	if len(config.Rules) > 0 {
+		firstRule := config.Rules[0].Rule
+
+		if firstRule.AlertType == "genericRule" {
+			rule := make(map[string]interface{})
+			ruleAttribute := c.mapGenericRuleToSchema(&config.Rules[0])
+			rule[InfraAlertConfigFieldGenericRule] = []interface{}{ruleAttribute}
+			result := make([]map[string]interface{}, 1)
+			result[0] = rule
+
+			return result
+		}
+	}
+
+	return []map[string]interface{}{}
+}
+
+func (c *infraAlertConfigResource) mapGenericRuleToSchema(ruleWithThreshold *restapi.RuleWithThreshold[restapi.InfraAlertRule]) map[string]interface{} {
+	var rule = ruleWithThreshold.Rule
+
+	return map[string]interface{}{
+		InfraAlertConfigFieldMetricName:             rule.MetricName,
+		InfraAlertConfigFieldEntityType:             rule.EntityType,
+		InfraAlertConfigFieldAggregation:            rule.Aggregation,
+		InfraAlertConfigFieldCrossSeriesAggregation: rule.CrossSeriesAggregation,
+		InfraAlertConfigFieldRegex:                  rule.Regex,
+		InfraAlertConfigFieldThresholdOperator:      ruleWithThreshold.ThresholdOperator,
+		ResourceFieldThresholdRule:                  c.mapThresholdToSchema(ruleWithThreshold),
+	}
+}
+
+func (c *infraAlertConfigResource) mapThresholdToSchema(ruleWithThreshold *restapi.RuleWithThreshold[restapi.InfraAlertRule]) []map[string]interface{} {
+	var thresholds = ruleWithThreshold.Thresholds
+	warningThresholdRule, isWarningThresholdPresent := thresholds[restapi.WarningSeverity]
+	criticalThresholdRule, isCriticalThresholdPresent := thresholds[restapi.CriticalSeverity]
+
+	result := make([]map[string]interface{}, 1)
+	thresholdMap := make(map[string]interface{})
+
+	if isWarningThresholdPresent {
+		thresholdMap[ResourceFieldThresholdRuleWarningSeverity] = newThresholdRuleMapper().toState(&warningThresholdRule)
+	}
+	if isCriticalThresholdPresent {
+		thresholdMap[ResourceFieldThresholdRuleCriticalSeverity] = newThresholdRuleMapper().toState(&criticalThresholdRule)
+	}
+
+	result[0] = thresholdMap
+
+	return result
+}
+
+func (c *infraAlertConfigResource) MapStateToDataObject(d *schema.ResourceData) (*restapi.InfraAlertConfig, error) {
+	var tagFilter *restapi.TagFilter
+	var err error
+	tagFilterStr, ok := d.GetOk(InfraAlertConfigFieldTagFilter)
+	if ok {
+		tagFilter, err = c.mapTagFilterExpressionFromSchema(tagFilterStr.(string))
+		if err != nil {
+			return &restapi.InfraAlertConfig{}, err
+		}
+	}
+
+	customPayloadFields, err := mapDefaultCustomPayloadFieldsFromSchema(d)
+	if err != nil {
+		return &restapi.InfraAlertConfig{}, err
+	}
+
+	return &restapi.InfraAlertConfig{
+		ID:                    d.Id(),
+		Name:                  d.Get(InfraAlertConfigFieldName).(string),
+		Description:           d.Get(InfraAlertConfigFieldDescription).(string),
+		TagFilterExpression:   tagFilter,
+		GroupBy:               ReadArrayParameterFromResource[string](d, InfraAlertConfigFieldGroupBy),
+		AlertChannels:         c.mapAlertChannelsFromSchema(d),
+		Granularity:           restapi.Granularity(d.Get(InfraAlertConfigFieldGranularity).(int)),
+		TimeThreshold:         c.mapTimeThresholdFromSchema(d),
+		CustomerPayloadFields: customPayloadFields,
+		Rules:                 c.mapRuleFromSchema(d),
+	}, nil
+}
+
+func (c *infraAlertConfigResource) mapTagFilterExpressionFromSchema(input string) (*restapi.TagFilter, error) {
+	parser := tagfilter.NewParser()
+	expr, err := parser.Parse(input)
+	if err != nil {
+		return nil, err
+	}
+
+	mapper := tagfilter.NewMapper()
+	return mapper.ToAPIModel(expr), nil
+}
+
+func (c *infraAlertConfigResource) mapTimeThresholdFromSchema(d *schema.ResourceData) restapi.InfraTimeThreshold {
+	timeThresholdSlice := d.Get(InfraAlertConfigFieldTimeThreshold).([]interface{})
+	timeThreshold := timeThresholdSlice[0].(map[string]interface{})
+
+	for timeThresholdType, v := range timeThreshold {
+		configSlice := v.([]interface{})
+		if len(configSlice) == 1 {
+			config := configSlice[0].(map[string]interface{})
+
+			return restapi.InfraTimeThreshold{
+				Type:       c.mapTimeThresholdTypeFromSchema(timeThresholdType),
+				TimeWindow: int64(config[InfraAlertConfigFieldTimeThresholdTimeWindow].(int)),
+			}
+		}
+	}
+	return restapi.InfraTimeThreshold{}
+}
+
+func (c *infraAlertConfigResource) mapTimeThresholdTypeFromSchema(input string) string {
+	if input == InfraAlertConfigFieldTimeThresholdViolationsInSequence {
+		return "violationsInSequence"
+	}
+
+	return input
+}
+
+func (c *infraAlertConfigResource) mapRuleFromSchema(d *schema.ResourceData) []restapi.RuleWithThreshold[restapi.InfraAlertRule] {
+	ruleSlice := d.Get(InfraAlertConfigFieldRules).([]interface{})
+	// Only one rule definition is allowed for now.
+	rule := ruleSlice[0].(map[string]interface{})
+
+	for alertType, v := range rule {
+		configSlice := v.([]interface{})
+		if alertType == InfraAlertConfigFieldGenericRule && len(configSlice) == 1 {
+			config := configSlice[0].(map[string]interface{})
+			return c.mapRuleWithThresholdFromSchema(config, alertType)
+		}
+	}
+
+	return []restapi.RuleWithThreshold[restapi.InfraAlertRule]{}
+}
+
+func (c *infraAlertConfigResource) mapAlertChannelsFromSchema(d *schema.ResourceData) map[restapi.AlertSeverity][]string {
+	alertChannelsSlice := d.Get(InfraAlertConfigFieldAlertChannels).([]interface{})
+	alertChannels := alertChannelsSlice[0].(map[string]interface{})
+
+	alertChannelsMap := make(map[restapi.AlertSeverity][]string)
+
+	if _, ok := alertChannels[ResourceFieldThresholdRuleWarningSeverity]; ok {
+		alertChannelsMap[restapi.WarningSeverity] = ReadArrayParameterFromMap[string](alertChannels, ResourceFieldThresholdRuleWarningSeverity)
+	}
+	if _, ok := alertChannels[ResourceFieldThresholdRuleCriticalSeverity]; ok {
+		alertChannelsMap[restapi.CriticalSeverity] = ReadArrayParameterFromMap[string](alertChannels, ResourceFieldThresholdRuleCriticalSeverity)
+	}
+
+	return alertChannelsMap
+}
+
+func (c *infraAlertConfigResource) mapAlertTypeFromSchema(alertType string) string {
+	if alertType == InfraAlertConfigFieldGenericRule {
+		return "genericRule"
+	}
+
+	return alertType
+}
+
+func (c *infraAlertConfigResource) mapRuleWithThresholdFromSchema(config map[string]interface{}, alertType string) []restapi.RuleWithThreshold[restapi.InfraAlertRule] {
+	result := make([]restapi.RuleWithThreshold[restapi.InfraAlertRule], 1)
+
+	infraAlertRule := restapi.InfraAlertRule{
+		AlertType:              c.mapAlertTypeFromSchema(alertType),
+		MetricName:             config[InfraAlertConfigFieldMetricName].(string),
+		EntityType:             config[InfraAlertConfigFieldEntityType].(string),
+		Aggregation:            restapi.Aggregation(config[InfraAlertConfigFieldAggregation].(string)),
+		CrossSeriesAggregation: restapi.Aggregation(config[InfraAlertConfigFieldCrossSeriesAggregation].(string)),
+		Regex:                  config[InfraAlertConfigFieldRegex].(bool),
+	}
+
+	thresholdSlice := config[ResourceFieldThresholdRule].([]interface{})
+	thresholdConfig := thresholdSlice[0].(map[string]interface{})
+	thresholdMap := make(map[restapi.AlertSeverity]restapi.ThresholdRule)
+
+	if v, ok := thresholdConfig[ResourceFieldThresholdRuleWarningSeverity]; ok && len(v.([]interface{})) == 1 {
+		warningThresholdSlice := v.([]interface{})
+		thresholdRule := newThresholdRuleMapper().fromState(warningThresholdSlice)
+		thresholdMap[restapi.WarningSeverity] = *thresholdRule
+	}
+	if v, ok := thresholdConfig[ResourceFieldThresholdRuleCriticalSeverity]; ok && len(v.([]interface{})) == 1 {
+		criticalThresholdSlice := v.([]interface{})
+		thresholdRule := newThresholdRuleMapper().fromState(criticalThresholdSlice)
+		thresholdMap[restapi.CriticalSeverity] = *thresholdRule
+	}
+
+	ruleWithThreshold := restapi.RuleWithThreshold[restapi.InfraAlertRule]{
+		ThresholdOperator: restapi.ThresholdOperator(config[InfraAlertConfigFieldThresholdOperator].(string)),
+		Rule:              infraAlertRule,
+		Thresholds:        thresholdMap,
+	}
+	result[0] = ruleWithThreshold
+
+	return result
+}
+
+func (c *infraAlertConfigResource) SetComputedFields(d *schema.ResourceData) error {
+	return nil
+}
+
+func (c *infraAlertConfigResource) GetRestResource(api restapi.InstanaAPI) restapi.RestResource[*restapi.InfraAlertConfig] {
+	return api.InfraAlertConfig()
+}

--- a/instana/resource-infra-alert-config_test.go
+++ b/instana/resource-infra-alert-config_test.go
@@ -1,0 +1,702 @@
+package instana_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/gessnerfl/terraform-provider-instana/instana/restapi"
+	"github.com/gessnerfl/terraform-provider-instana/testutils"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"testing"
+
+	. "github.com/gessnerfl/terraform-provider-instana/instana"
+)
+
+func TestInfraAlertConfig(t *testing.T) {
+	terraformResourceInstanceName := ResourceInstanaInfraAlertConfig + ".example"
+	inst := &infraAlertConfigTest{
+		terraformResourceInstanceName: terraformResourceInstanceName,
+		resourceHandle:                NewInfraAlertConfigResourceHandle(),
+	}
+	inst.run(t)
+}
+
+type infraAlertConfigTest struct {
+	terraformResourceInstanceName string
+	resourceHandle                ResourceHandle[*restapi.InfraAlertConfig]
+}
+
+var infraAlertConfigTerraformTemplate = `
+resource "instana_infra_alert_config" "example" {
+	name              = "name %d"
+    description       = "test-alert-description"
+    alert_channels {
+		warning = [ "alert-channel-id-1" ]
+		critical = [ "alert-channel-id-2" ]
+	}
+    group_by          = [ "metricId" ]
+    granularity       = 600000
+	tag_filter        = "host.fqdn@na STARTS_WITH 'fooBar'"
+
+	rules {
+		generic_rule {
+			metric_name 			 = "cpu\\.(nice|user|sys|wait)"
+			entity_type 			 = "host"
+			aggregation 			 = "MEAN"
+			cross_series_aggregation = "SUM"
+			regex 					 = true
+			threshold_operator       = ">="
+
+			threshold {
+				critical {
+					static {
+						value = 5.0
+					}	
+				}
+			}
+		}
+    }
+
+	time_threshold {
+		violations_in_sequence {
+			time_window = 600000
+		}
+    }
+
+	custom_payload_field {
+		key    = "test1"
+		value  = "foo"
+	}
+
+	custom_payload_field {
+		key = "test2"
+		dynamic_value {
+			key      = "dynamic-value-key"
+			tag_name = "dynamic-value-tag-name"
+		}
+	}
+}
+`
+
+var infraAlertConfigServerResponseTemplate = `
+	{
+		"id": "%s",
+		"name": "name %d",
+		"description": "test-alert-description",
+		"alertChannels": {
+			"WARNING": ["alert-channel-id-1"],
+			"CRITICAL": ["alert-channel-id-2"]
+		},
+		"tagFilterExpression": {
+			"type": "TAG_FILTER",
+			"name": "host.fqdn",
+			"stringValue": "fooBar",
+			"numberValue": null,
+			"booleanValue": null,
+			"key": null,
+			"value": "fooBar",
+			"operator": "STARTS_WITH",
+			"entity": "NOT_APPLICABLE"
+		},
+	    "rules":[
+		   {
+			  "thresholdOperator":">=",
+			  "rule":{
+			     "alertType":"genericRule",
+			     "metricName":"cpu\\.(nice|user|sys|wait)",
+			     "entityType":"host",
+			     "aggregation":"MEAN",
+			     "crossSeriesAggregation":"SUM",
+			     "regex":true
+			  },
+			  "thresholds":{
+			     "CRITICAL":{
+				    "type":"staticThreshold",
+				    "value":5.0
+			     }
+			  }
+		   }
+	    ],
+		"groupBy": [ "metricId" ],
+		"granularity": 600000,
+		"timeThreshold": {
+		  "type": "violationsInSequence",
+		  "timeWindow": 600000
+		},
+		"customPayloadFields": [
+			{
+				"type": "staticString",
+				"key": "test1",
+				"value": "foo"
+			},
+			{
+				"type": "dynamic",
+				"key": "test2",
+				"value": {
+					"key": "dynamic-value-key",
+					"tagName": "dynamic-value-tag-name"
+				}
+			}
+		],
+		"created": 1647679325301,
+		"readOnly": false,
+		"enabled": true
+  }
+`
+
+func (test *infraAlertConfigTest) run(t *testing.T) {
+	t.Run(fmt.Sprintf("CRUD integration test of %s", ResourceInstanaInfraAlertConfig), test.createIntegrationTest())
+	t.Run(fmt.Sprintf("%s should have schema version one", ResourceInstanaInfraAlertConfig), test.createTestResourceShouldHaveSchemaVersionOne())
+	t.Run(fmt.Sprintf("%s should have one state upgrader", ResourceInstanaInfraAlertConfig), test.createTestResourceShouldHaveOneStateUpgrader())
+	t.Run(fmt.Sprintf("%s should migrate fullname to name when executing first state migration and fullname is available", ResourceInstanaInfraAlertConfig), test.createTestInfraAlertConfigShouldMigrateFullnameToNameWhenExecutingFirstStateUpgraderAndFullnameIsAvailable())
+	t.Run(fmt.Sprintf("%s should do nothing when executing first state migration and fullname is not available", ResourceInstanaInfraAlertConfig), test.createTestInfraAlertConfigShouldDoNothingWhenExecutingFirstStateUpgraderAndFullnameIsAvailable())
+	t.Run(fmt.Sprintf("%s should have correct resouce name", ResourceInstanaInfraAlertConfig), test.createTestResourceShouldHaveCorrectResourceName())
+	test.createTestCasesForUpdatesOfTerraformResourceStateFromModel(t)
+	t.Run(fmt.Sprintf("%s should fail to update state from model when tag filter expression is invalid", ResourceInstanaInfraAlertConfig), test.createTestCasesShouldFailToUpdateTerraformResourceStateFromModeWhenTagFilterExpressionIsNotValid())
+	test.createTestCasesForMappingOfTerraformResourceStateToModel(t)
+	t.Run(fmt.Sprintf("%s should fail to map state to model when tag filter expression is invalid", ResourceInstanaInfraAlertConfig), test.createTestCaseShouldFailToMapTerraformResourceStateToModelWhenTagFilterIsNotValid())
+	t.Run(fmt.Sprintf("%s should return errr when converting state to data model and custom field is not valid", ResourceInstanaInfraAlertConfig), test.shouldReturnErrorWhenConvertingStateToDataModelAndCustomFieldIsNotValid)
+}
+
+func (test *infraAlertConfigTest) shouldReturnErrorWhenConvertingStateToDataModelAndCustomFieldIsNotValid(t *testing.T) {
+	testHelper := NewTestHelper[*restapi.InfraAlertConfig](t)
+	sut := test.resourceHandle
+	resourceData := testHelper.CreateEmptyResourceDataForResourceHandle(sut)
+	setValueOnResourceData(t, resourceData, InfraAlertConfigFieldName, "infra-alert-config-name")
+	setValueOnResourceData(t, resourceData, InfraAlertConfigFieldTagFilter, "host.fqdn@na EQUALS 'fooBar'")
+	setValueOnResourceData(t, resourceData, DefaultCustomPayloadFieldsName, []interface{}{
+		map[string]interface{}{
+			CustomPayloadFieldsFieldKey:               "dynamic-key",
+			CustomPayloadFieldsFieldStaticStringValue: "invalid",
+			CustomPayloadFieldsFieldDynamicValue: []interface{}{
+				map[string]interface{}{
+					CustomPayloadFieldsFieldDynamicKey:     "dynamic-value-key",
+					CustomPayloadFieldsFieldDynamicTagName: "dynamic-value-tag-name",
+				},
+			},
+		},
+	})
+
+	_, err := sut.MapStateToDataObject(resourceData)
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "either a static string value or a dynamic value must")
+}
+
+func (test *infraAlertConfigTest) createTestCaseShouldFailToMapTerraformResourceStateToModelWhenTagFilterIsNotValid() func(t *testing.T) {
+	return func(t *testing.T) {
+		testHelper := NewTestHelper[*restapi.InfraAlertConfig](t)
+		sut := test.resourceHandle
+		resourceData := testHelper.CreateEmptyResourceDataForResourceHandle(sut)
+		setValueOnResourceData(t, resourceData, InfraAlertConfigFieldName, "infra-alert-config-name")
+		setValueOnResourceData(t, resourceData, InfraAlertConfigFieldTagFilter, "invalid invalid invalid")
+
+		_, err := sut.MapStateToDataObject(resourceData)
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unexpected token")
+	}
+}
+
+func (test *infraAlertConfigTest) createTestCasesForMappingOfTerraformResourceStateToModel(t *testing.T) {
+	metricName := "cpu\\\\.(nice|user|sys|wait)"
+	host := "host"
+	aggregation := restapi.MeanAggregation
+
+	thresholdValue := 12.3
+	rules := []testPair[[]map[string]interface{}, restapi.RuleWithThreshold[restapi.InfraAlertRule]]{
+		{
+			name: "genericRule",
+			expected: restapi.RuleWithThreshold[restapi.InfraAlertRule]{
+				ThresholdOperator: ">",
+				Rule: restapi.InfraAlertRule{
+					AlertType:              "genericRule",
+					MetricName:             metricName,
+					EntityType:             host,
+					Aggregation:            aggregation,
+					CrossSeriesAggregation: aggregation,
+					Regex:                  true,
+				},
+				Thresholds: map[restapi.AlertSeverity]restapi.ThresholdRule{
+					restapi.WarningSeverity: {
+						Type:  "staticThreshold",
+						Value: &thresholdValue,
+					},
+				},
+			},
+			input: []map[string]interface{}{
+				{
+					InfraAlertConfigFieldGenericRule: []interface{}{
+						map[string]interface{}{
+							InfraAlertConfigFieldMetricName:             metricName,
+							InfraAlertConfigFieldEntityType:             host,
+							InfraAlertConfigFieldAggregation:            aggregation,
+							InfraAlertConfigFieldCrossSeriesAggregation: aggregation,
+							InfraAlertConfigFieldRegex:                  true,
+
+							InfraAlertConfigFieldThresholdOperator: ">",
+
+							ResourceFieldThresholdRule: []interface{}{
+								map[string]interface{}{
+									ResourceFieldThresholdRuleWarningSeverity: []interface{}{
+										map[string]interface{}{
+											ResourceFieldThresholdRuleHistoricBaseline: []interface{}{},
+											ResourceFieldThresholdRuleStatic: []interface{}{
+												map[string]interface{}{
+													ResourceFieldThresholdRuleStaticValue: thresholdValue,
+												},
+											},
+										},
+									},
+									ResourceFieldThresholdRuleCriticalSeverity: []interface{}{},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	timeThresholdWindow := int64(300000)
+	timeThresholds := []testPair[[]map[string]interface{}, restapi.InfraTimeThreshold]{
+		{
+			name: "ViolationsInSequence",
+			expected: restapi.InfraTimeThreshold{
+				Type:       "violationsInSequence",
+				TimeWindow: timeThresholdWindow,
+			},
+			input: []map[string]interface{}{
+				{
+					InfraAlertConfigFieldTimeThresholdViolationsInSequence: []interface{}{
+						map[string]interface{}{
+							InfraAlertConfigFieldTimeThresholdTimeWindow: int(timeThresholdWindow),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, rule := range rules {
+		for _, timeThreshold := range timeThresholds {
+			t.Run(fmt.Sprintf("Should update terraform state of %s from REST response with %s and %s", ResourceInstanaInfraAlertConfig, rule.name, timeThreshold.name),
+				test.createTestShouldMapTerraformResourceStateToModelCase(rule, timeThreshold))
+		}
+	}
+}
+
+func (test *infraAlertConfigTest) createTestShouldMapTerraformResourceStateToModelCase(
+	ruleTestPair testPair[[]map[string]interface{}, restapi.RuleWithThreshold[restapi.InfraAlertRule]],
+	timeThresholdTestPair testPair[[]map[string]interface{}, restapi.InfraTimeThreshold]) func(t *testing.T) {
+
+	return func(t *testing.T) {
+		infraAlertConfigID := "infra-alert-config-id"
+		name := "infra-alert-config-name"
+		dynamicValueKey := "dynamic-value-key"
+		dynamicValueTagName := "dynamic-value-tag-name"
+		expectedInfraConfig := restapi.InfraAlertConfig{
+			ID:                  infraAlertConfigID,
+			Name:                name,
+			Description:         "infra-alert-config-description",
+			TagFilterExpression: restapi.NewStringTagFilter(restapi.TagFilterEntityNotApplicable, "host.fqdn", restapi.EqualsOperator, "fooBar"),
+			GroupBy:             []string{"metricId"},
+			AlertChannels: map[restapi.AlertSeverity][]string{
+				restapi.WarningSeverity:  {"channel-1"},
+				restapi.CriticalSeverity: {"channel-2"},
+			},
+			Granularity:   restapi.Granularity300000,
+			TimeThreshold: timeThresholdTestPair.expected,
+			CustomerPayloadFields: []restapi.CustomPayloadField[any]{
+				{
+					Type:  restapi.StaticStringCustomPayloadType,
+					Key:   "static-key",
+					Value: restapi.StaticStringCustomPayloadFieldValue("static-value"),
+				},
+				{
+					Type:  restapi.DynamicCustomPayloadType,
+					Key:   "dynamic-key",
+					Value: restapi.DynamicCustomPayloadFieldValue{Key: &dynamicValueKey, TagName: dynamicValueTagName},
+				},
+			},
+			Rules: []restapi.RuleWithThreshold[restapi.InfraAlertRule]{
+				ruleTestPair.expected,
+			},
+		}
+
+		testHelper := NewTestHelper[*restapi.InfraAlertConfig](t)
+		sut := test.resourceHandle
+		resourceData := testHelper.CreateEmptyResourceDataForResourceHandle(sut)
+		setValueOnResourceData(t, resourceData, InfraAlertConfigFieldName, "infra-alert-config-name")
+		setValueOnResourceData(t, resourceData, InfraAlertConfigFieldDescription, "infra-alert-config-description")
+		setValueOnResourceData(t, resourceData, InfraAlertConfigFieldAlertChannels, []interface{}{
+			map[string]interface{}{
+				ResourceFieldThresholdRuleWarningSeverity:  []interface{}{"channel-1"},
+				ResourceFieldThresholdRuleCriticalSeverity: []interface{}{"channel-2"},
+			},
+		})
+		setValueOnResourceData(t, resourceData, InfraAlertConfigFieldGroupBy, []interface{}{"metricId"})
+		setValueOnResourceData(t, resourceData, InfraAlertConfigFieldGranularity, restapi.Granularity300000)
+		setValueOnResourceData(t, resourceData, InfraAlertConfigFieldTagFilter, "host.fqdn@na EQUALS 'fooBar'")
+		setValueOnResourceData(t, resourceData, InfraAlertConfigFieldRules, ruleTestPair.input)
+		setValueOnResourceData(t, resourceData, InfraAlertConfigFieldTimeThreshold, timeThresholdTestPair.input)
+		setValueOnResourceData(t, resourceData, DefaultCustomPayloadFieldsName, []interface{}{
+			map[string]interface{}{
+				CustomPayloadFieldsFieldKey:               "static-key",
+				CustomPayloadFieldsFieldStaticStringValue: "static-value",
+				CustomPayloadFieldsFieldDynamicValue:      []interface{}{},
+			},
+			map[string]interface{}{
+				CustomPayloadFieldsFieldKey:          "dynamic-key",
+				CustomPayloadFieldsFieldDynamicValue: []interface{}{map[string]interface{}{CustomPayloadFieldsFieldDynamicKey: dynamicValueKey, CustomPayloadFieldsFieldDynamicTagName: dynamicValueTagName}},
+			},
+		})
+
+		resourceData.SetId(infraAlertConfigID)
+
+		result, err := sut.MapStateToDataObject(resourceData)
+
+		require.NoError(t, err)
+		require.Equal(t, &expectedInfraConfig, result)
+	}
+}
+
+func (test *infraAlertConfigTest) createTestCasesShouldFailToUpdateTerraformResourceStateFromModeWhenTagFilterExpressionIsNotValid() func(t *testing.T) {
+	return func(t *testing.T) {
+		value := "fooBar"
+		operator := restapi.EqualsOperator
+		tagFilterName := "host.fqdn"
+		tagFilterEntity := restapi.TagFilterEntityNotApplicable
+		infraAlertConfig := restapi.InfraAlertConfig{
+			Name: "test",
+			TagFilterExpression: &restapi.TagFilter{
+				Entity:      &tagFilterEntity,
+				Name:        &tagFilterName,
+				Operator:    &operator,
+				StringValue: &value,
+				Value:       value,
+				Type:        restapi.TagFilterExpressionElementType("invalid"),
+			},
+		}
+
+		testHelper := NewTestHelper[*restapi.InfraAlertConfig](t)
+		sut := test.resourceHandle
+		resourceData := testHelper.CreateEmptyResourceDataForResourceHandle(sut)
+
+		err := sut.UpdateState(resourceData, &infraAlertConfig)
+
+		require.Error(t, err)
+		require.Equal(t, "unsupported tag filter expression of type invalid", err.Error())
+	}
+}
+
+func (test *infraAlertConfigTest) createTestCasesForUpdatesOfTerraformResourceStateFromModel(t *testing.T) {
+	metricName := "cpu\\\\.(nice|user|sys|wait)"
+	host := "host"
+	aggregation := restapi.MeanAggregation
+
+	thresholdValue := 12.3
+	rules := []testPair[restapi.RuleWithThreshold[restapi.InfraAlertRule], []interface{}]{
+		{
+			name: "genericRule",
+			input: restapi.RuleWithThreshold[restapi.InfraAlertRule]{
+				ThresholdOperator: ">",
+				Rule: restapi.InfraAlertRule{
+					AlertType:              "genericRule",
+					MetricName:             metricName,
+					EntityType:             host,
+					Aggregation:            aggregation,
+					CrossSeriesAggregation: aggregation,
+					Regex:                  true,
+				},
+				Thresholds: map[restapi.AlertSeverity]restapi.ThresholdRule{
+					restapi.WarningSeverity: {
+						Type:  "staticThreshold",
+						Value: &thresholdValue,
+					},
+				},
+			},
+			expected: []interface{}{
+				map[string]interface{}{
+					InfraAlertConfigFieldGenericRule: []interface{}{
+						map[string]interface{}{
+							InfraAlertConfigFieldMetricName:             metricName,
+							InfraAlertConfigFieldEntityType:             host,
+							InfraAlertConfigFieldAggregation:            "MEAN",
+							InfraAlertConfigFieldCrossSeriesAggregation: "MEAN",
+							InfraAlertConfigFieldRegex:                  true,
+
+							InfraAlertConfigFieldThresholdOperator: ">",
+
+							ResourceFieldThresholdRule: []interface{}{
+								map[string]interface{}{
+									ResourceFieldThresholdRuleWarningSeverity: []interface{}{
+										map[string]interface{}{
+											ResourceFieldThresholdRuleHistoricBaseline: []interface{}{},
+											ResourceFieldThresholdRuleStatic: []interface{}{
+												map[string]interface{}{
+													ResourceFieldThresholdRuleStaticValue: thresholdValue,
+												},
+											},
+										},
+									},
+									ResourceFieldThresholdRuleCriticalSeverity: []interface{}{},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	timeThresholdWindow := int64(300000)
+	timeThresholds := []testPair[restapi.InfraTimeThreshold, []interface{}]{
+		{
+			name: "ViolationsInSequence",
+			input: restapi.InfraTimeThreshold{
+				Type:       "violationsInSequence",
+				TimeWindow: timeThresholdWindow,
+			},
+			expected: []interface{}{
+				map[string]interface{}{
+					InfraAlertConfigFieldTimeThresholdViolationsInSequence: []interface{}{
+						map[string]interface{}{
+							InfraAlertConfigFieldTimeThresholdTimeWindow: int(timeThresholdWindow),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, rule := range rules {
+		for _, timeThreshold := range timeThresholds {
+			t.Run(fmt.Sprintf("Should update terraform state of %s from REST response with %s and %s", ResourceInstanaInfraAlertConfig, rule.name, timeThreshold.name),
+				test.createTestShouldUpdateTerraformResourceStateFromModelCase(rule, timeThreshold))
+		}
+	}
+}
+
+func (test *infraAlertConfigTest) createTestShouldUpdateTerraformResourceStateFromModelCase(
+	ruleTestPair testPair[restapi.RuleWithThreshold[restapi.InfraAlertRule], []interface{}],
+	timeThresholdTestPair testPair[restapi.InfraTimeThreshold, []interface{}]) func(t *testing.T) {
+
+	return func(t *testing.T) {
+		infraAlertConfigID := "infra-alert-config-id"
+		name := "infra-alert-config-name"
+		dynamicValueKey := "dynamic-value-key"
+		dynamicValueTagName := "dynamic-value-tag-name"
+		alertChannelsMap := make(map[restapi.AlertSeverity][]string)
+		alertChannelsMap[restapi.WarningSeverity] = []string{"channel-1"}
+		alertChannelsMap[restapi.CriticalSeverity] = []string{"channel-2"}
+
+		infraConfig := restapi.InfraAlertConfig{
+			ID:                  infraAlertConfigID,
+			Name:                name,
+			Description:         "infra-alert-config-description",
+			TagFilterExpression: restapi.NewStringTagFilter(restapi.TagFilterEntityNotApplicable, "host.fqdn", restapi.EqualsOperator, "fooBar"),
+			GroupBy:             []string{"metricId"},
+			AlertChannels:       alertChannelsMap,
+			Granularity:         restapi.Granularity300000,
+			TimeThreshold:       timeThresholdTestPair.input,
+			CustomerPayloadFields: []restapi.CustomPayloadField[any]{
+				{
+					Type:  restapi.StaticStringCustomPayloadType,
+					Key:   "static-key",
+					Value: restapi.StaticStringCustomPayloadFieldValue("static-value"),
+				},
+				{
+					Type:  restapi.DynamicCustomPayloadType,
+					Key:   "dynamic-key",
+					Value: restapi.DynamicCustomPayloadFieldValue{Key: &dynamicValueKey, TagName: dynamicValueTagName},
+				},
+			},
+			Rules: []restapi.RuleWithThreshold[restapi.InfraAlertRule]{
+				ruleTestPair.input,
+			},
+		}
+
+		testHelper := NewTestHelper[*restapi.InfraAlertConfig](t)
+		sut := test.resourceHandle
+		resourceData := testHelper.CreateEmptyResourceDataForResourceHandle(sut)
+
+		err := sut.UpdateState(resourceData, &infraConfig)
+		require.NoError(t, err)
+		require.Equal(t, infraAlertConfigID, resourceData.Id())
+
+		require.Equal(t, "infra-alert-config-name", resourceData.Get(InfraAlertConfigFieldName))
+		require.Equal(t, "infra-alert-config-description", resourceData.Get(InfraAlertConfigFieldDescription))
+		require.Equal(t, []interface{}{
+			map[string]interface{}{
+				ResourceFieldThresholdRuleWarningSeverity:  []interface{}{"channel-1"},
+				ResourceFieldThresholdRuleCriticalSeverity: []interface{}{"channel-2"},
+			},
+		}, resourceData.Get(InfraAlertConfigFieldAlertChannels).([]interface{}))
+		require.Equal(t, []interface{}{"metricId"}, resourceData.Get(InfraAlertConfigFieldGroupBy).([]interface{}))
+		require.Equal(t, ruleTestPair.expected, resourceData.Get(InfraAlertConfigFieldRules).([]interface{}))
+
+		require.Equal(t, []interface{}{
+			map[string]interface{}{
+				CustomPayloadFieldsFieldKey:               "static-key",
+				CustomPayloadFieldsFieldDynamicValue:      []interface{}{},
+				CustomPayloadFieldsFieldStaticStringValue: "static-value",
+			},
+			map[string]interface{}{
+				CustomPayloadFieldsFieldKey:               "dynamic-key",
+				CustomPayloadFieldsFieldDynamicValue:      []interface{}{map[string]interface{}{CustomPayloadFieldsFieldDynamicKey: dynamicValueKey, CustomPayloadFieldsFieldDynamicTagName: dynamicValueTagName}},
+				CustomPayloadFieldsFieldStaticStringValue: "",
+			},
+		}, resourceData.Get(DefaultCustomPayloadFieldsName).(*schema.Set).List())
+		require.Equal(t, "host.fqdn@na EQUALS 'fooBar'", resourceData.Get(InfraAlertConfigFieldTagFilter))
+		require.Equal(t, timeThresholdTestPair.expected, resourceData.Get(InfraAlertConfigFieldTimeThreshold))
+	}
+}
+
+func (test *infraAlertConfigTest) createIntegrationTest() func(t *testing.T) {
+	return func(t *testing.T) {
+		id := RandomID()
+		resourceRestAPIPath := restapi.InfraAlertConfigResourcePath
+		resourceInstanceRestAPIPath := resourceRestAPIPath + "/{internal-id}"
+
+		httpServer := testutils.NewTestHTTPServer()
+		httpServer.AddRoute(http.MethodPost, resourceRestAPIPath, func(w http.ResponseWriter, r *http.Request) {
+			config := &restapi.InfraAlertConfig{}
+			err := json.NewDecoder(r.Body).Decode(config)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				err = r.Write(bytes.NewBufferString("Failed to get request"))
+				if err != nil {
+					fmt.Printf("failed to write response; %s\n", err)
+				}
+			} else {
+				config.ID = id
+				w.Header().Set("Content-Type", r.Header.Get("Content-Type"))
+				w.WriteHeader(http.StatusOK)
+				err = json.NewEncoder(w).Encode(config)
+				if err != nil {
+					fmt.Printf("failed to encode json; %s\n", err)
+				}
+			}
+		})
+		httpServer.AddRoute(http.MethodPost, resourceInstanceRestAPIPath, func(w http.ResponseWriter, r *http.Request) {
+			testutils.EchoHandlerFunc(w, r)
+		})
+		httpServer.AddRoute(http.MethodDelete, resourceInstanceRestAPIPath, testutils.EchoHandlerFunc)
+		httpServer.AddRoute(http.MethodGet, resourceInstanceRestAPIPath, func(w http.ResponseWriter, r *http.Request) {
+			modCount := httpServer.GetCallCount(http.MethodPost, resourceRestAPIPath+"/"+id)
+			jsonData := fmt.Sprintf(infraAlertConfigServerResponseTemplate, id, modCount)
+			w.Header().Set(contentType, r.Header.Get(contentType))
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte(jsonData))
+			if err != nil {
+				fmt.Printf("failed to write response; %s\n", err)
+			}
+		})
+		httpServer.Start()
+		defer httpServer.Close()
+
+		resource.UnitTest(t, resource.TestCase{
+			ProviderFactories: testProviderFactory,
+			Steps: []resource.TestStep{
+				test.createIntegrationTestStep(httpServer.GetPort(), 0, id),
+				testStepImportWithCustomID(test.terraformResourceInstanceName, id),
+				test.createIntegrationTestStep(httpServer.GetPort(), 1, id),
+				testStepImportWithCustomID(test.terraformResourceInstanceName, id),
+			},
+		})
+	}
+}
+
+func (test *infraAlertConfigTest) createIntegrationTestStep(httpPort int, iteration int, id string) resource.TestStep {
+	ruleMetricName := fmt.Sprintf("%s.%d.%s.%d.%s", InfraAlertConfigFieldRules, 0, InfraAlertConfigFieldGenericRule, 0, InfraAlertConfigFieldMetricName)
+	ruleEntityType := fmt.Sprintf("%s.%d.%s.%d.%s", InfraAlertConfigFieldRules, 0, InfraAlertConfigFieldGenericRule, 0, InfraAlertConfigFieldEntityType)
+	ruleAggregation := fmt.Sprintf("%s.%d.%s.%d.%s", InfraAlertConfigFieldRules, 0, InfraAlertConfigFieldGenericRule, 0, InfraAlertConfigFieldAggregation)
+	ruleCrossSeriesAggregation := fmt.Sprintf("%s.%d.%s.%d.%s", InfraAlertConfigFieldRules, 0, InfraAlertConfigFieldGenericRule, 0, InfraAlertConfigFieldCrossSeriesAggregation)
+	ruleRegex := fmt.Sprintf("%s.%d.%s.%d.%s", InfraAlertConfigFieldRules, 0, InfraAlertConfigFieldGenericRule, 0, InfraAlertConfigFieldRegex)
+	thresholdOperator := fmt.Sprintf("%s.%d.%s.%d.%s", InfraAlertConfigFieldRules, 0, InfraAlertConfigFieldGenericRule, 0, InfraAlertConfigFieldThresholdOperator)
+
+	thresholdStaticValue := fmt.Sprintf("%s.0.%s.0.%s.0.%s.0.%s.0.%s", InfraAlertConfigFieldRules, InfraAlertConfigFieldGenericRule, ResourceFieldThresholdRule, ResourceFieldThresholdRuleCriticalSeverity, ResourceFieldThresholdRuleStatic, ResourceFieldThresholdRuleStaticValue)
+	timeThresholdViolationsInSequence := fmt.Sprintf("%s.%d.%s.%d.%s", InfraAlertConfigFieldTimeThreshold, 0, InfraAlertConfigFieldTimeThresholdViolationsInSequence, 0, InfraAlertConfigFieldTimeThresholdTimeWindow)
+
+	customPayloadFieldStaticKey := fmt.Sprintf("%s.1.%s", DefaultCustomPayloadFieldsName, CustomPayloadFieldsFieldKey)
+	customPayloadFieldStaticValue := fmt.Sprintf("%s.1.%s", DefaultCustomPayloadFieldsName, CustomPayloadFieldsFieldStaticStringValue)
+	customPayloadFieldDynamicKey := fmt.Sprintf("%s.0.%s", DefaultCustomPayloadFieldsName, CustomPayloadFieldsFieldKey)
+	customPayloadFieldDynamicValueKey := fmt.Sprintf("%s.0.%s.0.%s", DefaultCustomPayloadFieldsName, CustomPayloadFieldsFieldDynamicValue, CustomPayloadFieldsFieldDynamicKey)
+	customPayloadFieldDynamicValueTagName := fmt.Sprintf("%s.0.%s.0.%s", DefaultCustomPayloadFieldsName, CustomPayloadFieldsFieldDynamicValue, CustomPayloadFieldsFieldDynamicTagName)
+
+	return resource.TestStep{
+		Config: appendProviderConfig(fmt.Sprintf(infraAlertConfigTerraformTemplate, iteration), httpPort),
+		Check: resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, "id", id),
+			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, InfraAlertConfigFieldName, formatResourceName(iteration)),
+			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, InfraAlertConfigFieldDescription, "test-alert-description"),
+			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, InfraAlertConfigFieldAlertChannels+".0."+ResourceFieldThresholdRuleWarningSeverity+".0", "alert-channel-id-1"),
+			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, InfraAlertConfigFieldAlertChannels+".0."+ResourceFieldThresholdRuleCriticalSeverity+".0", "alert-channel-id-2"),
+			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, InfraAlertConfigFieldGroupBy+".0", "metricId"),
+			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, InfraAlertConfigFieldGranularity, "600000"),
+			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, InfraAlertConfigFieldTagFilter, "host.fqdn@na STARTS_WITH 'fooBar'"),
+			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, ruleMetricName, "cpu\\.(nice|user|sys|wait)"),
+			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, ruleEntityType, "host"),
+			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, ruleAggregation, "MEAN"),
+			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, ruleCrossSeriesAggregation, "SUM"),
+			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, ruleRegex, "true"),
+			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, thresholdOperator, ">="),
+			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, thresholdStaticValue, "5"),
+			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, timeThresholdViolationsInSequence, "600000"),
+			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, customPayloadFieldStaticKey, "test1"),
+			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, customPayloadFieldStaticValue, "foo"),
+			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, customPayloadFieldDynamicKey, "test2"),
+			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, customPayloadFieldDynamicValueKey, "dynamic-value-key"),
+			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, customPayloadFieldDynamicValueTagName, "dynamic-value-tag-name"),
+		),
+	}
+}
+
+func (test *infraAlertConfigTest) createTestResourceShouldHaveSchemaVersionOne() func(t *testing.T) {
+	return func(t *testing.T) {
+		require.Equal(t, 1, test.resourceHandle.MetaData().SchemaVersion)
+	}
+}
+
+func (test *infraAlertConfigTest) createTestResourceShouldHaveOneStateUpgrader() func(t *testing.T) {
+	return func(t *testing.T) {
+		require.Len(t, test.resourceHandle.StateUpgraders(), 1)
+	}
+}
+
+func (test *infraAlertConfigTest) createTestInfraAlertConfigShouldMigrateFullnameToNameWhenExecutingFirstStateUpgraderAndFullnameIsAvailable() func(t *testing.T) {
+	return func(t *testing.T) {
+		input := map[string]interface{}{
+			"full_name": "test",
+		}
+		result, err := NewInfraAlertConfigResourceHandle().StateUpgraders()[0].Upgrade(nil, input, nil)
+
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		require.NotContains(t, result, InfraAlertConfigFieldFullName)
+		require.Contains(t, result, InfraAlertConfigFieldName)
+		require.Equal(t, "test", result[InfraAlertConfigFieldName])
+	}
+}
+
+func (test *infraAlertConfigTest) createTestInfraAlertConfigShouldDoNothingWhenExecutingFirstStateUpgraderAndFullnameIsAvailable() func(t *testing.T) {
+	return func(t *testing.T) {
+		input := map[string]interface{}{
+			"name": "test",
+		}
+		result, err := NewInfraAlertConfigResourceHandle().StateUpgraders()[0].Upgrade(nil, input, nil)
+
+		require.NoError(t, err)
+		require.Equal(t, input, result)
+	}
+}
+
+func (test *infraAlertConfigTest) createTestResourceShouldHaveCorrectResourceName() func(t *testing.T) {
+	return func(t *testing.T) {
+		require.Equal(t, test.resourceHandle.MetaData().ResourceName, "instana_infra_alert_config")
+	}
+}

--- a/instana/restapi/Instana-api.go
+++ b/instana/restapi/Instana-api.go
@@ -36,6 +36,7 @@ type InstanaAPI interface {
 	SliConfigs() RestResource[*SliConfig]
 	WebsiteMonitoringConfig() RestResource[*WebsiteMonitoringConfig]
 	WebsiteAlertConfig() RestResource[*WebsiteAlertConfig]
+	InfraAlertConfig() RestResource[*InfraAlertConfig]
 	Groups() RestResource[*Group]
 	CustomDashboards() RestResource[*CustomDashboard]
 	SyntheticTest() RestResource[*SyntheticTest]

--- a/instana/restapi/aggregation.go
+++ b/instana/restapi/aggregation.go
@@ -57,3 +57,11 @@ var SupportedAggregations = Aggregations{SumAggregation, MeanAggregation, MaxAgg
 	Percentile50Aggregation, Percentile75Aggregation, Percentile90Aggregation, Percentile95Aggregation, Percentile98Aggregation,
 	Percentile99Aggregation, Percentile99_9Aggregation, Percentile99_99Aggregation, DistributionAggregation,
 	DistinctCountAggregation, SumPositiveAggregation, PerSecondAggregation, IncreaseAggregation}
+
+var InfraExploreAggregations = Aggregations{MeanAggregation, MaxAggregation, MinAggregation, Percentile25Aggregation,
+	Percentile50Aggregation, Percentile75Aggregation, Percentile90Aggregation, Percentile95Aggregation, Percentile98Aggregation,
+	Percentile99Aggregation, SumAggregation, PerSecondAggregation}
+
+var TimeAggregations = Aggregations{MeanAggregation, MaxAggregation, MinAggregation, Percentile25Aggregation,
+	Percentile50Aggregation, Percentile75Aggregation, Percentile90Aggregation, Percentile95Aggregation, Percentile98Aggregation,
+	Percentile99Aggregation, SumAggregation}

--- a/instana/restapi/infra-alert-configs.go
+++ b/instana/restapi/infra-alert-configs.go
@@ -8,11 +8,11 @@ type InfraAlertConfig struct {
 	Description           string                              `json:"description"`
 	TagFilterExpression   *TagFilter                          `json:"tagFilterExpression"`
 	GroupBy               []string                            `json:"groupBy"`
-	AlertChannelIDs       []string                            `json:"alertChannelIds"`
 	Granularity           Granularity                         `json:"granularity"`
 	TimeThreshold         InfraTimeThreshold                  `json:"timeThreshold"`
 	CustomerPayloadFields []CustomPayloadField[any]           `json:"customPayloadFields"`
 	Rules                 []RuleWithThreshold[InfraAlertRule] `json:"rules"`
+	AlertChannels         map[AlertSeverity][]string          `json:"alertChannels"`
 }
 
 func (config *InfraAlertConfig) GetIDForResourcePath() string {

--- a/instana/restapi/infra-alert-rule.go
+++ b/instana/restapi/infra-alert-rule.go
@@ -1,10 +1,10 @@
 package restapi
 
 type InfraAlertRule struct {
-	AlertType              string       `json:"alertType"`
-	MetricName             string       `json:"metricName"`
-	EntityType             string       `json:"entityType"`
-	Aggregation            *Aggregation `json:"aggregation"`
-	CrossSeriesAggregation *Aggregation `json:"crossSeriesAggregation"`
-	Regex                  bool         `json:"regex"`
+	AlertType              string      `json:"alertType"`
+	MetricName             string      `json:"metricName"`
+	EntityType             string      `json:"entityType"`
+	Aggregation            Aggregation `json:"aggregation"`
+	CrossSeriesAggregation Aggregation `json:"crossSeriesAggregation"`
+	Regex                  bool        `json:"regex"`
 }

--- a/instana/restapi/infra-time-threshold.go
+++ b/instana/restapi/infra-time-threshold.go
@@ -2,5 +2,5 @@ package restapi
 
 type InfraTimeThreshold struct {
 	Type       string `json:"type"`
-	TimeWindow *int64 `json:"timeWindow"`
+	TimeWindow int64  `json:"timeWindow"`
 }

--- a/instana/threshold-rule-mapping.go
+++ b/instana/threshold-rule-mapping.go
@@ -1,0 +1,191 @@
+package instana
+
+import (
+	"github.com/gessnerfl/terraform-provider-instana/instana/restapi"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+const (
+	//ResourceFieldThresholdRule constant value for field threshold
+	ResourceFieldThresholdRule = "threshold"
+	//ResourceFieldThresholdRuleHistoricBaseline constant value for field threshold.historic_baseline
+	ResourceFieldThresholdRuleHistoricBaseline = "historic_baseline"
+	//ResourceFieldThresholdRuleHistoricBaselineBaseline constant value for field threshold.historic_baseline.baseline
+	ResourceFieldThresholdRuleHistoricBaselineBaseline = "baseline"
+	//ResourceFieldThresholdRuleHistoricBaselineDeviationFactor constant value for field threshold.historic_baseline.deviation_factor
+	ResourceFieldThresholdRuleHistoricBaselineDeviationFactor = "deviation_factor"
+	//ResourceFieldThresholdRuleHistoricBaselineSeasonality constant value for field threshold.historic_baseline.seasonality
+	ResourceFieldThresholdRuleHistoricBaselineSeasonality = "seasonality"
+	//ResourceFieldThresholdRuleStatic constant value for field threshold.static
+	ResourceFieldThresholdRuleStatic = "static"
+	//ResourceFieldThresholdRuleStaticValue constant value for field threshold.static.value
+	ResourceFieldThresholdRuleStaticValue = "value"
+)
+
+var thresholdRuleSchema = &schema.Schema{
+	Type:        schema.TypeList,
+	MinItems:    0,
+	MaxItems:    1,
+	Optional:    true,
+	Description: "Indicates the type of threshold this alert rule is evaluated on.",
+	Elem: &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			ResourceFieldThresholdRuleHistoricBaseline: {
+				Type:        schema.TypeList,
+				MinItems:    0,
+				MaxItems:    1,
+				Optional:    true,
+				Description: "Threshold based on a historic baseline.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						ResourceFieldThresholdRuleHistoricBaselineBaseline: {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type:     schema.TypeSet,
+								Optional: false,
+								Elem: &schema.Schema{
+									Type: schema.TypeFloat,
+								},
+							},
+							Description: "The baseline of the historic baseline threshold",
+						},
+						ResourceFieldThresholdRuleHistoricBaselineDeviationFactor: {
+							Type:         schema.TypeFloat,
+							Optional:     true,
+							ValidateFunc: validation.FloatBetween(0.5, 16),
+							Description:  "The baseline of the historic baseline threshold",
+						},
+						ResourceFieldThresholdRuleHistoricBaselineSeasonality: {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(restapi.SupportedThresholdSeasonalities.ToStringSlice(), false),
+							Description:  "The seasonality of the historic baseline threshold",
+						},
+					},
+				},
+			},
+			ResourceFieldThresholdRuleStatic: {
+				Type:        schema.TypeList,
+				MinItems:    0,
+				MaxItems:    1,
+				Optional:    true,
+				Description: "Static threshold definition",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						ResourceFieldThresholdRuleStaticValue: {
+							Type:        schema.TypeFloat,
+							Optional:    true,
+							Description: "The value of the static threshold",
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+func newThresholdRuleMapper() thresholdRuleMapper {
+	return &thresholdRuleMapperImpl{}
+}
+
+type thresholdRuleMapper interface {
+	toState(threshold *restapi.ThresholdRule) []map[string]interface{}
+	fromState(thresholdSlice []interface{}) *restapi.ThresholdRule
+}
+
+type thresholdRuleMapperImpl struct{}
+
+func (t thresholdRuleMapperImpl) toState(threshold *restapi.ThresholdRule) []map[string]interface{} {
+	thresholdConfig := make(map[string]interface{})
+
+	if threshold.Value != nil {
+		thresholdConfig[ResourceFieldThresholdRuleStaticValue] = *threshold.Value
+	}
+	if threshold.Baseline != nil {
+		thresholdConfig[ResourceFieldThresholdRuleHistoricBaselineBaseline] = *threshold.Baseline
+	}
+	if threshold.DeviationFactor != nil {
+		thresholdConfig[ResourceFieldThresholdRuleHistoricBaselineDeviationFactor] = float64(*threshold.DeviationFactor)
+	}
+	if threshold.Seasonality != nil {
+		thresholdConfig[ResourceFieldThresholdRuleHistoricBaselineSeasonality] = *threshold.Seasonality
+	}
+
+	thresholdType := t.mapThresholdTypeToSchema(threshold.Type)
+	thresholdRule := make(map[string]interface{})
+	thresholdRule[thresholdType] = []interface{}{thresholdConfig}
+	result := make([]map[string]interface{}, 1)
+	result[0] = thresholdRule
+
+	return result
+}
+
+func (t *thresholdRuleMapperImpl) mapThresholdTypeToSchema(input string) string {
+	if input == "historicBaseline" {
+		return ResourceFieldThresholdRuleHistoricBaseline
+	} else if input == "staticThreshold" {
+		return ResourceFieldThresholdRuleStatic
+	}
+	return input
+}
+
+func (t *thresholdRuleMapperImpl) mapThresholdTypeFromSchema(input string) string {
+	if input == ResourceFieldThresholdRuleHistoricBaseline {
+		return "historicBaseline"
+	} else if input == ResourceFieldThresholdRuleStatic {
+		return "staticThreshold"
+	}
+	return input
+}
+
+func (t *thresholdRuleMapperImpl) fromState(thresholdSlice []interface{}) *restapi.ThresholdRule {
+	threshold := thresholdSlice[0].(map[string]interface{})
+
+	for thresholdType, v := range threshold {
+		configSlice := v.([]interface{})
+		if len(configSlice) == 1 {
+			config := configSlice[0].(map[string]interface{})
+			return t.mapThresholdConfigFromSchema(config, thresholdType)
+		}
+	}
+
+	return &restapi.ThresholdRule{}
+}
+
+func (t *thresholdRuleMapperImpl) mapThresholdConfigFromSchema(config map[string]interface{}, thresholdType string) *restapi.ThresholdRule {
+	var seasonalityPtr *restapi.ThresholdSeasonality
+	if v, ok := config[ResourceFieldThresholdHistoricBaselineSeasonality]; ok {
+		seasonality := restapi.ThresholdSeasonality(v.(string))
+		seasonalityPtr = &seasonality
+	}
+	var valuePtr *float64
+	if v, ok := config[ResourceFieldThresholdStaticValue]; ok {
+		value := v.(float64)
+		valuePtr = &value
+	}
+	var deviationFactorPtr *float32
+	if v, ok := config[ResourceFieldThresholdHistoricBaselineDeviationFactor]; ok {
+		deviationFactor := float32(v.(float64))
+		deviationFactorPtr = &deviationFactor
+	}
+	var baselinePtr *[][]float64
+	if v, ok := config[ResourceFieldThresholdHistoricBaselineBaseline]; ok {
+		baselineSet := v.(*schema.Set)
+		if baselineSet.Len() > 0 {
+			baseline := make([][]float64, baselineSet.Len())
+			for i, val := range baselineSet.List() {
+				baseline[i] = ConvertInterfaceSlice[float64](val.(*schema.Set).List())
+			}
+			baselinePtr = &baseline
+		}
+	}
+	return &restapi.ThresholdRule{
+		Type:            t.mapThresholdTypeFromSchema(thresholdType),
+		Value:           valuePtr,
+		DeviationFactor: deviationFactorPtr,
+		Baseline:        baselinePtr,
+		Seasonality:     seasonalityPtr,
+	}
+}

--- a/instana/utils.go
+++ b/instana/utils.go
@@ -45,6 +45,20 @@ func ReadStringSetParameterFromResource(d *schema.ResourceData, key string) []st
 	return nil
 }
 
+// ReadArrayParameterFromResource reads a string array parameter from a resource and returns it as a slice of strings
+func ReadArrayParameterFromResource[T any](d *schema.ResourceData, key string) []T {
+	if attr, ok := d.GetOk(key); ok {
+		var array []T
+		items := attr.([]interface{})
+		for _, x := range items {
+			item := x.(T)
+			array = append(array, item)
+		}
+		return array
+	}
+	return nil
+}
+
 // ReadSetParameterFromMap reads a set parameter from a map and returns it as a slice
 func ReadSetParameterFromMap[T any](data map[string]interface{}, key string) []T {
 	if attr, ok := data[key]; ok {

--- a/mocks/Instana-api_mocks.go
+++ b/mocks/Instana-api_mocks.go
@@ -243,3 +243,10 @@ func (mr *MockInstanaAPIMockRecorder) WebsiteMonitoringConfig() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WebsiteMonitoringConfig", reflect.TypeOf((*MockInstanaAPI)(nil).WebsiteMonitoringConfig))
 }
+
+func (m *MockInstanaAPI) InfraAlertConfig() restapi.RestResource[*restapi.InfraAlertConfig] {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InfraAlertConfig")
+	ret0, _ := ret[0].(restapi.RestResource[*restapi.InfraAlertConfig])
+	return ret0
+}


### PR DESCRIPTION
We want to add TF support for Infrastructure Smart Alerts.

In a previous PR https://github.com/instana/terraform-provider-instana/pull/18, we added API implementation for Infra Alert Config.

This PR adds Infra Alert Config Resource changes.