### PR TITLE
Extend instana_infra_alert_config schema with evaluation_type

### DIFF
--- a/instana/resource-infra-alert-config_test.go
+++ b/instana/resource-infra-alert-config_test.go
@@ -87,6 +87,7 @@ var infraAlertConfigServerResponseTemplate = `
 		"id": "%s",
 		"name": "name %d",
 		"description": "test-alert-description",
+  		"evaluationType": "CUSTOM",
 		"alertChannels": {
 			"WARNING": ["alert-channel-id-1"],
 			"CRITICAL": ["alert-channel-id-2"]
@@ -331,6 +332,7 @@ func (test *infraAlertConfigTest) createTestShouldMapTerraformResourceStateToMod
 			Rules: []restapi.RuleWithThreshold[restapi.InfraAlertRule]{
 				ruleTestPair.expected,
 			},
+			EvaluationType: restapi.EvaluationTypeCustom,
 		}
 
 		testHelper := NewTestHelper[*restapi.InfraAlertConfig](t)
@@ -524,6 +526,7 @@ func (test *infraAlertConfigTest) createTestShouldUpdateTerraformResourceStateFr
 			Rules: []restapi.RuleWithThreshold[restapi.InfraAlertRule]{
 				ruleTestPair.input,
 			},
+			EvaluationType: restapi.EvaluationTypePerEntity,
 		}
 
 		testHelper := NewTestHelper[*restapi.InfraAlertConfig](t)
@@ -536,6 +539,7 @@ func (test *infraAlertConfigTest) createTestShouldUpdateTerraformResourceStateFr
 
 		require.Equal(t, "infra-alert-config-name", resourceData.Get(InfraAlertConfigFieldName))
 		require.Equal(t, "infra-alert-config-description", resourceData.Get(InfraAlertConfigFieldDescription))
+		require.Equal(t, "PER_ENTITY", resourceData.Get(InfraAlertConfigFieldEvaluationType))
 		require.Equal(t, []interface{}{
 			map[string]interface{}{
 				ResourceFieldThresholdRuleWarningSeverity:  []interface{}{"channel-1"},
@@ -640,6 +644,7 @@ func (test *infraAlertConfigTest) createIntegrationTestStep(httpPort int, iterat
 			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, "id", id),
 			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, InfraAlertConfigFieldName, formatResourceName(iteration)),
 			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, InfraAlertConfigFieldDescription, "test-alert-description"),
+			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, InfraAlertConfigFieldEvaluationType, "CUSTOM"),
 			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, InfraAlertConfigFieldAlertChannels+".0."+ResourceFieldThresholdRuleWarningSeverity+".0", "alert-channel-id-1"),
 			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, InfraAlertConfigFieldAlertChannels+".0."+ResourceFieldThresholdRuleCriticalSeverity+".0", "alert-channel-id-2"),
 			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, InfraAlertConfigFieldGroupBy+".0", "metricId"),
@@ -729,12 +734,14 @@ func (test *infraAlertConfigTest) createTestWithSingleSeverityAlertChannelsShoul
 				ruleTestPair.expected,
 			},
 			CustomerPayloadFields: []restapi.CustomPayloadField[any]{},
+			EvaluationType:        restapi.EvaluationTypePerEntity,
 		}
 
 		testHelper := NewTestHelper[*restapi.InfraAlertConfig](t)
 		sut := test.resourceHandle
 		resourceData := testHelper.CreateEmptyResourceDataForResourceHandle(sut)
 		setValueOnResourceData(t, resourceData, InfraAlertConfigFieldName, "infra-alert-config-name")
+		setValueOnResourceData(t, resourceData, InfraAlertConfigFieldEvaluationType, "PER_ENTITY")
 		setValueOnResourceData(t, resourceData, InfraAlertConfigFieldDescription, "infra-alert-config-description")
 		setValueOnResourceData(t, resourceData, InfraAlertConfigFieldAlertChannels, []interface{}{
 			map[string]interface{}{
@@ -776,6 +783,7 @@ func (test *infraAlertConfigTest) createTestWithNoAlertChannelsShouldMapTerrafor
 				ruleTestPair.expected,
 			},
 			CustomerPayloadFields: []restapi.CustomPayloadField[any]{},
+			EvaluationType:        restapi.EvaluationTypeCustom,
 		}
 
 		testHelper := NewTestHelper[*restapi.InfraAlertConfig](t)
@@ -846,6 +854,7 @@ func (test *infraAlertConfigTest) shouldConvertJsonPayloadToUpdateStateAndMapSta
 					}
 				}
 			],
+			"evaluationType": "CUSTOM",
 			"alertChannels": {}
 		}`
 

--- a/instana/restapi/infra-alert-configs.go
+++ b/instana/restapi/infra-alert-configs.go
@@ -13,6 +13,7 @@ type InfraAlertConfig struct {
 	CustomerPayloadFields []CustomPayloadField[any]           `json:"customPayloadFields"`
 	Rules                 []RuleWithThreshold[InfraAlertRule] `json:"rules"`
 	AlertChannels         map[AlertSeverity][]string          `json:"alertChannels"`
+	EvaluationType        InfraAlertEvaluationType            `json:"evaluationType"`
 }
 
 func (config *InfraAlertConfig) GetIDForResourcePath() string {

--- a/instana/restapi/infra-alert-evaluation-type.go
+++ b/instana/restapi/infra-alert-evaluation-type.go
@@ -1,0 +1,29 @@
+package restapi
+
+// InfraAlertEvaluationType custom type representing the infrastructure alert evaluation type from the Instana API
+type InfraAlertEvaluationType string
+
+// InfraAlertEvaluationTypes custom type representing a slice of InfraAlertEvaluationType
+type InfraAlertEvaluationTypes []InfraAlertEvaluationType
+
+// ToStringSlice returns the corresponding string representations
+func (types InfraAlertEvaluationTypes) ToStringSlice() []string {
+	result := make([]string, len(types))
+	for i, v := range types {
+		result[i] = string(v)
+	}
+	return result
+}
+
+const (
+	// EvaluationTypePerEntity constant value for InfraAlertEvaluationType PER_ENTITY
+	EvaluationTypePerEntity = InfraAlertEvaluationType("PER_ENTITY")
+	// EvaluationTypeCustom constant value for InfraAlertEvaluationType CUSTOM
+	EvaluationTypeCustom = InfraAlertEvaluationType("CUSTOM")
+)
+
+// SupportedInfraAlertEvaluationTypes list of all supported InfraAlertEvaluationTypes
+var SupportedInfraAlertEvaluationTypes = InfraAlertEvaluationTypes{
+	EvaluationTypePerEntity,
+	EvaluationTypeCustom,
+}


### PR DESCRIPTION
As Infra Smart Alert now supports two types of evaluations.
1) CUSTOM 
2) PER_ENTITY

For more details. See [here](https://www.ibm.com/docs/en/instana-observability/1.0.298?topic=saas-release-10298#per-entity-alerting-in-smart-alerts-for-infrastructure) and [here](https://www.ibm.com/docs/en/instana-observability/1.0.299?topic=infrastructure-smart-alerts#defining-the-scope).

Extend Infra Alert Config schema with `evaluationType`.