### PR TITLE
Fix mapAlertChannelsToSchema

### DIFF
--- a/instana/resource-infra-alert-config.go
+++ b/instana/resource-infra-alert-config.go
@@ -285,8 +285,6 @@ func (c *infraAlertConfigResource) UpdateState(d *schema.ResourceData, config *r
 
 func (c *infraAlertConfigResource) mapAlertChannelsToSchema(config *restapi.InfraAlertConfig) []map[string]interface{} {
 	alertChannels := config.AlertChannels
-
-	result := make([]map[string]interface{}, 1)
 	alertChannelsMap := make(map[string]interface{})
 
 	if v, ok := alertChannels[restapi.WarningSeverity]; ok {
@@ -297,9 +295,13 @@ func (c *infraAlertConfigResource) mapAlertChannelsToSchema(config *restapi.Infr
 		alertChannelsMap[ResourceFieldThresholdRuleCriticalSeverity] = v
 	}
 
-	result[0] = alertChannelsMap
+	// Only add to result if we have something
+	if len(alertChannelsMap) > 0 {
+		return []map[string]interface{}{alertChannelsMap}
+	}
 
-	return result
+	// Otherwise, return an empty slice
+	return []map[string]interface{}{}
 }
 
 func (c *infraAlertConfigResource) mapTimeThresholdToSchema(config *restapi.InfraAlertConfig) []map[string]interface{} {

--- a/instana/utils.go
+++ b/instana/utils.go
@@ -56,7 +56,7 @@ func ReadArrayParameterFromResource[T any](d *schema.ResourceData, key string) [
 		}
 		return array
 	}
-	return nil
+	return []T{}
 }
 
 // ReadSetParameterFromMap reads a set parameter from a map and returns it as a slice


### PR DESCRIPTION
Fix `mapAlertChannelsToSchema` function.

Only add to result if we have something. Otherwise, return an empty slice.
Look into changes and related test for more details.
