### PR TITLE
Use correct tag filter as part of examples in the application_config.md

### DIFF
--- a/docs/resources/application_config.md
+++ b/docs/resources/application_config.md
@@ -58,13 +58,13 @@ identifier                := [a-zA-Z_][\.a-zA-Z0-9_\-/]*
 **Basic**
 
 ```plain
-entity.service.name EQUALS 'my-service' AND entity.tag:stage EQUALS 'PROD' AND call.http.status EQUALS 404
+service.name EQUALS 'my-service' AND agent.tag:stage EQUALS 'PROD' AND call.http.status@na EQUALS 404
 ```
 
 **Calls filtered on source**
 
 ```plain
-entity.service.name@src EQUALS 'my-service' AND entity.tag:stage@src EQUALS PROD
+service.name@src EQUALS 'my-service' AND agent.tag:stage@src EQUALS 'PROD'
 ```
 
 ## Import


### PR DESCRIPTION
## Why/What
It seems the example shared as part of application_config.md is incorrect and shows following error.

```
instana_application_config.terraform-non-prod: Creating...
╷
│ Error: failed to send HTTP POST request to Instana API; status code = 422; status message = 422 Unprocessable Entity; Headers map[Cache-Control:[no-store, max-age=0] Connection:[keep-alive] Content-Length:[64] Content-Type:[application/json;charset=utf-8] Date:[Sun, 29 Jun 2025 14:08:45 GMT] Referrer-Policy:[same-origin] Server:[openresty] Server-Timing:[intid;desc=43f6e7617e58beef] Vary:[Cookie, Authorization] X-Content-Type-Options:[nosniff] X-Frame-Options:[deny] X-Permitted-Cross-Domain-Policies:[none] X-Ratelimit-Limit:[10000] X-Ratelimit-Remaining:[9983] X-Ratelimit-Reset:[1751206562] X-Ratelimit-Zone:[default] X-Xss-Protection:[1; mode=block]]
│ Body: {"code":422,"message":"Unknown tag filter: entity.service.name"}
...
```

Use correct tag filter as part of examples in the `application_config.md`