### PR TITLE
Adding Timezone to the SLO payload

### DIFF
--- a/docs/resources/slo_config.md
+++ b/docs/resources/slo_config.md
@@ -191,13 +191,13 @@ One of the elements below must be configured:
 
 * `duration` - Required - The duration of the time window. Must be an integer.
 * `duration_unit` - Required - The unit of the duration. Allowed values: `day`, `week`.
-* `timezone` - Optional - The timezone the SLO config is bound with. Defaults to `UTC` if not defined.
+* `timezone` - Optional - The timezone associated with the SLO configuration. Defaults to `UTC` when not specified.
 
 Fixed Time Window Reference
 
 * `duration` - Required - The duration of the time window. Must be an integer.
 * `duration_unit` - Required - The unit of the duration. Allowed values: `day`, `week`.
-* `timezone` - Optional - The timezone the SLO config is bound with. Defaults to `UTC` if not defined.
+* `timezone` - Optional - The timezone associated with the SLO configuration. Defaults to `UTC` when not specified.
 * `initial_evaluation_timestamp` - Required - the starting timestamp for the Fixed Time Window.
 
 ### Tag Filter Expression Reference

--- a/docs/resources/slo_config.md
+++ b/docs/resources/slo_config.md
@@ -36,6 +36,7 @@ resource "instana_slo_config" "slo_1" {
     rolling {
       duration = 1
       duration_unit = "day"
+      timezone = "UTC"
     }
   }
 }
@@ -65,6 +66,7 @@ resource "instana_slo_config" "website_3" {
      fixed {
        duration = 1
        duration_unit = "day"
+       timezone = "Europe/Dublin"
        start_timestamp = var.fixed_timewindow_start_timestamp
      }
    }
@@ -95,6 +97,7 @@ resource "instana_slo_config" "synthetic_r_6" {
      rolling {
        duration = 1
        duration_unit = "day"
+       timezone = ""
      }
    }
 }
@@ -188,11 +191,13 @@ One of the elements below must be configured:
 
 * `duration` - Required - The duration of the time window. Must be an integer.
 * `duration_unit` - Required - The unit of the duration. Allowed values: `day`, `week`.
+* `timezone` - Optional - The timezone the SLO config is bound with. Defaults to `UTC` if not defined.
 
 Fixed Time Window Reference
 
 * `duration` - Required - The duration of the time window. Must be an integer.
 * `duration_unit` - Required - The unit of the duration. Allowed values: `day`, `week`.
+* `timezone` - Optional - The timezone the SLO config is bound with. Defaults to `UTC` if not defined.
 * `initial_evaluation_timestamp` - Required - the starting timestamp for the Fixed Time Window.
 
 ### Tag Filter Expression Reference

