### PR TITLE
Synthetic monitoring alert resource handle

### DIFF
--- a/docs/resources/synthetic_alert_config.md
+++ b/docs/resources/synthetic_alert_config.md
@@ -1,0 +1,118 @@
+# Synthetic Alert Configuration Resource
+
+This resource manages a synthetic alert configuration in Instana.
+
+API Documentation: <https://instana.github.io/openapi/#tag/Synthetic-Alert-Configuration>
+
+## Example Usage
+
+```hcl
+resource  "instana_synthetic_alert_config"  "example" {
+  name        = "Synthetic Test Failure Alert"
+  description = "Alert when synthetic tests fail"
+  
+  # Specific synthetic tests to monitor 
+  synthetic_test_ids = ["test-id-1", "test-id-2"]
+  
+  # Alert severity: 5 (critical) or 10 (warning)
+  severity = 5
+  
+  # tag filter to limit which synthetic tests are monitored
+  tag_filter = "synthetic.locationLabel@na EQUALS 'location'"
+  
+  # Rule configuration
+  rule {
+    alert_type  = "failure"
+    metric_name = "status"
+    aggregation = "SUM"
+  }
+  
+  # Alert channels to notify
+  alert_channel_ids = ["alert-channel-id-1", "alert-channel-id-2"]
+  
+  # Time threshold configuration
+  time_threshold {
+    type            = "violationsInSequence"
+    violations_count = 2
+  }
+  
+  # Grace period in milliseconds (optional)
+  grace_period = 300000
+  
+  # Custom payload fields for alert notifications
+  custom_payload_field {
+    key   = "key"
+    value = "value"
+  }
+  custom_payload_field {
+    key = "test2"
+    dynamic_value {
+      key = "dynamic-value-key"
+      tag_name = "dynamic-value-tag-name"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The name of the synthetic alert configuration.
+* `description` - (Required) A description of the synthetic alert configuration.
+* `synthetic_test_ids` - (Required) A list of synthetic test IDs to monitor. If not specified, all synthetic tests matching the tag filter will be monitored.
+* `severity` - (Optional) The severity of the alert. Must be either `5` (critical) or `10` (warning).
+* `tag_filter` - (Required) A tag filter expression to limit which synthetic tests are monitored.[Details](#tag-filter-argument-reference)
+* `rule` - (Required) The rule configuration block. Only one rule block is allowed.
+  * `alert_type` - (Required) The type of the alert rule. Currently only `failure` is supported.
+  * `metric_name` - (Required) The metric name to monitor (e.g., `status`).
+  * `aggregation` - (Optional) The aggregation method. Allowed avalues are `SUM`, `MEAN`, `MAX`, `MIN`, `P25`, `P50`, `P75`, `P90`, `P95`, `P98`, `P99`, `P99_9`, `P99_99`, `DISTINCT_COUNT`, `SUM_POSITIVE`, `PER_SECOND`, `INCREASE`.
+* `alert_channel_ids` - (Required) A list of alert channel IDs to notify when the alert is triggered.
+* `time_threshold` - (Required) The time threshold configuration block. Only one time threshold block is allowed.
+  * `type` - (Required) The type of the time threshold. Must be either `violationsInSequence` or `violationsInPeriod`.
+  * `violations_count` - (Optional) The number of violations required to trigger the alert.
+* `grace_period` - (Optional) The duration in milliseconds for which an alert remains open after conditions are no longer violated, with the alert auto-closing once the grace period expires.
+* `custom_payload_field` - (Optional) Custom payload fields to include in alert notifications. Multiple blocks can be specified.
+[Details](#custom-payload-field-argument-reference)
+
+
+### Custom Payload Field Argument Reference
+
+* `key` - Required - The key of the custom payload field
+* `value` - Optional - The static string value of the custom payload field. Either `value` or `dynamic_value` must be defined.
+* `dynamic_value` - Optional - The dynamic value of the custom payload field [Details](#dynamic-custom-payload-field-value).
+
+#### Dynamic Custom Payload Field Value
+* `key` - Optional - The key of the tag which should be added to the payload
+* `tag_name` - Required - The name of the tag which should be added to the payload
+
+
+### Tag Filter Argument Reference
+The **tag_filter** defines which entities should be included into the application. It supports:
+
+* logical AND and/or logical OR conjunctions whereas AND has higher precedence then OR
+* comparison operators EQUALS, NOT_EQUAL, CONTAINS | NOT_CONTAIN, STARTS_WITH, ENDS_WITH, NOT_STARTS_WITH, NOT_ENDS_WITH, GREATER_OR_EQUAL_THAN, LESS_OR_EQUAL_THAN, LESS_THAN, GREATER_THAN
+* unary operators IS_EMPTY, NOT_EMPTY, IS_BLANK, NOT_BLANK.
+
+The **tag_filter** is defined by the following eBNF:
+
+```plain
+tag_filter                := logical_or
+logical_or                := logical_and OR logical_or | logical_and
+logical_and               := primary_expression AND logical_and | primary_expression
+primary_expression        := comparison | unary_operator_expression
+comparison                := identifier comparison_operator value | identifier@entity_origin comparison_operator value | identifier:tag_key comparison_operator value | identifier:tag_key@entity_origin comparison_operator value
+comparison_operator       := EQUALS | NOT_EQUAL | CONTAINS | NOT_CONTAIN | STARTS_WITH | ENDS_WITH | NOT_STARTS_WITH | NOT_ENDS_WITH | GREATER_OR_EQUAL_THAN | LESS_OR_EQUAL_THAN | LESS_THAN | GREATER_THAN
+unary_operator_expression := identifier unary_operator | identifier@entity_origin unary_operator
+unary_operator            := IS_EMPTY | NOT_EMPTY | IS_BLANK | NOT_BLANK
+tag_key                   := identifier | string_value
+entity_origin             := src | dest | na
+value                     := string_value | number_value | boolean_value
+string_value              := "'" <string> "'"
+number_value              := (+-)?[0-9]+
+boolean_value             := TRUE | FALSE
+identifier                := [a-zA-Z_][\.a-zA-Z0-9_\-/]*
+```
+
+## Attribute Reference
+
+* `id` - The ID of the synthetic alert configuration.
+

--- a/instana/provider.go
+++ b/instana/provider.go
@@ -77,6 +77,7 @@ func providerResources() map[string]*schema.Resource {
 	bindResourceHandle(resources, NewGroupResourceHandle())
 	bindResourceHandle(resources, NewCustomDashboardResourceHandle())
 	bindResourceHandle(resources, NewSyntheticTestResourceHandle())
+	bindResourceHandle(resources, NewSyntheticAlertConfigResourceHandle())
 	bindResourceHandle(resources, NewAutomationActionResourceHandle())
 	bindResourceHandle(resources, NewAutomationPolicyResourceHandle())
 	return resources

--- a/instana/provider_test.go
+++ b/instana/provider_test.go
@@ -29,7 +29,7 @@ func TestProviderShouldContainValidSchemaDefinition(t *testing.T) {
 func TestProviderShouldContainValidResourceDefinitions(t *testing.T) {
 	config := Provider()
 
-	assert.Equal(t, 19, len(config.ResourcesMap))
+	assert.Equal(t, 20, len(config.ResourcesMap))
 
 	assert.NotNil(t, config.ResourcesMap[ResourceInstanaAPIToken])
 	assert.NotNil(t, config.ResourcesMap[ResourceInstanaApplicationConfig])
@@ -45,6 +45,7 @@ func TestProviderShouldContainValidResourceDefinitions(t *testing.T) {
 	assert.NotNil(t, config.ResourcesMap[ResourceInstanaGroup])
 	assert.NotNil(t, config.ResourcesMap[ResourceInstanaCustomDashboard])
 	assert.NotNil(t, config.ResourcesMap[ResourceInstanaSyntheticTest])
+	assert.NotNil(t, config.ResourcesMap[ResourceInstanaSyntheticAlertConfig])
 	assert.NotNil(t, config.ResourcesMap[ResourceInstanaCustomEventSpecification])
 	assert.NotNil(t, config.ResourcesMap[ResourceInstanaAlertingChannel])
 	assert.NotNil(t, config.ResourcesMap[ResourceInstanaAlertingConfig])

--- a/instana/resource-synthetic-alert-config.go
+++ b/instana/resource-synthetic-alert-config.go
@@ -1,0 +1,322 @@
+package instana
+
+import (
+	"context"
+
+	"github.com/gessnerfl/terraform-provider-instana/instana/restapi"
+	"github.com/gessnerfl/terraform-provider-instana/instana/tagfilter"
+	"github.com/gessnerfl/terraform-provider-instana/tfutils"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+// ResourceInstanaSyntheticAlertConfig the name of the terraform-provider-instana resource to manage synthetic alert configurations
+const ResourceInstanaSyntheticAlertConfig = "instana_synthetic_alert_config"
+
+const (
+	// SyntheticAlertConfigFieldName constant value for the schema field name
+	SyntheticAlertConfigFieldName = "name"
+	// SyntheticAlertConfigFieldName constant value for the schema field full name
+	SyntheticAlertConfigFieldFullName = "full_name"
+	// SyntheticAlertConfigFieldDescription constant value for the schema field description
+	SyntheticAlertConfigFieldDescription = "description"
+	// SyntheticAlertConfigFieldSyntheticTestIds constant value for the schema field synthetic_test_ids
+	SyntheticAlertConfigFieldSyntheticTestIds = "synthetic_test_ids"
+	// SyntheticAlertConfigFieldSeverity constant value for the schema field severity
+	SyntheticAlertConfigFieldSeverity = "severity"
+	// SyntheticAlertConfigFieldTagFilter constant value for the schema field tag_filter
+	SyntheticAlertConfigFieldTagFilter = "tag_filter"
+	// SyntheticAlertConfigFieldRule constant value for the schema field rule
+	SyntheticAlertConfigFieldRule = "rule"
+	// SyntheticAlertConfigFieldAlertChannelIds constant value for the schema field alert_channel_ids
+	SyntheticAlertConfigFieldAlertChannelIds = "alert_channel_ids"
+	// SyntheticAlertConfigFieldTimeThreshold constant value for the schema field time_threshold
+	SyntheticAlertConfigFieldTimeThreshold = "time_threshold"
+	// SyntheticAlertConfigFieldGracePeriod constant value for the schema field grace_period
+	SyntheticAlertConfigFieldGracePeriod = "grace_period"
+
+	// Rule fields
+	SyntheticAlertRuleFieldAlertType   = "alert_type"
+	SyntheticAlertRuleFieldMetricName  = "metric_name"
+	SyntheticAlertRuleFieldAggregation = "aggregation"
+
+	// TimeThreshold fields
+	SyntheticAlertTimeThresholdFieldType            = "type"
+	SyntheticAlertTimeThresholdFieldViolationsCount = "violations_count"
+)
+
+// SyntheticAlertConfigSchemaName schema field definition of instana_synthetic_alert_config field name
+var SyntheticAlertConfigSchemaName = &schema.Schema{
+	Type:         schema.TypeString,
+	Required:     true,
+	Description:  "Configures the name of the synthetic alert configuration",
+	ValidateFunc: validation.StringLenBetween(1, 256),
+}
+
+// SyntheticAlertConfigSchemaDescription schema field definition of instana_synthetic_alert_config field description
+var SyntheticAlertConfigSchemaDescription = &schema.Schema{
+	Type:         schema.TypeString,
+	Required:     true,
+	Description:  "Configures the description of the synthetic alert configuration",
+	ValidateFunc: validation.StringLenBetween(0, 1024),
+}
+
+// SyntheticAlertConfigSchemaSyntheticTestIds schema field definition of instana_synthetic_alert_config field synthetic_test_ids
+var SyntheticAlertConfigSchemaSyntheticTestIds = &schema.Schema{
+	Type:     schema.TypeSet,
+	MinItems: 0,
+	MaxItems: 1024,
+	Elem: &schema.Schema{
+		Type: schema.TypeString,
+	},
+	Required:    true,
+	Description: "Configures the list of Synthetic Test IDs to monitor.",
+}
+
+// SyntheticAlertConfigSchemaSeverity schema field definition of instana_synthetic_alert_config field severity
+var SyntheticAlertConfigSchemaSeverity = &schema.Schema{
+	Type:         schema.TypeInt,
+	Optional:     true,
+	Description:  "Configures the severity of the alert (5=critical, 10=warning)",
+	ValidateFunc: validation.IntInSlice([]int{5, 10}),
+}
+
+// SyntheticAlertConfigSchemaAlertChannelIds schema field definition of instana_synthetic_alert_config field alert_channel_ids
+var SyntheticAlertConfigSchemaAlertChannelIds = &schema.Schema{
+	Type:     schema.TypeSet,
+	MinItems: 0,
+	MaxItems: 1024,
+	Elem: &schema.Schema{
+		Type: schema.TypeString,
+	},
+	Required:    true,
+	Description: "Configures the list of Alert Channel IDs.",
+}
+
+// SyntheticAlertConfigSchemaGracePeriod schema field definition of instana_synthetic_alert_config field grace_period
+var SyntheticAlertConfigSchemaGracePeriod = &schema.Schema{
+	Type:        schema.TypeInt,
+	Optional:    true,
+	Description: "The duration in milliseconds for which an alert remains open after conditions are no longer violated, with the alert auto-closing once the grace period expires",
+}
+
+// SyntheticAlertConfigSchemaRule schema field definition of instana_synthetic_alert_config field rule
+var SyntheticAlertConfigSchemaRule = &schema.Schema{
+	Type:        schema.TypeList,
+	Required:    true,
+	MaxItems:    1,
+	Description: "Configures the rule for the synthetic alert",
+	Elem: &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			SyntheticAlertRuleFieldAlertType: {
+				Type:         schema.TypeString,
+				Required:     true,
+				Description:  "The type of the alert rule (e.g., failure)",
+				ValidateFunc: validation.StringInSlice([]string{"failure"}, false),
+			},
+			SyntheticAlertRuleFieldMetricName: {
+				Type:         schema.TypeString,
+				Required:     true,
+				Description:  "The metric name to monitor (e.g., status)",
+				ValidateFunc: validation.StringLenBetween(1, 256),
+			},
+			SyntheticAlertRuleFieldAggregation: {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "The aggregation method {SUM,MEAN,MAX,MIN,P25,P50,P75,P90,P95,P98,P99,P99_9,P99_99,DISTINCT_COUNT,SUM_POSITIVE,PER_SECOND,INCREASE}",
+				ValidateFunc: validation.StringInSlice([]string{"SUM", "MEAN", "MAX", "MIN", "P25", "P50", "P75", "P90", "P95", "P98", "P99", "P99_9", "P99_99", "DISTINCT_COUNT", "SUM_POSITIVE", "PER_SECOND", "INCREASE"}, false),
+			},
+		},
+	},
+}
+
+// SyntheticAlertConfigSchemaTimeThreshold schema field definition of instana_synthetic_alert_config field time_threshold
+var SyntheticAlertConfigSchemaTimeThreshold = &schema.Schema{
+	Type:        schema.TypeList,
+	Required:    true,
+	MaxItems:    1,
+	Description: "Configures the time threshold for the synthetic alert",
+	Elem: &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			SyntheticAlertTimeThresholdFieldType: {
+				Type:         schema.TypeString,
+				Required:     true,
+				Description:  "The type of the time threshold (only violationsInSequence is supported)",
+				ValidateFunc: validation.StringInSlice([]string{"violationsInSequence"}, false),
+			},
+			SyntheticAlertTimeThresholdFieldViolationsCount: {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Description:  "The number of violations required to trigger the alert (value between 1 and 12)",
+				ValidateFunc: validation.IntBetween(1, 12),
+			},
+		},
+	},
+}
+
+// NewSyntheticAlertConfigResourceHandle creates the resource handle for Synthetic Alert Configuration
+func NewSyntheticAlertConfigResourceHandle() ResourceHandle[*restapi.SyntheticAlertConfig] {
+	return &syntheticAlertConfigResource{
+		metaData: ResourceMetaData{
+			ResourceName: ResourceInstanaSyntheticAlertConfig,
+			Schema: map[string]*schema.Schema{
+				SyntheticAlertConfigFieldName:             SyntheticAlertConfigSchemaName,
+				SyntheticAlertConfigFieldDescription:      SyntheticAlertConfigSchemaDescription,
+				SyntheticAlertConfigFieldSyntheticTestIds: SyntheticAlertConfigSchemaSyntheticTestIds,
+				SyntheticAlertConfigFieldSeverity:         SyntheticAlertConfigSchemaSeverity,
+				SyntheticAlertConfigFieldTagFilter:        OptionalTagFilterExpressionSchema,
+				SyntheticAlertConfigFieldRule:             SyntheticAlertConfigSchemaRule,
+				SyntheticAlertConfigFieldAlertChannelIds:  SyntheticAlertConfigSchemaAlertChannelIds,
+				SyntheticAlertConfigFieldTimeThreshold:    SyntheticAlertConfigSchemaTimeThreshold,
+				SyntheticAlertConfigFieldGracePeriod:      SyntheticAlertConfigSchemaGracePeriod,
+				DefaultCustomPayloadFieldsName:            buildStaticStringCustomPayloadFields(),
+			},
+			SchemaVersion: 1,
+		},
+	}
+}
+
+type syntheticAlertConfigResource struct {
+	metaData ResourceMetaData
+}
+
+func (r *syntheticAlertConfigResource) MetaData() *ResourceMetaData {
+	return &r.metaData
+}
+
+func (r *syntheticAlertConfigResource) stateUpgradeV0(_ context.Context, state map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
+	// Handle field name changes
+	if _, ok := state[SyntheticAlertConfigFieldFullName]; ok {
+		state[SyntheticAlertConfigFieldName] = state[SyntheticAlertConfigFieldFullName]
+		delete(state, SyntheticAlertConfigFieldFullName)
+	}
+	return state, nil
+}
+
+func (r *syntheticAlertConfigResource) StateUpgraders() []schema.StateUpgrader {
+	return []schema.StateUpgrader{
+		{
+			Type:    r.schemaV0().CoreConfigSchema().ImpliedType(),
+			Upgrade: r.stateUpgradeV0,
+			Version: 0,
+		},
+	}
+}
+
+func (r *syntheticAlertConfigResource) GetRestResource(api restapi.InstanaAPI) restapi.RestResource[*restapi.SyntheticAlertConfig] {
+	return api.SyntheticAlertConfigs()
+}
+
+func (r *syntheticAlertConfigResource) SetComputedFields(_ *schema.ResourceData) error {
+	return nil
+}
+
+func (r *syntheticAlertConfigResource) UpdateState(d *schema.ResourceData, config *restapi.SyntheticAlertConfig) error {
+	d.SetId(config.ID)
+
+	var normalizedTagFilterString *string
+	var err error
+	if config.TagFilterExpression != nil {
+		normalizedTagFilterString, err = tagfilter.MapTagFilterToNormalizedString(config.TagFilterExpression)
+		if err != nil {
+			return err
+		}
+	}
+
+	return tfutils.UpdateState(d, map[string]interface{}{
+		SyntheticAlertConfigFieldName:             config.Name,
+		SyntheticAlertConfigFieldDescription:      config.Description,
+		SyntheticAlertConfigFieldSyntheticTestIds: config.SyntheticTestIds,
+		SyntheticAlertConfigFieldSeverity:         config.Severity,
+		SyntheticAlertConfigFieldTagFilter:        normalizedTagFilterString,
+		SyntheticAlertConfigFieldRule: []interface{}{
+			map[string]interface{}{
+				SyntheticAlertRuleFieldAlertType:   config.Rule.AlertType,
+				SyntheticAlertRuleFieldMetricName:  config.Rule.MetricName,
+				SyntheticAlertRuleFieldAggregation: config.Rule.Aggregation,
+			},
+		},
+		SyntheticAlertConfigFieldAlertChannelIds: config.AlertChannelIds,
+		SyntheticAlertConfigFieldTimeThreshold: []interface{}{
+			map[string]interface{}{
+				SyntheticAlertTimeThresholdFieldType:            config.TimeThreshold.Type,
+				SyntheticAlertTimeThresholdFieldViolationsCount: config.TimeThreshold.ViolationsCount,
+			},
+		},
+		SyntheticAlertConfigFieldGracePeriod: config.GracePeriod,
+		DefaultCustomPayloadFieldsName:       mapCustomPayloadFieldsToSchema(config),
+	})
+}
+
+func (r *syntheticAlertConfigResource) MapStateToDataObject(d *schema.ResourceData) (*restapi.SyntheticAlertConfig, error) {
+	customPayloadFields, err := mapDefaultCustomPayloadFieldsFromSchema(d)
+	if err != nil {
+		return &restapi.SyntheticAlertConfig{}, err
+	}
+
+	rule := d.Get(SyntheticAlertConfigFieldRule).([]interface{})[0].(map[string]interface{})
+	timeThreshold := d.Get(SyntheticAlertConfigFieldTimeThreshold).([]interface{})[0].(map[string]interface{})
+
+	var tagFilter *restapi.TagFilter
+	tagFilterStr, ok := d.GetOk(SyntheticAlertConfigFieldTagFilter)
+	if ok {
+		tagFilter, err = mapTagFilterExpressionFromSchema(tagFilterStr.(string))
+		if err != nil {
+			return &restapi.SyntheticAlertConfig{}, err
+		}
+	}
+
+	var gracePeriod int64
+	if val, ok := d.GetOk(SyntheticAlertConfigFieldGracePeriod); ok {
+		gracePeriod = int64(val.(int))
+	}
+
+	return &restapi.SyntheticAlertConfig{
+		ID:                  d.Id(),
+		Name:                d.Get(SyntheticAlertConfigFieldName).(string),
+		Description:         d.Get(SyntheticAlertConfigFieldDescription).(string),
+		SyntheticTestIds:    ReadStringSetParameterFromResource(d, SyntheticAlertConfigFieldSyntheticTestIds),
+		Severity:            d.Get(SyntheticAlertConfigFieldSeverity).(int),
+		TagFilterExpression: tagFilter,
+		Rule: restapi.SyntheticAlertRule{
+			AlertType:   rule[SyntheticAlertRuleFieldAlertType].(string),
+			MetricName:  rule[SyntheticAlertRuleFieldMetricName].(string),
+			Aggregation: rule[SyntheticAlertRuleFieldAggregation].(string),
+		},
+		AlertChannelIds: ReadStringSetParameterFromResource(d, SyntheticAlertConfigFieldAlertChannelIds),
+		TimeThreshold: restapi.SyntheticAlertTimeThreshold{
+			Type:            timeThreshold[SyntheticAlertTimeThresholdFieldType].(string),
+			ViolationsCount: timeThreshold[SyntheticAlertTimeThresholdFieldViolationsCount].(int),
+		},
+		GracePeriod:           gracePeriod,
+		CustomerPayloadFields: customPayloadFields,
+	}, nil
+}
+
+func mapTagFilterExpressionFromSchema(input string) (*restapi.TagFilter, error) {
+	parser := tagfilter.NewParser()
+	expr, err := parser.Parse(input)
+	if err != nil {
+		return nil, err
+	}
+
+	mapper := tagfilter.NewMapper()
+	return mapper.ToAPIModel(expr), nil
+}
+
+func (r *syntheticAlertConfigResource) schemaV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			SyntheticAlertConfigFieldName:             SyntheticAlertConfigSchemaName,
+			SyntheticAlertConfigFieldDescription:      SyntheticAlertConfigSchemaDescription,
+			SyntheticAlertConfigFieldSyntheticTestIds: SyntheticAlertConfigSchemaSyntheticTestIds,
+			SyntheticAlertConfigFieldSeverity:         SyntheticAlertConfigSchemaSeverity,
+			SyntheticAlertConfigFieldTagFilter:        OptionalTagFilterExpressionSchema,
+			SyntheticAlertConfigFieldRule:             SyntheticAlertConfigSchemaRule,
+			SyntheticAlertConfigFieldAlertChannelIds:  SyntheticAlertConfigSchemaAlertChannelIds,
+			SyntheticAlertConfigFieldTimeThreshold:    SyntheticAlertConfigSchemaTimeThreshold,
+			SyntheticAlertConfigFieldGracePeriod:      SyntheticAlertConfigSchemaGracePeriod,
+			DefaultCustomPayloadFieldsName:            buildStaticStringCustomPayloadFields(),
+		},
+	}
+}

--- a/instana/resource-synthetic-alert-config_test.go
+++ b/instana/resource-synthetic-alert-config_test.go
@@ -1,0 +1,414 @@
+package instana_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/require"
+
+	. "github.com/gessnerfl/terraform-provider-instana/instana"
+	"github.com/gessnerfl/terraform-provider-instana/instana/restapi"
+	"github.com/gessnerfl/terraform-provider-instana/testutils"
+)
+
+func TestSyntheticAlertConfig(t *testing.T) {
+	terraformResourceInstanceName := ResourceInstanaSyntheticAlertConfig + ".example"
+	inst := &syntheticAlertConfigTest{
+		terraformResourceInstanceName: terraformResourceInstanceName,
+		resourceHandle:                NewSyntheticAlertConfigResourceHandle(),
+	}
+	inst.run(t)
+}
+
+type syntheticAlertConfigTest struct {
+	terraformResourceInstanceName string
+	resourceHandle                ResourceHandle[*restapi.SyntheticAlertConfig]
+}
+
+var syntheticAlertConfigTerraformTemplate = `
+resource "instana_synthetic_alert_config" "example" {
+	name = "name %d"
+	description = "description %d"
+	synthetic_test_ids = [ "test-1", "test-2" ]
+	severity = 5
+	tag_filter = "synthetic.testId@na EQUALS 'test-1'"
+	rule {
+		alert_type = "failure"
+		metric_name = "status"
+		aggregation = "SUM"
+	}
+	alert_channel_ids = [ "channel-1", "channel-2" ]
+	time_threshold {
+		type = "violationsInSequence"
+		violations_count = 2
+	}
+
+	custom_payload_field {
+		key    = "static-key"
+		value  = "static-value"
+	}
+}
+`
+
+var syntheticAlertConfigServerResponseTemplate = `
+{
+	"id" : "%s",
+	"name" : "name %d",
+	"description" : "description %d",
+	"syntheticTestIds" : [ "test-2", "test-1" ],
+	"severity" : 5,
+	"tagFilterExpression" : {
+		"type": "TAG_FILTER",
+		"name": "synthetic.testId",
+		"stringValue": "test-1",
+		"operator": "EQUALS",
+		"entity": "NOT_APPLICABLE"
+	},
+	"rule" : {
+		"alertType" : "failure",
+		"metricName" : "status",
+		"aggregation" : "SUM"
+	},
+	"alertChannelIds" : [ "channel-2", "channel-1" ],
+	"timeThreshold" : {
+		"type" : "violationsInSequence",
+		"violationsCount" : 2
+	},
+	   "customPayloadFields": [
+		{
+			"type": "staticString",
+			"key": "static-key",
+			"value": "static-value"
+      	}
+	]
+}
+`
+
+func (test *syntheticAlertConfigTest) run(t *testing.T) {
+	t.Run("CRUD integration test", test.createIntegrationTest())
+	t.Run("schema should be valid", test.resourceSchemaShouldBeValid)
+	t.Run("should return correct schema name", test.shouldReturnCorrectResourceNameForSyntheticAlertConfig)
+	t.Run("should have schema version one", test.shouldHaveSchemaVersionOne)
+	t.Run("should have one state upgrader for version zero", test.shouldHaveOneStateUpgraderForVersionZero)
+	t.Run("should update resource state", test.shouldUpdateResourceState)
+	t.Run("should convert state to data model", test.shouldConvertStateToDataModel)
+	t.Run("should migrate full_name to name when executing state upgrader and full_name is available", test.shouldMigrateFullNameToNameWhenExecutingStateUpgraderAndFullNameIsAvailable)
+	t.Run("should do nothing when executing state upgrader and full_name is not available", test.shouldDoNothingWhenExecutingStateUpgraderAndFullNameIsNotAvailable)
+}
+
+func (test *syntheticAlertConfigTest) createIntegrationTest() func(t *testing.T) {
+	return func(t *testing.T) {
+		id := RandomID()
+		resourceRestAPIPath := restapi.SyntheticAlertConfigsResourcePath
+		resourceInstanceRestAPIPath := resourceRestAPIPath + "/{internal-id}"
+
+		httpServer := testutils.NewTestHTTPServer()
+		httpServer.AddRoute(http.MethodPost, resourceRestAPIPath, func(w http.ResponseWriter, r *http.Request) {
+			config := &restapi.SyntheticAlertConfig{}
+			err := json.NewDecoder(r.Body).Decode(config)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				err = r.Write(bytes.NewBufferString("Failed to get request"))
+				if err != nil {
+					fmt.Printf("failed to write response; %s\n", err)
+				}
+			} else {
+				config.ID = id
+				w.Header().Set("Content-Type", r.Header.Get("Content-Type"))
+				w.WriteHeader(http.StatusOK)
+				err = json.NewEncoder(w).Encode(config)
+				if err != nil {
+					fmt.Printf("failed to encode json; %s\n", err)
+				}
+			}
+		})
+		httpServer.AddRoute(http.MethodPost, resourceInstanceRestAPIPath, func(w http.ResponseWriter, r *http.Request) {
+			testutils.EchoHandlerFunc(w, r)
+		})
+		httpServer.AddRoute(http.MethodDelete, resourceInstanceRestAPIPath, testutils.EchoHandlerFunc)
+		httpServer.AddRoute(http.MethodGet, resourceInstanceRestAPIPath, func(w http.ResponseWriter, r *http.Request) {
+			modCount := httpServer.GetCallCount(http.MethodPost, resourceRestAPIPath+"/"+id)
+			jsonData := fmt.Sprintf(syntheticAlertConfigServerResponseTemplate, id, modCount, modCount)
+			w.Header().Set(contentType, r.Header.Get(contentType))
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte(jsonData))
+			if err != nil {
+				fmt.Printf("failed to write response; %s\n", err)
+			}
+		})
+		httpServer.Start()
+		defer httpServer.Close()
+
+		resource.UnitTest(t, resource.TestCase{
+			ProviderFactories: testProviderFactory,
+			Steps: []resource.TestStep{
+				test.createIntegrationTestStep(httpServer.GetPort(), 0, id),
+				testStepImportWithCustomID(test.terraformResourceInstanceName, id),
+				test.createIntegrationTestStep(httpServer.GetPort(), 1, id),
+				testStepImportWithCustomID(test.terraformResourceInstanceName, id),
+			},
+		})
+	}
+}
+
+func (test *syntheticAlertConfigTest) createIntegrationTestStep(httpPort int, iteration int, id string) resource.TestStep {
+	return resource.TestStep{
+		Config: appendProviderConfig(fmt.Sprintf(syntheticAlertConfigTerraformTemplate, iteration, iteration), httpPort),
+		Check: resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, "id", id),
+			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, SyntheticAlertConfigFieldName, fmt.Sprintf("name %d", iteration)),
+			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, SyntheticAlertConfigFieldDescription, fmt.Sprintf("description %d", iteration)),
+			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, fmt.Sprintf("%s.#", SyntheticAlertConfigFieldSyntheticTestIds), "2"),
+			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, SyntheticAlertConfigFieldSeverity, "5"),
+			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, SyntheticAlertConfigFieldTagFilter, "synthetic.testId@na EQUALS 'test-1'"),
+			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, fmt.Sprintf("%s.0.%s", SyntheticAlertConfigFieldRule, SyntheticAlertRuleFieldAlertType), "failure"),
+			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, fmt.Sprintf("%s.0.%s", SyntheticAlertConfigFieldRule, SyntheticAlertRuleFieldMetricName), "status"),
+			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, fmt.Sprintf("%s.0.%s", SyntheticAlertConfigFieldRule, SyntheticAlertRuleFieldAggregation), "SUM"),
+			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, fmt.Sprintf("%s.#", SyntheticAlertConfigFieldAlertChannelIds), "2"),
+			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, fmt.Sprintf("%s.0.%s", SyntheticAlertConfigFieldTimeThreshold, SyntheticAlertTimeThresholdFieldType), "violationsInSequence"),
+			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, fmt.Sprintf("%s.0.%s", SyntheticAlertConfigFieldTimeThreshold, SyntheticAlertTimeThresholdFieldViolationsCount), "2"),
+			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, fmt.Sprintf("%s.0.%s", DefaultCustomPayloadFieldsName, CustomPayloadFieldsFieldKey), "static-key"),
+			resource.TestCheckResourceAttr(test.terraformResourceInstanceName, fmt.Sprintf("%s.0.%s", DefaultCustomPayloadFieldsName, CustomPayloadFieldsFieldStaticStringValue), "static-value"),
+		),
+	}
+}
+
+func (test *syntheticAlertConfigTest) resourceSchemaShouldBeValid(t *testing.T) {
+	resourceHandle := NewSyntheticAlertConfigResourceHandle()
+	schemaMap := resourceHandle.MetaData().Schema
+
+	// Verify required fields
+	require.Equal(t, schema.TypeString, schemaMap[SyntheticAlertConfigFieldName].Type)
+	require.True(t, schemaMap[SyntheticAlertConfigFieldName].Required)
+
+	require.Equal(t, schema.TypeString, schemaMap[SyntheticAlertConfigFieldDescription].Type)
+	require.True(t, schemaMap[SyntheticAlertConfigFieldDescription].Required)
+
+	require.Equal(t, schema.TypeSet, schemaMap[SyntheticAlertConfigFieldSyntheticTestIds].Type)
+	require.True(t, schemaMap[SyntheticAlertConfigFieldSyntheticTestIds].Required)
+
+	require.Equal(t, schema.TypeInt, schemaMap[SyntheticAlertConfigFieldSeverity].Type)
+	require.True(t, schemaMap[SyntheticAlertConfigFieldSeverity].Optional)
+
+	require.Equal(t, schema.TypeString, schemaMap[SyntheticAlertConfigFieldTagFilter].Type)
+	require.True(t, schemaMap[SyntheticAlertConfigFieldTagFilter].Optional)
+
+	require.Equal(t, schema.TypeList, schemaMap[SyntheticAlertConfigFieldRule].Type)
+	require.True(t, schemaMap[SyntheticAlertConfigFieldRule].Required)
+
+	require.Equal(t, schema.TypeSet, schemaMap[SyntheticAlertConfigFieldAlertChannelIds].Type)
+	require.True(t, schemaMap[SyntheticAlertConfigFieldAlertChannelIds].Required)
+
+	require.Equal(t, schema.TypeList, schemaMap[SyntheticAlertConfigFieldTimeThreshold].Type)
+	require.True(t, schemaMap[SyntheticAlertConfigFieldTimeThreshold].Required)
+}
+
+func (test *syntheticAlertConfigTest) shouldReturnCorrectResourceNameForSyntheticAlertConfig(t *testing.T) {
+	name := NewSyntheticAlertConfigResourceHandle().MetaData().ResourceName
+
+	require.Equal(t, "instana_synthetic_alert_config", name, "Expected resource name to be instana_synthetic_alert_config")
+}
+
+func (test *syntheticAlertConfigTest) shouldHaveSchemaVersionOne(t *testing.T) {
+	require.Equal(t, 1, NewSyntheticAlertConfigResourceHandle().MetaData().SchemaVersion)
+}
+
+func (test *syntheticAlertConfigTest) shouldHaveOneStateUpgraderForVersionZero(t *testing.T) {
+	resourceHandler := NewSyntheticAlertConfigResourceHandle()
+
+	require.Equal(t, 1, len(resourceHandler.StateUpgraders()))
+	require.Equal(t, 0, resourceHandler.StateUpgraders()[0].Version)
+}
+
+func (test *syntheticAlertConfigTest) shouldMigrateFullNameToNameWhenExecutingStateUpgraderAndFullNameIsAvailable(t *testing.T) {
+	input := map[string]interface{}{
+		SyntheticAlertConfigFieldFullName: "test",
+	}
+	result, err := NewSyntheticAlertConfigResourceHandle().StateUpgraders()[0].Upgrade(nil, input, nil)
+
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	require.NotContains(t, result, SyntheticAlertConfigFieldFullName)
+	require.Contains(t, result, SyntheticAlertConfigFieldName)
+	require.Equal(t, "test", result[SyntheticAlertConfigFieldName])
+}
+
+func (test *syntheticAlertConfigTest) shouldDoNothingWhenExecutingStateUpgraderAndFullNameIsNotAvailable(t *testing.T) {
+	input := map[string]interface{}{
+		SyntheticAlertConfigFieldName: "test",
+	}
+	result, err := NewSyntheticAlertConfigResourceHandle().StateUpgraders()[0].Upgrade(nil, input, nil)
+
+	require.NoError(t, err)
+	require.Equal(t, input, result)
+}
+
+const (
+	syntheticAlertConfigID          = "synthetic-alert-id"
+	syntheticAlertConfigName        = "synthetic-alert-name"
+	syntheticAlertConfigDescription = "synthetic-alert-description"
+	syntheticAlertConfigTestId1     = "synthetic-test-id1"
+	syntheticAlertConfigTestId2     = "synthetic-test-id2"
+	syntheticAlertConfigChannelId1  = "synthetic-channel-id1"
+	syntheticAlertConfigChannelId2  = "synthetic-channel-id2"
+	syntheticAlertConfigTagFilter   = "synthetic.testId@na EQUALS 'test-1'"
+)
+
+func (test *syntheticAlertConfigTest) shouldUpdateResourceState(t *testing.T) {
+	testHelper := NewTestHelper[*restapi.SyntheticAlertConfig](t)
+	resourceHandle := NewSyntheticAlertConfigResourceHandle()
+	resourceData := testHelper.CreateEmptyResourceDataForResourceHandle(resourceHandle)
+
+	data := restapi.SyntheticAlertConfig{
+		ID:               syntheticAlertConfigID,
+		Name:             syntheticAlertConfigName,
+		Description:      syntheticAlertConfigDescription,
+		SyntheticTestIds: []string{syntheticAlertConfigTestId1, syntheticAlertConfigTestId2},
+		Severity:         5,
+		TagFilterExpression: &restapi.TagFilter{
+			Type:        restapi.TagFilterType,
+			Name:        stringPtr("synthetic.testId"),
+			StringValue: stringPtr("test-1"),
+			Operator:    expressionOperatorPtr(restapi.EqualsOperator),
+			Entity:      tagFilterEntityPtr(restapi.TagFilterEntityNotApplicable),
+		},
+		Rule: restapi.SyntheticAlertRule{
+			AlertType:   "failure",
+			MetricName:  "status",
+			Aggregation: "SUM",
+		},
+		AlertChannelIds: []string{syntheticAlertConfigChannelId1, syntheticAlertConfigChannelId2},
+		TimeThreshold: restapi.SyntheticAlertTimeThreshold{
+			Type:            "violationsInSequence",
+			ViolationsCount: 2,
+		},
+		CustomerPayloadFields: []restapi.CustomPayloadField[any]{
+			{
+				Type:  restapi.StaticStringCustomPayloadType,
+				Key:   "static-key-1",
+				Value: restapi.StaticStringCustomPayloadFieldValue("static-value-1"),
+			},
+			{
+				Type:  restapi.StaticStringCustomPayloadType,
+				Key:   "static-key-2",
+				Value: restapi.StaticStringCustomPayloadFieldValue("static-value-2"),
+			},
+		},
+	}
+
+	err := resourceHandle.UpdateState(resourceData, &data)
+
+	require.Nil(t, err)
+	require.Equal(t, syntheticAlertConfigID, resourceData.Id())
+	require.Equal(t, syntheticAlertConfigName, resourceData.Get(SyntheticAlertConfigFieldName))
+	require.Equal(t, syntheticAlertConfigDescription, resourceData.Get(SyntheticAlertConfigFieldDescription))
+	require.Equal(t, 5, resourceData.Get(SyntheticAlertConfigFieldSeverity))
+	require.Equal(t, syntheticAlertConfigTagFilter, resourceData.Get(SyntheticAlertConfigFieldTagFilter))
+
+	// Check synthetic test IDs
+	syntheticTestIds := resourceData.Get(SyntheticAlertConfigFieldSyntheticTestIds).(*schema.Set)
+	require.Equal(t, 2, syntheticTestIds.Len())
+	for _, v := range []string{syntheticAlertConfigTestId1, syntheticAlertConfigTestId2} {
+		require.Contains(t, syntheticTestIds.List(), v)
+	}
+
+	// Check alert channel IDs
+	alertChannelIds := resourceData.Get(SyntheticAlertConfigFieldAlertChannelIds).(*schema.Set)
+	require.Equal(t, 2, alertChannelIds.Len())
+	for _, v := range []string{syntheticAlertConfigChannelId1, syntheticAlertConfigChannelId2} {
+		require.Contains(t, alertChannelIds.List(), v)
+	}
+
+	// Check custom payload fields
+	fields := resourceData.Get(DefaultCustomPayloadFieldsName)
+	require.NotNil(t, fields)
+	require.IsType(t, &schema.Set{}, fields)
+	fieldList := fields.(*schema.Set).List()
+	require.Len(t, fieldList, 2)
+}
+
+func (test *syntheticAlertConfigTest) shouldConvertStateToDataModel(t *testing.T) {
+	testHelper := NewTestHelper[*restapi.SyntheticAlertConfig](t)
+	resourceHandle := NewSyntheticAlertConfigResourceHandle()
+	resourceData := testHelper.CreateEmptyResourceDataForResourceHandle(resourceHandle)
+	resourceData.SetId(syntheticAlertConfigID)
+
+	testIds := []string{syntheticAlertConfigTestId1, syntheticAlertConfigTestId2}
+	channelIds := []string{syntheticAlertConfigChannelId1, syntheticAlertConfigChannelId2}
+
+	setValueOnResourceData(t, resourceData, SyntheticAlertConfigFieldName, syntheticAlertConfigName)
+	setValueOnResourceData(t, resourceData, SyntheticAlertConfigFieldDescription, syntheticAlertConfigDescription)
+	setValueOnResourceData(t, resourceData, SyntheticAlertConfigFieldSyntheticTestIds, testIds)
+	setValueOnResourceData(t, resourceData, SyntheticAlertConfigFieldSeverity, 5)
+	setValueOnResourceData(t, resourceData, SyntheticAlertConfigFieldTagFilter, syntheticAlertConfigTagFilter)
+	setValueOnResourceData(t, resourceData, SyntheticAlertConfigFieldRule, []interface{}{
+		map[string]interface{}{
+			SyntheticAlertRuleFieldAlertType:   "failure",
+			SyntheticAlertRuleFieldMetricName:  "status",
+			SyntheticAlertRuleFieldAggregation: "SUM",
+		},
+	})
+	setValueOnResourceData(t, resourceData, SyntheticAlertConfigFieldAlertChannelIds, channelIds)
+	setValueOnResourceData(t, resourceData, SyntheticAlertConfigFieldTimeThreshold, []interface{}{
+		map[string]interface{}{
+			SyntheticAlertTimeThresholdFieldType:            "violationsInSequence",
+			SyntheticAlertTimeThresholdFieldViolationsCount: 2,
+		},
+	})
+	setValueOnResourceData(t, resourceData, DefaultCustomPayloadFieldsName, []interface{}{
+		map[string]interface{}{
+			CustomPayloadFieldsFieldKey:               "static-key-1",
+			CustomPayloadFieldsFieldStaticStringValue: "static-value-1",
+		},
+		map[string]interface{}{
+			CustomPayloadFieldsFieldKey:               "static-key-2",
+			CustomPayloadFieldsFieldStaticStringValue: "static-value-2",
+		},
+	})
+
+	model, err := resourceHandle.MapStateToDataObject(resourceData)
+
+	require.Nil(t, err)
+	require.IsType(t, &restapi.SyntheticAlertConfig{}, model)
+	require.Equal(t, syntheticAlertConfigID, model.GetIDForResourcePath())
+	require.Equal(t, syntheticAlertConfigName, model.Name)
+	require.Equal(t, syntheticAlertConfigDescription, model.Description)
+	require.Equal(t, 5, model.Severity)
+	require.Equal(t, "failure", model.Rule.AlertType)
+	require.Equal(t, "status", model.Rule.MetricName)
+	require.Equal(t, "SUM", model.Rule.Aggregation)
+	require.Equal(t, "violationsInSequence", model.TimeThreshold.Type)
+	require.Equal(t, 2, model.TimeThreshold.ViolationsCount)
+
+	// Check synthetic test IDs
+	require.Equal(t, 2, len(model.SyntheticTestIds))
+	for _, v := range testIds {
+		require.Contains(t, model.SyntheticTestIds, v)
+	}
+
+	// Check alert channel IDs
+	require.Equal(t, 2, len(model.AlertChannelIds))
+	for _, v := range channelIds {
+		require.Contains(t, model.AlertChannelIds, v)
+	}
+
+	// Check custom payload fields
+	require.Equal(t, 2, len(model.CustomerPayloadFields))
+}
+
+func stringPtr(s string) *string {
+	return &s
+}
+
+func expressionOperatorPtr(op restapi.ExpressionOperator) *restapi.ExpressionOperator {
+	return &op
+}
+
+func tagFilterEntityPtr(entity restapi.TagFilterEntity) *restapi.TagFilterEntity {
+	return &entity
+}

--- a/instana/restapi/Instana-api.go
+++ b/instana/restapi/Instana-api.go
@@ -48,6 +48,7 @@ type InstanaAPI interface {
 	CustomDashboards() RestResource[*CustomDashboard]
 	SyntheticTest() RestResource[*SyntheticTest]
 	SyntheticLocation() ReadOnlyRestResource[*SyntheticLocation]
+	SyntheticAlertConfigs() RestResource[*SyntheticAlertConfig]
 	AutomationActions() RestResource[*AutomationAction]
 	AutomationPolicies() RestResource[*AutomationPolicy]
 	HostAgents() ReadOnlyRestResource[*HostAgent]
@@ -146,6 +147,11 @@ func (api *baseInstanaAPI) SyntheticTest() RestResource[*SyntheticTest] {
 // SyntheticLocation implementation of InstanaAPI interface
 func (api *baseInstanaAPI) SyntheticLocation() ReadOnlyRestResource[*SyntheticLocation] {
 	return NewReadOnlyRestResource(SyntheticLocationResourcePath, NewDefaultJSONUnmarshaller(&SyntheticLocation{}), api.client)
+}
+
+// SyntheticAlertConfigs implementation of InstanaAPI interface
+func (api *baseInstanaAPI) SyntheticAlertConfigs() RestResource[*SyntheticAlertConfig] {
+	return NewCreatePOSTUpdatePOSTRestResource(SyntheticAlertConfigsResourcePath, NewCustomPayloadFieldsUnmarshallerAdapter(NewDefaultJSONUnmarshaller(&SyntheticAlertConfig{})), api.client)
 }
 
 func (api *baseInstanaAPI) AutomationActions() RestResource[*AutomationAction] {

--- a/instana/restapi/synthetic-alert-config.go
+++ b/instana/restapi/synthetic-alert-config.go
@@ -1,0 +1,47 @@
+package restapi
+
+// SyntheticAlertConfigsResourcePath is the path to the synthetic alert configs resource of the Instana API
+const SyntheticAlertConfigsResourcePath = "/api/events/settings/global-alert-configs/synthetics"
+
+// SyntheticAlertConfig represents the API model for synthetic alert configurations
+type SyntheticAlertConfig struct {
+	ID                    string                      `json:"id,omitempty"`
+	Name                  string                      `json:"name"`
+	Description           string                      `json:"description,omitempty"`
+	SyntheticTestIds      []string                    `json:"syntheticTestIds,omitempty"`
+	Severity              int                         `json:"severity"`
+	TagFilterExpression   *TagFilter                  `json:"tagFilterExpression,omitempty"`
+	Rule                  SyntheticAlertRule          `json:"rule"`
+	AlertChannelIds       []string                    `json:"alertChannelIds"`
+	TimeThreshold         SyntheticAlertTimeThreshold `json:"timeThreshold"`
+	CustomerPayloadFields []CustomPayloadField[any]   `json:"customPayloadFields,omitempty"`
+	GracePeriod           int64                       `json:"gracePeriod,omitempty"`
+}
+
+// SyntheticAlertRule represents the rule configuration for synthetic alerts
+type SyntheticAlertRule struct {
+	AlertType   string `json:"alertType"`
+	MetricName  string `json:"metricName"`
+	Aggregation string `json:"aggregation"`
+}
+
+// SyntheticAlertTimeThreshold represents the time threshold configuration for synthetic alerts
+type SyntheticAlertTimeThreshold struct {
+	Type            string `json:"type"`
+	ViolationsCount int    `json:"violationsCount"`
+}
+
+// GetIDForResourcePath returns the ID to be used in the resource path when calling the API
+func (r *SyntheticAlertConfig) GetIDForResourcePath() string {
+	return r.ID
+}
+
+// GetCustomerPayloadFields implements the CustomPayloadFieldsAware interface
+func (r *SyntheticAlertConfig) GetCustomerPayloadFields() []CustomPayloadField[any] {
+	return r.CustomerPayloadFields
+}
+
+// SetCustomerPayloadFields implements the CustomPayloadFieldsAware interface
+func (r *SyntheticAlertConfig) SetCustomerPayloadFields(fields []CustomPayloadField[any]) {
+	r.CustomerPayloadFields = fields
+}

--- a/mocks/synthetic-alert-config-mock.go
+++ b/mocks/synthetic-alert-config-mock.go
@@ -1,0 +1,22 @@
+package mocks
+
+import (
+	"reflect"
+
+	"github.com/gessnerfl/terraform-provider-instana/instana/restapi"
+	"go.uber.org/mock/gomock"
+)
+
+// SyntheticAlertConfigs mocks base method.
+func (m *MockInstanaAPI) SyntheticAlertConfigs() restapi.RestResource[*restapi.SyntheticAlertConfig] {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SyntheticAlertConfigs")
+	ret0, _ := ret[0].(restapi.RestResource[*restapi.SyntheticAlertConfig])
+	return ret0
+}
+
+// SyntheticAlertConfigs indicates an expected call of SyntheticAlertConfigs.
+func (mr *MockInstanaAPIMockRecorder) SyntheticAlertConfigs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyntheticAlertConfigs", reflect.TypeOf((*MockInstanaAPI)(nil).SyntheticAlertConfigs))
+}


### PR DESCRIPTION
This PR implements a new Terraform resource for Instana's synthetic monitoring alerts .

New Resource: **Synthetic Alert Configuration**
    - Implemented a new resource instana_synthetic_alert_config for managing synthetic monitoring alerts in Instana
    - Created the resource schema with all necessary fields based on the Instana API specification
    - Implemented CRUD operations for the resource