### PR TITLE
Importing an Application config fix

### DIFF
--- a/instana/tagfilter/instana-api-model-to-tag-filter.go
+++ b/instana/tagfilter/instana-api-model-to-tag-filter.go
@@ -2,6 +2,7 @@ package tagfilter
 
 import (
 	"fmt"
+
 	"github.com/gessnerfl/terraform-provider-instana/utils"
 
 	"github.com/gessnerfl/terraform-provider-instana/instana/restapi"
@@ -125,9 +126,6 @@ func (m *tagFilterMapper) mapLogicalAnd(elements []*expressionHandle) (*expressi
 	total := len(elements)
 	if total < 1 {
 		return nil, fmt.Errorf("at least one element is expected for logical and")
-	}
-	if elements[0].and != nil {
-		return nil, fmt.Errorf("invalid logical and expression: logical and is not allowed for first element")
 	}
 
 	operator := Operator(restapi.LogicalAnd)

--- a/instana/tagfilter/instana-api-model-to-tag-filter_test.go
+++ b/instana/tagfilter/instana-api-model-to-tag-filter_test.go
@@ -2,8 +2,9 @@ package tagfilter_test
 
 import (
 	"fmt"
-	"github.com/gessnerfl/terraform-provider-instana/utils"
 	"testing"
+
+	"github.com/gessnerfl/terraform-provider-instana/utils"
 
 	"github.com/stretchr/testify/require"
 
@@ -435,18 +436,6 @@ func TestShouldMapLogicalAndWithTwoElementsFromInstanaAPIWhereTheFirstElementIsA
 	}
 
 	runTestCaseForMappingFromAPI(input, expectedResult, t)
-}
-
-func TestShouldFailToMapLogicalAndFromInstanaAPIWhenFirstElementIsAnAndExpression(t *testing.T) {
-	primaryExpression := restapi.NewUnaryTagFilter(restapi.TagFilterEntityDestination, tagFilterName, restapi.IsEmptyOperator)
-	nestedAnd := restapi.NewLogicalAndTagFilter([]*restapi.TagFilter{primaryExpression, primaryExpression})
-	input := restapi.NewLogicalAndTagFilter([]*restapi.TagFilter{nestedAnd, primaryExpression})
-
-	mapper := NewMapper()
-	_, err := mapper.FromAPIModel(input)
-
-	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "logical and is not allowed for first element")
 }
 
 func TestShouldUnwrapLogicalAndFromInstanaAPIWhenOnlyOneElementIsProvided(t *testing.T) {


### PR DESCRIPTION
In the instana UI application config expressions like 
`service.name = 'test' OR (service.name = 'test2' AND endpoint.name = 'test3')`
 are valid creations however terraform fails to import them stating an expression cannot start with a logical and. This is because the current terraform provider does not allow for nested ANDs in an expression.

Although no explicit nested AND is in this expression, the response returned from the api/application-monitoring/settings/application/_appIDValue_ used to import the application config treats parenthesis like an AND. Therefore creating a nested AND in its response to terraform as shown:

```json
{
	"id": "nRgbq88vRryAN6GQtLqiAA",
	"label": "terraform-import-test",
	"matchSpecification": null,
	"tagFilterExpression": {
		"type": "EXPRESSION",
		"logicalOperator": "OR",
		"elements": [
			{
				"type": "TAG_FILTER",
				"name": "service.name",
				"stringValue": "test",
				"numberValue": null,
				"booleanValue": null,
				"floatValue": null,
				"key": null,
				"value": "test",
				"operator": "EQUALS",
				"entity": "DESTINATION"
			},
			{
				"type": "EXPRESSION",
				"logicalOperator": "AND",
				"elements": [
					{
						"type": "EXPRESSION",
						"logicalOperator": "AND",
						"elements": [
							{
								"type": "TAG_FILTER",
								"name": "service.name",
								"stringValue": "test2",
								"numberValue": null,
								"booleanValue": null,
								"floatValue": null,
								"key": null,
								"value": "test2",
								"operator": "EQUALS",
								"entity": "DESTINATION"
							},
							{
								"type": "TAG_FILTER",
								"name": "endpoint.name",
								"stringValue": "test3",
								"numberValue": null,
								"booleanValue": null,
								"floatValue": null,
								"key": null,
								"value": "test3",
								"operator": "EQUALS",
								"entity": "DESTINATION"
							}
						]
					}
				]
			}
		]
	},
	"scope": "INCLUDE_IMMEDIATE_DOWNSTREAM_DATABASE_AND_MESSAGING",
	"boundaryScope": "INBOUND",
	"accessRules": [
		{
			"accessType": "READ_WRITE",
			"relationType": "GLOBAL",
			"relatedId": null
		}
	],
	"restrictingApplication": false
}
```
The proposed changes remove the check for a nested AND and throwing of an error if found, allowing this valid syntax to be imported from the instana UI into terraform
