### PR TITLE
Fixes for instana_slo_config indicators

### DIFF
--- a/instana/resource-slo-config-def.go
+++ b/instana/resource-slo-config-def.go
@@ -69,8 +69,8 @@ const (
 	SloConfigAPIFieldTimezone        = "timezone"
 	SloConfigAPIFieldStartTimestamp  = "startTimestamp"
 	SloConfigAPIFieldTrafficType     = "trafficType"
-	SloConfigAPIFieldGoodEventFilter = "goodEventFilterExpression"
-	SloConfigAPIFieldBadEventFilter  = "badEventFilterExpression"
+	SloConfigAPIFieldGoodEventFilter = "goodEventsFilter"
+	SloConfigAPIFieldBadEventFilter  = "badEventsFilter"
 
 	SloConfigAPIFieldFilter = "tagFilterExpression"
 

--- a/instana/resource-slo-config-def.go
+++ b/instana/resource-slo-config-def.go
@@ -165,6 +165,7 @@ var (
 
 	SloConfigSchemaAggregation = &schema.Schema{
 		Type:         schema.TypeString,
+		ForceNew:     true,
 		Required:     true,
 		ValidateFunc: validation.StringInSlice([]string{"SUM", "MEAN", "MAX", "MIN", "P25", "P50", "P75", "P90", "P95", "P98", "P99", "P99_9", "P99_99", "DISTRIBUTION", "DISTINCT_COUNT", "SUM_POSITIVE", "PER_SECOND"}, true),
 		Description:  "The aggregation type for the metric configuration (SUM, MEAN, MAX, MIN, P25, P50, P75, P90, P95, P98, P99, P99_9, P99_99, DISTRIBUTION, DISTINCT_COUNT, SUM_POSITIVE, PER_SECOND)",
@@ -172,6 +173,7 @@ var (
 
 	SloConfigSchemaThreshold = &schema.Schema{
 		Type:        schema.TypeFloat,
+		ForceNew:    true,
 		Required:    true,
 		Description: "The threshold for the metric configuration",
 		ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
@@ -304,6 +306,7 @@ var (
 
 	SloConfigSchemaTrafficType = &schema.Schema{
 		Type:         schema.TypeString,
+		ForceNew:     true,
 		Required:     true,
 		ValidateFunc: validation.StringInSlice([]string{"all", "erroneous"}, true),
 		Description:  "The boundary scope for the entity configuration (ALL, INBOUND)",
@@ -372,6 +375,7 @@ var (
 		Type:        schema.TypeList,
 		MinItems:    1,
 		MaxItems:    1,
+		ForceNew:    true,
 		Required:    true,
 		Description: "The entity to use for the SLI config.",
 		Elem: &schema.Resource{

--- a/instana/resource-slo-config-indicator.go
+++ b/instana/resource-slo-config-indicator.go
@@ -125,7 +125,9 @@ func (r *sloConfigResource) mapSloIndicatorToState(sloConfig *restapi.SloConfig)
 		}
 		if indicator[SloConfigAPIFieldType] == SloConfigAPIIndicatorMeasurementTypeEventBased && indicator[SloConfigAPIFieldBlueprint] == SloConfigAPIIndicatorBlueprintAvailability {
 			result := map[string]interface{}{
-				"event_based_availability": []interface{}{},
+				"event_based_availability": []interface{}{
+					map[string]interface{}{},
+				},
 			}
 			return result, nil
 		}

--- a/instana/resource-slo-config-indicator.go
+++ b/instana/resource-slo-config-indicator.go
@@ -125,7 +125,7 @@ func (r *sloConfigResource) mapSloIndicatorToState(sloConfig *restapi.SloConfig)
 		}
 		if indicator[SloConfigAPIFieldType] == SloConfigAPIIndicatorMeasurementTypeEventBased && indicator[SloConfigAPIFieldBlueprint] == SloConfigAPIIndicatorBlueprintAvailability {
 			result := map[string]interface{}{
-				"event_based_latency": []interface{}{},
+				"event_based_availability": []interface{}{},
 			}
 			return result, nil
 		}

--- a/instana/resource-slo-config-indicator.go
+++ b/instana/resource-slo-config-indicator.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 
 	"github.com/gessnerfl/terraform-provider-instana/instana/restapi"
+	"github.com/gessnerfl/terraform-provider-instana/instana/tagfilter"
 )
 
 // state -> api

--- a/instana/resource-slo-config-indicator.go
+++ b/instana/resource-slo-config-indicator.go
@@ -114,7 +114,7 @@ func (r *sloConfigResource) mapSloIndicatorToState(sloConfig *restapi.SloConfig)
 
 		if indicator[SloConfigAPIFieldType] == SloConfigAPIIndicatorMeasurementTypeTimeBased && indicator[SloConfigAPIFieldBlueprint] == SloConfigAPIIndicatorBlueprintAvailability {
 			result := map[string]interface{}{
-				"time_based_latency": []interface{}{
+				"time_based_availability": []interface{}{
 					map[string]interface{}{
 						SloConfigFieldThreshold:   indicator[SloConfigAPIFieldThreshold].(float64),
 						SloConfigFieldAggregation: indicator[SloConfigAPIFieldAggregation].(string),

--- a/instana/resource-slo-config-indicator.go
+++ b/instana/resource-slo-config-indicator.go
@@ -38,13 +38,13 @@ func (r *sloConfigResource) mapSliIndicatorListFromState(stateObject map[string]
 				Aggregation: *GetPointerFromMap[string](data, SloConfigFieldAggregation),
 			}, nil
 		}
-		if _, ok := stateObject["event_based_availability"]; ok {
+		if details, ok := stateObject["event_based_availability"]; ok && r.isSet(details) {
 			return restapi.SloEventBasedLatencyIndicator{
 				Type:      SloConfigAPIIndicatorMeasurementTypeEventBased,
 				Blueprint: SloConfigAPIIndicatorBlueprintAvailability,
 			}, nil
 		}
-		if details, ok := stateObject["custom"]; ok && r.isSet(details) {
+		if details, ok := stateObject["traffic"]; ok && r.isSet(details) {
 			data := details.([]interface{})[0].(map[string]interface{})
 			return restapi.SloTrafficIndicator{
 				Blueprint:   SloConfigAPIIndicatorBlueprintTraffic,
@@ -53,7 +53,7 @@ func (r *sloConfigResource) mapSliIndicatorListFromState(stateObject map[string]
 				Aggregation: *GetPointerFromMap[string](data, SloConfigFieldAggregation),
 			}, nil
 		}
-		if details, ok := stateObject["traffic"]; ok && r.isSet(details) {
+		if details, ok := stateObject["custom"]; ok && r.isSet(details) {
 			data := details.([]interface{})[0].(map[string]interface{})
 			var goodEventFilterExpression *restapi.TagFilter
 			var badEventFilterExpression *restapi.TagFilter

--- a/instana/resource-slo-config-indicator.go
+++ b/instana/resource-slo-config-indicator.go
@@ -145,20 +145,30 @@ func (r *sloConfigResource) mapSloIndicatorToState(sloConfig *restapi.SloConfig)
 			return result, nil
 		}
 		if indicator[SloConfigAPIFieldType] == SloConfigAPIIndicatorMeasurementTypeEventBased && indicator[SloConfigAPIFieldBlueprint] == SloConfigAPIIndicatorBlueprintCustom {
-			goodEventFilterExp, validExp1, err1 := fiterExpFromAPIModel(indicator[SloConfigAPIFieldGoodEventFilter])
-			if validExp1 {
-				return nil, err1
+			var err error
+			goodTagFilter, err := getTagFilterFromAPIModel(indicator[SloConfigAPIFieldGoodEventFilter])
+			if err != nil {
+				return nil, err
 			}
-			badEventFilterExp, validExp2, err2 := fiterExpFromAPIModel(indicator[SloConfigAPIFieldBadEventFilter])
-			if validExp2 {
-				return nil, err2
+			mappedTagFilter, err := tagfilter.MapTagFilterToNormalizedString(goodTagFilter)
+			if err != nil {
+				return nil, err
+			}
+
+			badTagFilter, err := getTagFilterFromAPIModel(indicator[SloConfigAPIFieldBadEventFilter])
+			if err != nil {
+				return nil, err
+			}
+			mappedBadTagFilter, err := tagfilter.MapTagFilterToNormalizedString(badTagFilter)
+			if err != nil {
+				return nil, err
 			}
 
 			result := map[string]interface{}{
 				"custom": []interface{}{
 					map[string]interface{}{
-						SloConfigFieldGoodEventFilterExpression: goodEventFilterExp,
-						SloConfigFieldBadEventFilterExpression:  badEventFilterExp,
+						SloConfigFieldGoodEventFilterExpression: mappedTagFilter,
+						SloConfigFieldBadEventFilterExpression:  mappedBadTagFilter,
 					},
 				},
 			}

--- a/instana/resource-slo-config.go
+++ b/instana/resource-slo-config.go
@@ -44,6 +44,23 @@ func fiterExpFromAPIModel(filter interface{}) (*tagfilter.FilterExpression, bool
 	return t, false, nil
 }
 
+// helper function to convert a map[string]interface{} from the API response to a *restapi.TagFilter
+func getTagFilterFromAPIModel(input interface{}) (*restapi.TagFilter, error) {
+	m, ok := input.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("failed to convert tag filter from API model: got %T", input)
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	var tagFilter restapi.TagFilter
+	if err := json.Unmarshal(b, &tagFilter); err != nil {
+		return nil, err
+	}
+	return &tagFilter, nil
+}
+
 func (r *sloConfigResource) mapTagFilterStringToAPIModel(input string) (*restapi.TagFilter, error) {
 	parser := tagfilter.NewParser()
 	expr, err := parser.Parse(input)

--- a/instana/tag-filter-schema.go
+++ b/instana/tag-filter-schema.go
@@ -34,6 +34,7 @@ var tagFilterValidateFunc = func(val interface{}, key string) (warns []string, e
 
 var OptionalTagFilterExpressionSchema = &schema.Schema{
 	Type:             schema.TypeString,
+	ForceNew:         true,
 	Optional:         true,
 	Description:      "The tag filter expression",
 	DiffSuppressFunc: tagFilterDiffSuppressFunc,
@@ -43,6 +44,7 @@ var OptionalTagFilterExpressionSchema = &schema.Schema{
 
 var RequiredTagFilterExpressionSchema = &schema.Schema{
 	Type:             schema.TypeString,
+	ForceNew:         true,
 	Required:         true,
 	Description:      "The tag filter expression",
 	DiffSuppressFunc: tagFilterDiffSuppressFunc,


### PR DESCRIPTION
This PR fixed the following problems:

- custom and traffic indicators were mixed up and couldn't be configured
- event_based_availability, time_based_availability and custom indicators always showed a drift / change with an unchanged configuration directly after creation
-  changing indicators after creation resulted in a HTTP 403 error since indicators can't be changed, now indicator changes result in a new SLO being created