### PR TITLE
Extend index.md with Infrastructure Alert Config

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,8 @@ resource.
   * Website Monitoring Config - `instana_website_monitoring_config`
   * Website Alert Config - `instana_website_alert_config`
 * Custom Dashboard - `instana_custom_dashboard`
+* Infrastructure Monitoring
+  * Infrastructure Alert Config - `instana_infra_alert_config`
 
 ## Supported Data Source:
 


### PR DESCRIPTION
Main [Documentation page](https://registry.terraform.io/providers/instana/instana/3.1.0/docs) is missing `Infrastructure Monitoring` section.

We now support `instana_infra_alert_config` resource starting **v3.1.0**. See https://registry.terraform.io/providers/instana/instana/3.1.0/docs/resources/infra_alert_config.

We should make it visible on the main index page as well. 😇 