### PR TITLE
Allow 1m granularity for smart alert resources

### DIFF
--- a/instana/resource-application-alert-config.go
+++ b/instana/resource-application-alert-config.go
@@ -255,7 +255,7 @@ var (
 		Type:         schema.TypeInt,
 		Optional:     true,
 		Default:      restapi.Granularity600000,
-		ValidateFunc: validation.IntInSlice(restapi.SupportedGranularities.ToIntSlice()),
+		ValidateFunc: validation.IntInSlice(restapi.SupportedSmartAlertGranularities.ToIntSlice()),
 		Description:  "The evaluation granularity used for detection of violations of the defined threshold. In other words, it defines the size of the tumbling window used",
 	}
 	applicationAlertConfigSchemaIncludeInternal = &schema.Schema{

--- a/instana/resource-infra-alert-config.go
+++ b/instana/resource-infra-alert-config.go
@@ -162,7 +162,7 @@ var (
 		Type:         schema.TypeInt,
 		Optional:     true,
 		Default:      restapi.Granularity600000,
-		ValidateFunc: validation.IntInSlice(restapi.SupportedGranularities.ToIntSlice()),
+		ValidateFunc: validation.IntInSlice(restapi.SupportedSmartAlertGranularities.ToIntSlice()),
 		Description:  "The evaluation granularity used for detection of violations of the defined threshold. In other words, it defines the size of the tumbling window used",
 	}
 	infraAlertConfigSchemaTimeThreshold = &schema.Schema{

--- a/instana/resource-website-alert-config.go
+++ b/instana/resource-website-alert-config.go
@@ -93,7 +93,7 @@ var (
 		Type:         schema.TypeInt,
 		Optional:     true,
 		Default:      restapi.Granularity600000,
-		ValidateFunc: validation.IntInSlice(restapi.SupportedGranularities.ToIntSlice()),
+		ValidateFunc: validation.IntInSlice(restapi.SupportedSmartAlertGranularities.ToIntSlice()),
 		Description:  "The evaluation granularity used for detection of violations of the defined threshold. In other words, it defines the size of the tumbling window used",
 	}
 	websiteAlertConfigSchemaName = &schema.Schema{

--- a/instana/restapi/granularity.go
+++ b/instana/restapi/granularity.go
@@ -16,17 +16,19 @@ func (granularities Granularities) ToIntSlice() []int {
 }
 
 const (
-	//Granularity300000 constant value for granularity of 30sec
+	//Granularity60000 constant value for granularity of 1min(60 sec)
+	Granularity60000 = Granularity(60000)
+	//Granularity300000 constant value for granularity of 5min(300 sec)
 	Granularity300000 = Granularity(300000)
-	//Granularity600000 constant value for granularity of 1min
+	//Granularity600000 constant value for granularity of 10min(600 sec)
 	Granularity600000 = Granularity(600000)
-	//Granularity900000 constant value for granularity of 1min 30sec
+	//Granularity900000 constant value for granularity of 15min(900 sec)
 	Granularity900000 = Granularity(900000)
-	//Granularity1200000 constant value for granularity of 2min
+	//Granularity1200000 constant value for granularity of 20min(1200 sec)
 	Granularity1200000 = Granularity(1200000)
-	//Granularity1800000 constant value for granularity of 3min
+	//Granularity1800000 constant value for granularity of 30min(1800 sec)
 	Granularity1800000 = Granularity(1800000)
 )
 
-// SupportedGranularities list of all supported Granularities
-var SupportedGranularities = Granularities{Granularity300000, Granularity600000, Granularity900000, Granularity1200000, Granularity1800000}
+// SupportedSmartAlertGranularities list of all supported Granularities
+var SupportedSmartAlertGranularities = Granularities{Granularity60000, Granularity300000, Granularity600000, Granularity900000, Granularity1200000, Granularity1800000}

--- a/instana/restapi/granularity_test.go
+++ b/instana/restapi/granularity_test.go
@@ -8,6 +8,6 @@ import (
 )
 
 func TestShouldReturnSupportedGranularitiesAsIntSlice(t *testing.T) {
-	expected := []int{300000, 600000, 900000, 1200000, 1800000}
+	expected := []int{60000, 300000, 600000, 900000, 1200000, 1800000}
 	require.Equal(t, expected, SupportedSmartAlertGranularities.ToIntSlice())
 }

--- a/instana/restapi/granularity_test.go
+++ b/instana/restapi/granularity_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestShouldReturnSupportedGranularitiesAsIntSlice(t *testing.T) {
 	expected := []int{300000, 600000, 900000, 1200000, 1800000}
-	require.Equal(t, expected, SupportedGranularities.ToIntSlice())
+	require.Equal(t, expected, SupportedSmartAlertGranularities.ToIntSlice())
 }


### PR DESCRIPTION
## Why

As of now, the minimum granularity supported is 5m as per our TF provider validation.
However, in the meantime, we already support 1m granularity for the static threshold. 😇 

We tried to use 1m granularity and following validation error msg was shown.
```
Error: expected granularity to be one of [300000 600000 900000 1200000 1800000], got 60000

  on bar.tf line 78, in resource "instana_infra_alert_config" "foo":
  78:   granularity = 60000
```

## What

- Improved doc for each granularity constant
- Allow 1m granularity for smart alert resources

