### PR TITLE
Fix call to Instana API always recieving a http 500 status response code for application configs

### DIFF
--- a/instana/restapi/Instana-api.go
+++ b/instana/restapi/Instana-api.go
@@ -72,7 +72,7 @@ func (api *baseInstanaAPI) APITokens() RestResource[*APIToken] {
 
 // ApplicationConfigs implementation of InstanaAPI interface
 func (api *baseInstanaAPI) ApplicationConfigs() RestResource[*ApplicationConfig] {
-	return NewCreatePUTUpdatePUTRestResource(ApplicationConfigsResourcePath, NewDefaultJSONUnmarshaller(&ApplicationConfig{}), api.client)
+	return NewCreatePOSTUpdatePUTRestResource(ApplicationConfigsResourcePath, NewDefaultJSONUnmarshaller(&ApplicationConfig{}), api.client)
 }
 
 // ApplicationAlertConfigs implementation of InstanaAPI interface


### PR DESCRIPTION
Fix for the [issue](https://github.com/instana/terraform-provider-instana/issues/35) when trying to create an application config the terraform provider would always receive a 500 status error. 