### PR TITLE
Add data source for Instana RBAC Role

### DIFF
--- a/docs/data-sources/rbac_role.md
+++ b/docs/data-sources/rbac_role.md
@@ -1,0 +1,21 @@
+# Data Source: instana_rbac_role
+
+Use this data source to get information about an Instana RBAC Role by its ID.
+
+## Example Usage
+
+```hcl
+ data "instana_rbac_role" "example" {
+   id = "<role-id>"
+ }
+```
+
+## Argument Reference
+
+- `id` (Required) - The ID of the RBAC Role.
+
+## Attribute Reference
+
+- `id` - The ID of the RBAC Role.
+- `name` - The name of the RBAC Role.
+- `permissions` - The set of permissions assigned to the RBAC Role.

--- a/docs/data-sources/rbac_role.md
+++ b/docs/data-sources/rbac_role.md
@@ -21,10 +21,8 @@ data "instana_rbac_role" "by_name" {
 
 ## Argument Reference
 
-- `id` (Optional) - The ID of the RBAC Role. If both `id` and `name` are provided, `id` is used.
-- `name` (Optional) - The name of the RBAC Role. Used if `id` is not set.
-
-At least one of `id` or `name` must be specified.
+- `id` (Optional) - The ID of the RBAC Role. Exactly one of `id` or `name` must be specified.
+- `name` (Optional) - The name of the RBAC Role. Exactly one of `id` or `name` must be specified.
 
 ## Attribute Reference
 

--- a/docs/data-sources/rbac_role.md
+++ b/docs/data-sources/rbac_role.md
@@ -1,18 +1,30 @@
 # Data Source: instana_rbac_role
 
-Use this data source to get information about an Instana RBAC Role by its ID.
+
+Use this data source to get information about an Instana RBAC Role by its ID or name.
 
 ## Example Usage
 
+
 ```hcl
- data "instana_rbac_role" "example" {
-   id = "<role-id>"
- }
+# Fetch by ID
+data "instana_rbac_role" "by_id" {
+  id = "<role-id>"
+}
+
+# Fetch by name
+data "instana_rbac_role" "by_name" {
+  name = "My Role Name"
+}
 ```
+
 
 ## Argument Reference
 
-- `id` (Required) - The ID of the RBAC Role.
+- `id` (Optional) - The ID of the RBAC Role. If both `id` and `name` are provided, `id` is used.
+- `name` (Optional) - The name of the RBAC Role. Used if `id` is not set.
+
+At least one of `id` or `name` must be specified.
 
 ## Attribute Reference
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,6 +56,7 @@ resource.
   * Custom Event Specifications - `instana_custom_event_spec`
 * Host Agent - `instana_host_agents`
 * Settings
+  * RBAC Role - `instana_rbac_role`
   * User - `instana_user`
 * Synthetic Settings
   * Synthetic Location - `instana_synthetic_location`

--- a/internal/datasources/data-source-rbac-role-constants.go
+++ b/internal/datasources/data-source-rbac-role-constants.go
@@ -1,6 +1,18 @@
 package datasources
 
 const (
-	RbacRoleDataSourceFieldID = "id"
-	RbacRoleDescDataSource    = "Data source for an Instana RBAC role. RBAC roles define permissions for users and teams."
+	RbacRoleDataSourceFieldID          = "id"
+	RbacRoleDataSourceFieldName        = "name"
+	RbacRoleDataSourceFieldPermissions = "permissions"
+
+	RbacRoleDescDataSource  = "Data source for an Instana RBAC role. RBAC roles define permissions for users and teams."
+	RbacRoleDescID          = "ID of the RBAC Role."
+	RbacRoleDescName        = "Name of the RBAC Role."
+	RbacRoleDescPermissions = "Permissions assigned to the RBAC Role."
+
+	RbacRoleErrMissingLookupAttribute = "Exactly one of 'id' or 'name' must be set."
+	RbacRoleErrReadByID               = "Could not read RBAC Role with ID '%s': %s"
+	RbacRoleErrReadAll                = "Could not read RBAC Roles: %s"
+	RbacRoleErrNotFoundByID           = "No RBAC Role found with ID '%s'"
+	RbacRoleErrNotFoundByName         = "No RBAC Role found with name '%s'"
 )

--- a/internal/datasources/data-source-rbac-role-constants.go
+++ b/internal/datasources/data-source-rbac-role-constants.go
@@ -1,0 +1,6 @@
+package datasources
+
+const (
+	RbacRoleDataSourceFieldID = "id"
+	RbacRoleDescDataSource    = "Data source for an Instana RBAC role. RBAC roles define permissions for users and teams."
+)

--- a/internal/datasources/data-source-rbac-role.go
+++ b/internal/datasources/data-source-rbac-role.go
@@ -1,0 +1,95 @@
+package datasources
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/instana/instana-go-client/client"
+	"github.com/instana/terraform-provider-instana/internal/shared"
+)
+
+const DataSourceInstanaRbacRole = "rbac_role"
+
+// RbacRoleDataSourceModel represents the data model for the rbac_role data source
+type RbacRoleDataSourceModel struct {
+	ID   types.String `tfsdk:"id"`
+	Name types.String `tfsdk:"name"`
+}
+
+// NewRbacRoleDataSource creates a new data source for rbac_role
+func NewRbacRoleDataSource() datasource.DataSource {
+	return &RbacRoleDataSource{}
+}
+
+type RbacRoleDataSource struct {
+	instanaAPI client.InstanaAPI
+}
+
+func (d *RbacRoleDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_" + DataSourceInstanaRbacRole
+}
+
+func (d *RbacRoleDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: RbacRoleDescDataSource,
+		Attributes: map[string]schema.Attribute{
+			RbacRoleDataSourceFieldID: schema.StringAttribute{
+				Description: "ID of the RBAC Role.",
+				Required:    true,
+			},
+			"name": schema.StringAttribute{
+				Description: "Name of the RBAC Role.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func (d *RbacRoleDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	providerMeta, ok := req.ProviderData.(*shared.ProviderMeta)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected ProviderData type",
+			fmt.Sprintf("Expected *shared.ProviderMeta, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.instanaAPI = providerMeta.InstanaAPI
+}
+
+func (d *RbacRoleDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+       var data RbacRoleDataSourceModel
+       resp.Diagnostics.Append(req.Config.Get(ctx, &data)...) // Read config into data
+       if resp.Diagnostics.HasError() {
+	       return
+       }
+
+       id := data.ID.ValueString()
+       if id == "" {
+	       resp.Diagnostics.AddError("Missing ID", "The 'id' attribute must be set.")
+	       return
+       }
+
+       role, err := d.instanaAPI.Roles().GetOne(id)
+       if err != nil {
+	       resp.Diagnostics.AddError("Error reading RBAC Role", fmt.Sprintf("Could not read RBAC Role with ID '%s': %s", id, err))
+	       return
+       }
+       if role == nil {
+	       resp.Diagnostics.AddError("Not found", fmt.Sprintf("No RBAC Role found with ID '%s'", id))
+	       return
+       }
+
+       data.ID = types.StringValue(role.ID)
+       data.Name = types.StringValue(role.Name)
+
+       resp.Diagnostics.Append(resp.State.Set(ctx, &data)...) 
+}

--- a/internal/datasources/data-source-rbac-role.go
+++ b/internal/datasources/data-source-rbac-role.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/instana/instana-go-client/api"
 	"github.com/instana/instana-go-client/client"
 	"github.com/instana/terraform-provider-instana/internal/shared"
 )
@@ -34,24 +35,24 @@ func (d *RbacRoleDataSource) Metadata(_ context.Context, req datasource.Metadata
 }
 
 func (d *RbacRoleDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-       resp.Schema = schema.Schema{
-	       Description: RbacRoleDescDataSource,
-	       Attributes: map[string]schema.Attribute{
-		       RbacRoleDataSourceFieldID: schema.StringAttribute{
-			       Description: "ID of the RBAC Role.",
-			       Required:    true,
+	       resp.Schema = schema.Schema{
+		       Description: RbacRoleDescDataSource,
+		       Attributes: map[string]schema.Attribute{
+			       RbacRoleDataSourceFieldID: schema.StringAttribute{
+				       Description: "ID of the RBAC Role.",
+				       Optional:    true,
+			       },
+			       "name": schema.StringAttribute{
+				       Description: "Name of the RBAC Role.",
+				       Optional:    true,
+			       },
+			       "permissions": schema.SetAttribute{
+				       Description: "Permissions assigned to the RBAC Role.",
+				       Computed:    true,
+				       ElementType: types.StringType,
+			       },
 		       },
-		       "name": schema.StringAttribute{
-			       Description: "Name of the RBAC Role.",
-			       Computed:    true,
-		       },
-		       "permissions": schema.SetAttribute{
-			       Description: "Permissions assigned to the RBAC Role.",
-			       Computed:    true,
-			       ElementType: types.StringType,
-		       },
-	       },
-       }
+	       }
 }
 
 func (d *RbacRoleDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
@@ -72,34 +73,56 @@ func (d *RbacRoleDataSource) Configure(_ context.Context, req datasource.Configu
 }
 
 func (d *RbacRoleDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-       var data RbacRoleDataSourceModel
-       resp.Diagnostics.Append(req.Config.Get(ctx, &data)...) // Read config into data
-       if resp.Diagnostics.HasError() {
-	       return
-       }
+	       var data RbacRoleDataSourceModel
+	       resp.Diagnostics.Append(req.Config.Get(ctx, &data)...) // Read config into data
+	       if resp.Diagnostics.HasError() {
+		       return
+	       }
 
-       id := data.ID.ValueString()
-       if id == "" {
-	       resp.Diagnostics.AddError("Missing ID", "The 'id' attribute must be set.")
-	       return
-       }
+	       id := data.ID.ValueString()
+	       name := data.Name.ValueString()
+	       if id == "" && name == "" {
+		       resp.Diagnostics.AddError("Missing Attribute", "Either 'id' or 'name' must be set.")
+		       return
+	       }
 
-       role, err := d.instanaAPI.Roles().GetOne(id)
-       if err != nil {
-	       resp.Diagnostics.AddError("Error reading RBAC Role", fmt.Sprintf("Could not read RBAC Role with ID '%s': %s", id, err))
-	       return
-       }
-       if role == nil {
-	       resp.Diagnostics.AddError("Not found", fmt.Sprintf("No RBAC Role found with ID '%s'", id))
-	       return
-       }
+		var role *api.Role
+	       var err error
+	       if id != "" {
+		       role, err = d.instanaAPI.Roles().GetOne(id)
+		       if err != nil {
+			       resp.Diagnostics.AddError("Error reading RBAC Role", fmt.Sprintf("Could not read RBAC Role with ID '%s': %s", id, err))
+			       return
+		       }
+		       if role == nil {
+			       resp.Diagnostics.AddError("Not found", fmt.Sprintf("No RBAC Role found with ID '%s'", id))
+			       return
+		       }
+	       } else {
+		       // Fetch all roles and match by name
+		       roles, err := d.instanaAPI.Roles().GetAll()
+		       if err != nil {
+			       resp.Diagnostics.AddError("Error reading RBAC Roles", fmt.Sprintf("Could not read RBAC Roles: %s", err))
+			       return
+		       }
+		       for _, r := range *roles {
+			       if r.Name == name {
+				       role = r
+				       break
+			       }
+		       }
+		       if role == nil {
+			       resp.Diagnostics.AddError("Not found", fmt.Sprintf("No RBAC Role found with name '%s'", name))
+			       return
+		       }
+	       }
 
-       data.ID = types.StringValue(role.ID)
-       data.Name = types.StringValue(role.Name)
-       data.Permissions = make([]types.String, len(role.Permissions))
-       for i, p := range role.Permissions {
-	       data.Permissions[i] = types.StringValue(p)
-       }
+	       data.ID = types.StringValue(role.ID)
+	       data.Name = types.StringValue(role.Name)
+	       data.Permissions = make([]types.String, len(role.Permissions))
+	       for i, p := range role.Permissions {
+		       data.Permissions[i] = types.StringValue(p)
+	       }
 
-       resp.Diagnostics.Append(resp.State.Set(ctx, &data)...) 
+	       resp.Diagnostics.Append(resp.State.Set(ctx, &data)...) 
 }

--- a/internal/datasources/data-source-rbac-role.go
+++ b/internal/datasources/data-source-rbac-role.go
@@ -15,8 +15,9 @@ const DataSourceInstanaRbacRole = "rbac_role"
 
 // RbacRoleDataSourceModel represents the data model for the rbac_role data source
 type RbacRoleDataSourceModel struct {
-	ID   types.String `tfsdk:"id"`
-	Name types.String `tfsdk:"name"`
+	ID          types.String   `tfsdk:"id"`
+	Name        types.String   `tfsdk:"name"`
+	Permissions []types.String `tfsdk:"permissions"`
 }
 
 // NewRbacRoleDataSource creates a new data source for rbac_role
@@ -33,19 +34,24 @@ func (d *RbacRoleDataSource) Metadata(_ context.Context, req datasource.Metadata
 }
 
 func (d *RbacRoleDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	resp.Schema = schema.Schema{
-		Description: RbacRoleDescDataSource,
-		Attributes: map[string]schema.Attribute{
-			RbacRoleDataSourceFieldID: schema.StringAttribute{
-				Description: "ID of the RBAC Role.",
-				Required:    true,
-			},
-			"name": schema.StringAttribute{
-				Description: "Name of the RBAC Role.",
-				Computed:    true,
-			},
-		},
-	}
+       resp.Schema = schema.Schema{
+	       Description: RbacRoleDescDataSource,
+	       Attributes: map[string]schema.Attribute{
+		       RbacRoleDataSourceFieldID: schema.StringAttribute{
+			       Description: "ID of the RBAC Role.",
+			       Required:    true,
+		       },
+		       "name": schema.StringAttribute{
+			       Description: "Name of the RBAC Role.",
+			       Computed:    true,
+		       },
+		       "permissions": schema.SetAttribute{
+			       Description: "Permissions assigned to the RBAC Role.",
+			       Computed:    true,
+			       ElementType: types.StringType,
+		       },
+	       },
+       }
 }
 
 func (d *RbacRoleDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
@@ -90,6 +96,10 @@ func (d *RbacRoleDataSource) Read(ctx context.Context, req datasource.ReadReques
 
        data.ID = types.StringValue(role.ID)
        data.Name = types.StringValue(role.Name)
+       data.Permissions = make([]types.String, len(role.Permissions))
+       for i, p := range role.Permissions {
+	       data.Permissions[i] = types.StringValue(p)
+       }
 
        resp.Diagnostics.Append(resp.State.Set(ctx, &data)...) 
 }

--- a/internal/datasources/data-source-rbac-role.go
+++ b/internal/datasources/data-source-rbac-role.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/instana/instana-go-client/api"
 	"github.com/instana/instana-go-client/client"
@@ -35,24 +38,30 @@ func (d *RbacRoleDataSource) Metadata(_ context.Context, req datasource.Metadata
 }
 
 func (d *RbacRoleDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	       resp.Schema = schema.Schema{
-		       Description: RbacRoleDescDataSource,
-		       Attributes: map[string]schema.Attribute{
-			       RbacRoleDataSourceFieldID: schema.StringAttribute{
-				       Description: "ID of the RBAC Role.",
-				       Optional:    true,
-			       },
-			       "name": schema.StringAttribute{
-				       Description: "Name of the RBAC Role.",
-				       Optional:    true,
-			       },
-			       "permissions": schema.SetAttribute{
-				       Description: "Permissions assigned to the RBAC Role.",
-				       Computed:    true,
-				       ElementType: types.StringType,
-			       },
-		       },
-	       }
+	resp.Schema = schema.Schema{
+		Description: RbacRoleDescDataSource,
+		Attributes: map[string]schema.Attribute{
+			RbacRoleDataSourceFieldID: schema.StringAttribute{
+				Description: RbacRoleDescID,
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.ExactlyOneOf(path.MatchRoot(RbacRoleDataSourceFieldID), path.MatchRoot(RbacRoleDataSourceFieldName)),
+				},
+			},
+			RbacRoleDataSourceFieldName: schema.StringAttribute{
+				Description: RbacRoleDescName,
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.ExactlyOneOf(path.MatchRoot(RbacRoleDataSourceFieldID), path.MatchRoot(RbacRoleDataSourceFieldName)),
+				},
+			},
+			RbacRoleDataSourceFieldPermissions: schema.SetAttribute{
+				Description: RbacRoleDescPermissions,
+				Computed:    true,
+				ElementType: types.StringType,
+			},
+		},
+	}
 }
 
 func (d *RbacRoleDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
@@ -73,56 +82,55 @@ func (d *RbacRoleDataSource) Configure(_ context.Context, req datasource.Configu
 }
 
 func (d *RbacRoleDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	       var data RbacRoleDataSourceModel
-	       resp.Diagnostics.Append(req.Config.Get(ctx, &data)...) // Read config into data
-	       if resp.Diagnostics.HasError() {
-		       return
-	       }
+	var data RbacRoleDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-	       id := data.ID.ValueString()
-	       name := data.Name.ValueString()
-	       if id == "" && name == "" {
-		       resp.Diagnostics.AddError("Missing Attribute", "Either 'id' or 'name' must be set.")
-		       return
-	       }
+	id := data.ID.ValueString()
+	name := data.Name.ValueString()
+	if id == "" && name == "" {
+		resp.Diagnostics.AddError("Missing Attribute", RbacRoleErrMissingLookupAttribute)
+		return
+	}
 
 		var role *api.Role
-	       var err error
-	       if id != "" {
-		       role, err = d.instanaAPI.Roles().GetOne(id)
-		       if err != nil {
-			       resp.Diagnostics.AddError("Error reading RBAC Role", fmt.Sprintf("Could not read RBAC Role with ID '%s': %s", id, err))
-			       return
-		       }
-		       if role == nil {
-			       resp.Diagnostics.AddError("Not found", fmt.Sprintf("No RBAC Role found with ID '%s'", id))
-			       return
-		       }
-	       } else {
-		       // Fetch all roles and match by name
-		       roles, err := d.instanaAPI.Roles().GetAll()
-		       if err != nil {
-			       resp.Diagnostics.AddError("Error reading RBAC Roles", fmt.Sprintf("Could not read RBAC Roles: %s", err))
-			       return
-		       }
-		       for _, r := range *roles {
-			       if r.Name == name {
-				       role = r
-				       break
-			       }
-		       }
-		       if role == nil {
-			       resp.Diagnostics.AddError("Not found", fmt.Sprintf("No RBAC Role found with name '%s'", name))
-			       return
-		       }
-	       }
+	var err error
+	if id != "" {
+		role, err = d.instanaAPI.Roles().GetOne(id)
+		if err != nil {
+			resp.Diagnostics.AddError("Error reading RBAC Role", fmt.Sprintf(RbacRoleErrReadByID, id, err))
+			return
+		}
+		if role == nil {
+			resp.Diagnostics.AddError("Not found", fmt.Sprintf(RbacRoleErrNotFoundByID, id))
+			return
+		}
+	} else {
+		roles, err := d.instanaAPI.Roles().GetAll()
+		if err != nil {
+			resp.Diagnostics.AddError("Error reading RBAC Roles", fmt.Sprintf(RbacRoleErrReadAll, err))
+			return
+		}
+		for _, r := range *roles {
+			if r.Name == name {
+				role = r
+				break
+			}
+		}
+		if role == nil {
+			resp.Diagnostics.AddError("Not found", fmt.Sprintf(RbacRoleErrNotFoundByName, name))
+			return
+		}
+	}
 
-	       data.ID = types.StringValue(role.ID)
-	       data.Name = types.StringValue(role.Name)
-	       data.Permissions = make([]types.String, len(role.Permissions))
-	       for i, p := range role.Permissions {
-		       data.Permissions[i] = types.StringValue(p)
-	       }
+	data.ID = types.StringValue(role.ID)
+	data.Name = types.StringValue(role.Name)
+	data.Permissions = make([]types.String, len(role.Permissions))
+	for i, p := range role.Permissions {
+		data.Permissions[i] = types.StringValue(p)
+	}
 
-	       resp.Diagnostics.Append(resp.State.Set(ctx, &data)...) 
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/datasources/data-source-rbac-role_test.go
+++ b/internal/datasources/data-source-rbac-role_test.go
@@ -1,0 +1,34 @@
+package datasources
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRbacRoleDataSource(t *testing.T) {
+	ds := NewRbacRoleDataSource()
+	_, ok := ds.(*RbacRoleDataSource)
+	require.True(t, ok)
+}
+
+func TestRbacRoleDataSourceMetadata(t *testing.T) {
+	ds := NewRbacRoleDataSource()
+	req := datasource.MetadataRequest{ProviderTypeName: "instana"}
+	resp := &datasource.MetadataResponse{}
+	ds.Metadata(context.Background(), req, resp)
+	require.Equal(t, "instana_rbac_role", resp.TypeName)
+}
+
+func TestRbacRoleDataSourceSchema(t *testing.T) {
+	ds := NewRbacRoleDataSource()
+	resp := &datasource.SchemaResponse{}
+	ds.Schema(context.Background(), datasource.SchemaRequest{}, resp)
+	require.Equal(t, RbacRoleDescDataSource, resp.Schema.Description)
+	_, ok := resp.Schema.Attributes[RbacRoleDataSourceFieldID]
+	require.True(t, ok)
+	_, ok = resp.Schema.Attributes["name"]
+	require.True(t, ok)
+}

--- a/internal/datasources/data-source-rbac-role_test.go
+++ b/internal/datasources/data-source-rbac-role_test.go
@@ -30,12 +30,8 @@ func TestRbacRoleDataSourceSchema(t *testing.T) {
 	require.Equal(t, RbacRoleDescDataSource, resp.Schema.Description)
 	_, ok := resp.Schema.Attributes[RbacRoleDataSourceFieldID]
 	require.True(t, ok)
-	_, ok = resp.Schema.Attributes["name"]
+	_, ok = resp.Schema.Attributes[RbacRoleDataSourceFieldName]
+	require.True(t, ok)
+	_, ok = resp.Schema.Attributes[RbacRoleDataSourceFieldPermissions]
 	require.True(t, ok)
 }
-
-// Additional tests for Read logic would go here, using a mock InstanaAPI.
-// Example (pseudo):
-// func TestRbacRoleDataSourceRead_ByID(t *testing.T) { ... }
-// func TestRbacRoleDataSourceRead_ByName(t *testing.T) { ... }
-// func TestRbacRoleDataSourceRead_ErrorCases(t *testing.T) { ... }

--- a/internal/datasources/data-source-rbac-role_test.go
+++ b/internal/datasources/data-source-rbac-role_test.go
@@ -22,6 +22,7 @@ func TestRbacRoleDataSourceMetadata(t *testing.T) {
 	require.Equal(t, "instana_rbac_role", resp.TypeName)
 }
 
+
 func TestRbacRoleDataSourceSchema(t *testing.T) {
 	ds := NewRbacRoleDataSource()
 	resp := &datasource.SchemaResponse{}
@@ -32,3 +33,9 @@ func TestRbacRoleDataSourceSchema(t *testing.T) {
 	_, ok = resp.Schema.Attributes["name"]
 	require.True(t, ok)
 }
+
+// Additional tests for Read logic would go here, using a mock InstanaAPI.
+// Example (pseudo):
+// func TestRbacRoleDataSourceRead_ByID(t *testing.T) { ... }
+// func TestRbacRoleDataSourceRead_ByName(t *testing.T) { ... }
+// func TestRbacRoleDataSourceRead_ErrorCases(t *testing.T) { ... }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -335,6 +335,7 @@ func (p *InstanaProvider) DataSources(_ context.Context) []func() datasource.Dat
 		datasources.NewHostAgentsDataSource,
 		datasources.NewSyntheticLocationDataSource,
 		datasources.NewUserDataSource,
+		datasources.NewRbacRoleDataSource,
 	}
 }
 


### PR DESCRIPTION
## Summary 
This PR introduces a new Terraform data source for Instana RBAC roles.

Adds data_source_rbac_role to allow users to fetch RBAC role details by ID.
Exposes the following attributes:
-  id
- name (computed)
- permissions (computed set of strings)

## Consequence
This enables users to reference RBAC roles and their permissions in Terraform configurations.