--- a/instana/resource-slo-config-def.go
+++ b/instana/resource-slo-config-def.go
@@ -278,6 +278,7 @@ var (
 	SloConfigSchemaTimezone = &schema.Schema{
 		Type:        schema.TypeString,
 		Optional:    true,
+		Default:     "UTC",
 		Description: "The Timezone for the SLO configuration. If not set, UTC is used by default.",
 	}
 

--- a/instana/resource-slo-config-def.go
+++ b/instana/resource-slo-config-def.go
@@ -14,7 +14,7 @@ const SloConfigFromTerraformIdPrefix = "SLOTF"
 const (
 	//SloConfigField names for terraform
 	SloConfigFieldName                      = "name"
-	SloConfigFieldFullName					= "full_name"
+	SloConfigFieldFullName                  = "full_name"
 	SloConfigFieldTarget                    = "target"
 	SloConfigFieldTags                      = "tags"
 	SloConfigFieldLastUpdated               = "last_updated"
@@ -39,6 +39,7 @@ const (
 	SloConfigFieldTrafficType               = "traffic_type"
 	SloConfigFieldDuration                  = "duration"
 	SloConfigFieldDurationUnit              = "duration_unit"
+	SloConfigFieldTimezone                  = "timezone"
 	SloConfigFieldStartTimestamp            = "start_timestamp"
 
 	// Slo entity types for terraform
@@ -65,6 +66,7 @@ const (
 	SloConfigAPIFieldAggregation     = "aggregation"
 	SloConfigAPIFieldDuration        = "duration"
 	SloConfigAPIFieldDurationUnit    = "durationUnit"
+	SloConfigAPIFieldTimezone        = "timezone"
 	SloConfigAPIFieldStartTimestamp  = "startTimestamp"
 	SloConfigAPIFieldTrafficType     = "trafficType"
 	SloConfigAPIFieldGoodEventFilter = "goodEventFilterExpression"
@@ -273,6 +275,12 @@ var (
 		Description:  "The boundary scope for the entity configuration (ALL, INBOUND)",
 	}
 
+	SloConfigSchemaTimezone = &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "The Timezone for the SLO configuration. If not set, UTC is used by default.",
+	}
+
 	SloConfigSchemaStartTime = &schema.Schema{
 		Type:        schema.TypeFloat,
 		Required:    true,
@@ -464,6 +472,7 @@ var (
 						Schema: map[string]*schema.Schema{
 							"duration":      SloConfigSchemaDuration,
 							"duration_unit": SloConfigSchemaDurationUnit,
+							"timezone":      SloConfigSchemaTimezone,
 						},
 					},
 					ExactlyOneOf: sloConfigTimeWindowTypeKeys,
@@ -477,6 +486,7 @@ var (
 						Schema: map[string]*schema.Schema{
 							"duration":        SloConfigSchemaDuration,
 							"duration_unit":   SloConfigSchemaDurationUnit,
+							"timezone":        SloConfigSchemaTimezone,
 							"start_timestamp": SloConfigSchemaStartTime,
 						},
 					},

--- a/instana/resource-slo-config-timewindow.go
+++ b/instana/resource-slo-config-timewindow.go
@@ -19,6 +19,7 @@ func (r *sloConfigResource) mapSliTimeWindowListFromState(stateObject map[string
 				Type:         SloConfigRollingTimeWindow,
 				Duration:     *GetPointerFromMap[int](data, SloConfigFieldDuration),
 				DurationUnit: *GetPointerFromMap[string](data, SloConfigFieldDurationUnit),
+				Timezone:     *GetPointerFromMap[string](data, SloConfigFieldTimezone),
 			}, nil
 		}
 		if details, ok := stateObject[SloConfigFixedTimeWindow]; ok && r.isSet(details) {
@@ -27,7 +28,8 @@ func (r *sloConfigResource) mapSliTimeWindowListFromState(stateObject map[string
 				Type:         SloConfigFixedTimeWindow,
 				Duration:     *GetPointerFromMap[int](data, SloConfigFieldDuration),
 				DurationUnit: *GetPointerFromMap[string](data, SloConfigFieldDurationUnit),
-				StartTime:    *GetPointerFromMap[float64](data, SloConfigFieldStartTimestamp),
+				Timezone:     *GetPointerFromMap[string](data, SloConfigFieldTimezone),
+				StartTime: *GetPointerFromMap[float64](data, SloConfigFieldStartTimestamp),
 			}, nil
 
 		}
@@ -48,6 +50,7 @@ func (r *sloConfigResource) mapSloTimeWindowToState(sloConfig *restapi.SloConfig
 					map[string]interface{}{
 						SloConfigFieldDuration:     timeWindow[SloConfigAPIFieldDuration],
 						SloConfigFieldDurationUnit: timeWindow[SloConfigAPIFieldDurationUnit].(string),
+						SloConfigFieldTimezone:     timeWindow[SloConfigAPIFieldTimezone].(string),
 					},
 				},
 			}
@@ -58,6 +61,7 @@ func (r *sloConfigResource) mapSloTimeWindowToState(sloConfig *restapi.SloConfig
 					map[string]interface{}{
 						SloConfigFieldDuration:       timeWindow[SloConfigAPIFieldDuration],
 						SloConfigFieldDurationUnit:   timeWindow[SloConfigAPIFieldDurationUnit].(string),
+						SloConfigFieldTimezone:       timeWindow[SloConfigAPIFieldTimezone].(string),
 						SloConfigFieldStartTimestamp: timeWindow[SloConfigAPIFieldStartTimestamp].(float64),
 					},
 				},

--- a/instana/resource-slo-config-timewindow.go
+++ b/instana/resource-slo-config-timewindow.go
@@ -50,7 +50,7 @@ func (r *sloConfigResource) mapSloTimeWindowToState(sloConfig *restapi.SloConfig
 					map[string]interface{}{
 						SloConfigFieldDuration:     timeWindow[SloConfigAPIFieldDuration],
 						SloConfigFieldDurationUnit: timeWindow[SloConfigAPIFieldDurationUnit].(string),
-						SloConfigFieldTimezone:     timeWindow[SloConfigAPIFieldTimezone].(string),
+						SloConfigFieldTimezone:     GetStringOrEmpty(timeWindow, SloConfigAPIFieldTimezone),
 					},
 				},
 			}
@@ -61,7 +61,7 @@ func (r *sloConfigResource) mapSloTimeWindowToState(sloConfig *restapi.SloConfig
 					map[string]interface{}{
 						SloConfigFieldDuration:       timeWindow[SloConfigAPIFieldDuration],
 						SloConfigFieldDurationUnit:   timeWindow[SloConfigAPIFieldDurationUnit].(string),
-						SloConfigFieldTimezone:       timeWindow[SloConfigAPIFieldTimezone].(string),
+						SloConfigFieldTimezone:       GetStringOrEmpty(timeWindow, SloConfigAPIFieldTimezone),
 						SloConfigFieldStartTimestamp: timeWindow[SloConfigAPIFieldStartTimestamp].(float64),
 					},
 				},

--- a/instana/resource-slo-config-timewindow.go
+++ b/instana/resource-slo-config-timewindow.go
@@ -29,7 +29,7 @@ func (r *sloConfigResource) mapSliTimeWindowListFromState(stateObject map[string
 				Duration:     *GetPointerFromMap[int](data, SloConfigFieldDuration),
 				DurationUnit: *GetPointerFromMap[string](data, SloConfigFieldDurationUnit),
 				Timezone:     *GetPointerFromMap[string](data, SloConfigFieldTimezone),
-				StartTime: *GetPointerFromMap[float64](data, SloConfigFieldStartTimestamp),
+				StartTime:    *GetPointerFromMap[float64](data, SloConfigFieldStartTimestamp),
 			}, nil
 
 		}

--- a/instana/resource-slo-config-timewindow.go
+++ b/instana/resource-slo-config-timewindow.go
@@ -19,7 +19,7 @@ func (r *sloConfigResource) mapSliTimeWindowListFromState(stateObject map[string
 				Type:         SloConfigRollingTimeWindow,
 				Duration:     *GetPointerFromMap[int](data, SloConfigFieldDuration),
 				DurationUnit: *GetPointerFromMap[string](data, SloConfigFieldDurationUnit),
-				Timezone:     *GetPointerFromMap[string](data, SloConfigFieldTimezone),
+				Timezone:     GetStringOrEmpty(data, SloConfigFieldTimezone),
 			}, nil
 		}
 		if details, ok := stateObject[SloConfigFixedTimeWindow]; ok && r.isSet(details) {
@@ -28,7 +28,7 @@ func (r *sloConfigResource) mapSliTimeWindowListFromState(stateObject map[string
 				Type:         SloConfigFixedTimeWindow,
 				Duration:     *GetPointerFromMap[int](data, SloConfigFieldDuration),
 				DurationUnit: *GetPointerFromMap[string](data, SloConfigFieldDurationUnit),
-				Timezone:     *GetPointerFromMap[string](data, SloConfigFieldTimezone),
+				Timezone:     GetStringOrEmpty(data, SloConfigFieldTimezone),
 				StartTime:    *GetPointerFromMap[float64](data, SloConfigFieldStartTimestamp),
 			}, nil
 
@@ -71,4 +71,13 @@ func (r *sloConfigResource) mapSloTimeWindowToState(sloConfig *restapi.SloConfig
 	}
 
 	return nil, fmt.Errorf("unsupported time window type %s", reflect.TypeOf(sloTimeWindow).Name())
+}
+
+func GetStringOrEmpty(m map[string]interface{}, key string) string {
+	if v, ok := m[key]; ok && v != nil {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
 }

--- a/instana/restapi/slo-config-api.go
+++ b/instana/restapi/slo-config-api.go
@@ -94,14 +94,14 @@ type SloRollingTimeWindow struct {
 	Type         string `json:"type"`
 	Duration     int    `json:"duration"`
 	DurationUnit string `json:"durationUnit"`
-	Timezone     string `json:"timezone"`
+	Timezone     string `json:"timezone,omitempty"`
 }
 
 type SloFixedTimeWindow struct {
 	Type         string  `json:"type"`
 	Duration     int     `json:"duration"`
 	DurationUnit string  `json:"durationUnit"`
-	Timezone     string  `json:"timezone"`
+	Timezone     string  `json:"timezone,omitempty"`
 	StartTime    float64 `json:"startTimestamp"`
 }
 

--- a/instana/restapi/slo-config-api.go
+++ b/instana/restapi/slo-config-api.go
@@ -94,12 +94,14 @@ type SloRollingTimeWindow struct {
 	Type         string `json:"type"`
 	Duration     int    `json:"duration"`
 	DurationUnit string `json:"durationUnit"`
+	Timezone     string `json:"timezone"`
 }
 
 type SloFixedTimeWindow struct {
 	Type         string  `json:"type"`
 	Duration     int     `json:"duration"`
 	DurationUnit string  `json:"durationUnit"`
+	Timezone     string  `json:"timezone"`
 	StartTime    float64 `json:"startTimestamp"`
 }
 


### PR DESCRIPTION
We have introduced `timezone` parameter in the SLO payload. SLOs are now explicitly bound to specific timezones, ensuring charts display consistent data that aligns with the SLO’s timezone. This ensures accurate start and end times, even during daylight saving time shifts.