### PR TITLE
Enhance API Token resource with validation and normalization rules

### DIFF
--- a/docs/resources/api_token.md
+++ b/docs/resources/api_token.md
@@ -239,7 +239,7 @@ All scope limitation attributes are optional and default to `false`:
 * `limited_xen_server_scope` - Limits the scope to Xen Server
 * `limited_windows_hypervisor_scope` - Limits the scope to Windows Hypervisor
 * `limited_alert_channels_scope` - Limits the scope to alert channels
-* `limited_linux_kvm_hypervisor_scope` - Limits the scope to Linux KVM Hypervisor
+* `limited_linux_kvm_hypervisor_scope` - Limits the scope to Linux KVM Hypervisor (**always normalized to false; setting to true will cause a plan-time error**)
 * `limited_service_level_scope` - Limits the scope to service levels
 * `limited_ai_gateway_scope` - Limits the scope to AI Gateway
 
@@ -256,7 +256,7 @@ All additional permission attributes are optional and default to `false`:
 * `can_configure_synthetic_tests` - Enables permission to configure synthetic tests
 * `can_configure_synthetic_locations` - Enables permission to configure synthetic locations
 * `can_configure_synthetic_credentials` - Enables permission to configure synthetic credentials
-* `can_view_synthetic_tests` - Enables permission to view synthetic tests
+* `can_view_synthetic_tests` - Enables permission to view synthetic tests (**must be true if `can_configure_synthetic_tests` is true; setting to false in this case will cause a plan-time error**)
 * `can_view_synthetic_locations` - Enables permission to view synthetic locations
 * `can_view_synthetic_test_results` - Enables permission to view synthetic test results
 * `can_use_synthetic_credentials` - Enables permission to use synthetic credentials
@@ -297,6 +297,16 @@ $ terraform import instana_api_token.my_token 60845e4e5e6b9cf8fc2868da
 ```
 
 ## Notes
+
+### ⚠️ Backend-Normalized and Derived Permissions
+
+Some permissions are always normalized or derived by the Instana backend. The provider enforces these rules at plan time:
+
+- `can_configure_personal_api_tokens`: Always false for API tokens. Setting to true will cause a plan-time error.
+- `limited_linux_kvm_hypervisor_scope`: Always false. Setting to true will cause a plan-time error.
+- `can_view_synthetic_tests`: Must be true if `can_configure_synthetic_tests` is true. Setting to false in this case will cause a plan-time error.
+
+If you see a plan-time error for these fields, update your Terraform configuration to match the backend-normalized value and re-run `terraform plan`.
 
 ### Token Security
 

--- a/internal/resources/apitoken/api-token-model.go
+++ b/internal/resources/apitoken/api-token-model.go
@@ -6,32 +6,19 @@ import (
 
 // APITokenModel represents the data model for the API token resource
 type APITokenModel struct {
+	// This struct is now aligned exactly with the schema attributes for the API token resource.
 	ID                                       types.String `tfsdk:"id"`
 	AccessGrantingToken                      types.String `tfsdk:"access_granting_token"`
 	InternalID                               types.String `tfsdk:"internal_id"`
 	Name                                     types.String `tfsdk:"name"`
-	CanConfigureServiceMapping               types.Bool   `tfsdk:"can_configure_service_mapping"`
-	CanConfigureEumApplications              types.Bool   `tfsdk:"can_configure_eum_applications"`
-	CanConfigureMobileAppMonitoring          types.Bool   `tfsdk:"can_configure_mobile_app_monitoring"`
-	CanConfigureUsers                        types.Bool   `tfsdk:"can_configure_users"`
-	CanInstallNewAgents                      types.Bool   `tfsdk:"can_install_new_agents"`
-	CanConfigureIntegrations                 types.Bool   `tfsdk:"can_configure_integrations"`
 	CanConfigureEventsAndAlerts              types.Bool   `tfsdk:"can_configure_events_and_alerts"`
 	CanConfigureMaintenanceWindows           types.Bool   `tfsdk:"can_configure_maintenance_windows"`
 	CanConfigureApplicationSmartAlerts       types.Bool   `tfsdk:"can_configure_application_smart_alerts"`
 	CanConfigureWebsiteSmartAlerts           types.Bool   `tfsdk:"can_configure_website_smart_alerts"`
 	CanConfigureMobileAppSmartAlerts         types.Bool   `tfsdk:"can_configure_mobile_app_smart_alerts"`
-	CanConfigureAPITokens                    types.Bool   `tfsdk:"can_configure_api_tokens"`
-	CanConfigureAgentRunMode                 types.Bool   `tfsdk:"can_configure_agent_run_mode"`
-	CanViewAuditLog                          types.Bool   `tfsdk:"can_view_audit_log"`
-	CanConfigureAgents                       types.Bool   `tfsdk:"can_configure_agents"`
-	CanConfigureAuthenticationMethods        types.Bool   `tfsdk:"can_configure_authentication_methods"`
-	CanConfigureApplications                 types.Bool   `tfsdk:"can_configure_applications"`
-	CanConfigureTeams                        types.Bool   `tfsdk:"can_configure_teams"`
-	CanConfigureReleases                     types.Bool   `tfsdk:"can_configure_releases"`
-	CanConfigureLogManagement                types.Bool   `tfsdk:"can_configure_log_management"`
-	CanCreatePublicCustomDashboards          types.Bool   `tfsdk:"can_create_public_custom_dashboards"`
-	CanViewLogs                              types.Bool   `tfsdk:"can_view_logs"`
+	CanConfigureServiceLevelCorrectionWindows types.Bool  `tfsdk:"can_configure_service_level_correction_windows"`
+	CanConfigureServiceLevelSmartAlerts      types.Bool   `tfsdk:"can_configure_service_level_smart_alerts"`
+	CanConfigureServiceLevels                types.Bool   `tfsdk:"can_configure_service_levels"`
 	CanViewTraceDetails                      types.Bool   `tfsdk:"can_view_trace_details"`
 	CanConfigureSessionSettings              types.Bool   `tfsdk:"can_configure_session_settings"`
 	CanConfigureGlobalAlertPayload           types.Bool   `tfsdk:"can_configure_global_alert_payload"`
@@ -41,62 +28,55 @@ type APITokenModel struct {
 	CanConfigureGlobalLogSmartAlerts         types.Bool   `tfsdk:"can_configure_global_log_smart_alerts"`
 	CanViewAccountAndBillingInformation      types.Bool   `tfsdk:"can_view_account_and_billing_information"`
 	CanEditAllAccessibleCustomDashboards     types.Bool   `tfsdk:"can_edit_all_accessible_custom_dashboards"`
-
-	// Scope limitations
-	LimitedApplicationsScope       types.Bool `tfsdk:"limited_applications_scope"`
-	LimitedBizOpsScope             types.Bool `tfsdk:"limited_biz_ops_scope"`
-	LimitedWebsitesScope           types.Bool `tfsdk:"limited_websites_scope"`
-	LimitedKubernetesScope         types.Bool `tfsdk:"limited_kubernetes_scope"`
-	LimitedMobileAppsScope         types.Bool `tfsdk:"limited_mobile_apps_scope"`
-	LimitedInfrastructureScope     types.Bool `tfsdk:"limited_infrastructure_scope"`
-	LimitedSyntheticsScope         types.Bool `tfsdk:"limited_synthetics_scope"`
-	LimitedVsphereScope            types.Bool `tfsdk:"limited_vsphere_scope"`
-	LimitedPhmcScope               types.Bool `tfsdk:"limited_phmc_scope"`
-	LimitedPvcScope                types.Bool `tfsdk:"limited_pvc_scope"`
-	LimitedZhmcScope               types.Bool `tfsdk:"limited_zhmc_scope"`
-	LimitedPcfScope                types.Bool `tfsdk:"limited_pcf_scope"`
-	LimitedOpenstackScope          types.Bool `tfsdk:"limited_openstack_scope"`
-	LimitedAutomationScope         types.Bool `tfsdk:"limited_automation_scope"`
-	LimitedLogsScope               types.Bool `tfsdk:"limited_logs_scope"`
-	LimitedNutanixScope            types.Bool `tfsdk:"limited_nutanix_scope"`
-	LimitedXenServerScope          types.Bool `tfsdk:"limited_xen_server_scope"`
-	LimitedWindowsHypervisorScope  types.Bool `tfsdk:"limited_windows_hypervisor_scope"`
-	LimitedAlertChannelsScope      types.Bool `tfsdk:"limited_alert_channels_scope"`
-	LimitedLinuxKvmHypervisorScope types.Bool `tfsdk:"limited_linux_kvm_hypervisor_scope"`
-	LimitedServiceLevelScope       types.Bool `tfsdk:"limited_service_level_scope"`
-	LimitedAiGatewayScope          types.Bool `tfsdk:"limited_ai_gateway_scope"`
-
-	// Additional permissions
-	CanConfigurePersonalAPITokens             types.Bool `tfsdk:"can_configure_personal_api_tokens"`
-	CanConfigureDatabaseManagement            types.Bool `tfsdk:"can_configure_database_management"`
-	CanConfigureAutomationActions             types.Bool `tfsdk:"can_configure_automation_actions"`
-	CanConfigureAutomationPolicies            types.Bool `tfsdk:"can_configure_automation_policies"`
-	CanRunAutomationActions                   types.Bool `tfsdk:"can_run_automation_actions"`
-	CanDeleteAutomationActionHistory          types.Bool `tfsdk:"can_delete_automation_action_history"`
-	CanConfigureSyntheticTests                types.Bool `tfsdk:"can_configure_synthetic_tests"`
-	CanConfigureSyntheticLocations            types.Bool `tfsdk:"can_configure_synthetic_locations"`
-	CanConfigureSyntheticCredentials          types.Bool `tfsdk:"can_configure_synthetic_credentials"`
-	CanViewSyntheticTests                     types.Bool `tfsdk:"can_view_synthetic_tests"`
-	CanViewSyntheticLocations                 types.Bool `tfsdk:"can_view_synthetic_locations"`
-	CanViewSyntheticTestResults               types.Bool `tfsdk:"can_view_synthetic_test_results"`
-	CanUseSyntheticCredentials                types.Bool `tfsdk:"can_use_synthetic_credentials"`
-	CanConfigureBizops                        types.Bool `tfsdk:"can_configure_bizops"`
-	CanViewBusinessProcesses                  types.Bool `tfsdk:"can_view_business_processes"`
-	CanViewBusinessProcessDetails             types.Bool `tfsdk:"can_view_business_process_details"`
-	CanViewBusinessActivities                 types.Bool `tfsdk:"can_view_business_activities"`
-	CanViewBizAlerts                          types.Bool `tfsdk:"can_view_biz_alerts"`
-	CanDeleteLogs                             types.Bool `tfsdk:"can_delete_logs"`
-	CanCreateHeapDump                         types.Bool `tfsdk:"can_create_heap_dump"`
-	CanCreateThreadDump                       types.Bool `tfsdk:"can_create_thread_dump"`
-	CanManuallyCloseIssue                     types.Bool `tfsdk:"can_manually_close_issue"`
-	CanViewLogVolume                          types.Bool `tfsdk:"can_view_log_volume"`
-	CanConfigureLogRetentionPeriod            types.Bool `tfsdk:"can_configure_log_retention_period"`
-	CanConfigureSubtraces                     types.Bool `tfsdk:"can_configure_subtraces"`
-	CanInvokeAlertChannel                     types.Bool `tfsdk:"can_invoke_alert_channel"`
-	CanConfigureLlm                           types.Bool `tfsdk:"can_configure_llm"`
-	CanConfigureAiAgents                      types.Bool `tfsdk:"can_configure_ai_agents"`
-	CanConfigureApdex                         types.Bool `tfsdk:"can_configure_apdex"`
-	CanConfigureServiceLevelCorrectionWindows types.Bool `tfsdk:"can_configure_service_level_correction_windows"`
-	CanConfigureServiceLevelSmartAlerts       types.Bool `tfsdk:"can_configure_service_level_smart_alerts"`
-	CanConfigureServiceLevels                 types.Bool `tfsdk:"can_configure_service_levels"`
+	LimitedApplicationsScope                 types.Bool   `tfsdk:"limited_applications_scope"`
+	LimitedBizOpsScope                       types.Bool   `tfsdk:"limited_biz_ops_scope"`
+	LimitedWebsitesScope                     types.Bool   `tfsdk:"limited_websites_scope"`
+	LimitedKubernetesScope                   types.Bool   `tfsdk:"limited_kubernetes_scope"`
+	LimitedMobileAppsScope                   types.Bool   `tfsdk:"limited_mobile_apps_scope"`
+	LimitedInfrastructureScope               types.Bool   `tfsdk:"limited_infrastructure_scope"`
+	LimitedSyntheticsScope                   types.Bool   `tfsdk:"limited_synthetics_scope"`
+	LimitedVsphereScope                      types.Bool   `tfsdk:"limited_vsphere_scope"`
+	LimitedPhmcScope                         types.Bool   `tfsdk:"limited_phmc_scope"`
+	LimitedPvcScope                          types.Bool   `tfsdk:"limited_pvc_scope"`
+	LimitedZhmcScope                         types.Bool   `tfsdk:"limited_zhmc_scope"`
+	LimitedPcfScope                          types.Bool   `tfsdk:"limited_pcf_scope"`
+	LimitedOpenstackScope                    types.Bool   `tfsdk:"limited_openstack_scope"`
+	LimitedAutomationScope                   types.Bool   `tfsdk:"limited_automation_scope"`
+	LimitedLogsScope                         types.Bool   `tfsdk:"limited_logs_scope"`
+	LimitedNutanixScope                      types.Bool   `tfsdk:"limited_nutanix_scope"`
+	LimitedXenServerScope                    types.Bool   `tfsdk:"limited_xen_server_scope"`
+	LimitedWindowsHypervisorScope            types.Bool   `tfsdk:"limited_windows_hypervisor_scope"`
+	LimitedAlertChannelsScope                types.Bool   `tfsdk:"limited_alert_channels_scope"`
+	LimitedLinuxKvmHypervisorScope           types.Bool   `tfsdk:"limited_linux_kvm_hypervisor_scope"`
+	LimitedServiceLevelScope                 types.Bool   `tfsdk:"limited_service_level_scope"`
+	LimitedAiGatewayScope                    types.Bool   `tfsdk:"limited_ai_gateway_scope"`
+	CanConfigurePersonalAPITokens            types.Bool   `tfsdk:"can_configure_personal_api_tokens"`
+	CanConfigureDatabaseManagement           types.Bool   `tfsdk:"can_configure_database_management"`
+	CanConfigureAutomationActions            types.Bool   `tfsdk:"can_configure_automation_actions"`
+	CanConfigureAutomationPolicies           types.Bool   `tfsdk:"can_configure_automation_policies"`
+	CanRunAutomationActions                  types.Bool   `tfsdk:"can_run_automation_actions"`
+	CanDeleteAutomationActionHistory         types.Bool   `tfsdk:"can_delete_automation_action_history"`
+	CanConfigureSyntheticTests               types.Bool   `tfsdk:"can_configure_synthetic_tests"`
+	CanConfigureSyntheticLocations           types.Bool   `tfsdk:"can_configure_synthetic_locations"`
+	CanConfigureSyntheticCredentials         types.Bool   `tfsdk:"can_configure_synthetic_credentials"`
+	CanViewSyntheticTests                    types.Bool   `tfsdk:"can_view_synthetic_tests"`
+	CanViewSyntheticLocations                types.Bool   `tfsdk:"can_view_synthetic_locations"`
+	CanViewSyntheticTestResults              types.Bool   `tfsdk:"can_view_synthetic_test_results"`
+	CanUseSyntheticCredentials               types.Bool   `tfsdk:"can_use_synthetic_credentials"`
+	CanConfigureBizops                       types.Bool   `tfsdk:"can_configure_bizops"`
+	CanViewBusinessProcesses                 types.Bool   `tfsdk:"can_view_business_processes"`
+	CanViewBusinessProcessDetails            types.Bool   `tfsdk:"can_view_business_process_details"`
+	CanViewBusinessActivities                types.Bool   `tfsdk:"can_view_business_activities"`
+	CanViewBizAlerts                         types.Bool   `tfsdk:"can_view_biz_alerts"`
+	CanDeleteLogs                            types.Bool   `tfsdk:"can_delete_logs"`
+	CanCreateHeapDump                        types.Bool   `tfsdk:"can_create_heap_dump"`
+	CanCreateThreadDump                      types.Bool   `tfsdk:"can_create_thread_dump"`
+	CanManuallyCloseIssue                    types.Bool   `tfsdk:"can_manually_close_issue"`
+	CanViewLogVolume                         types.Bool   `tfsdk:"can_view_log_volume"`
+	CanConfigureLogRetentionPeriod           types.Bool   `tfsdk:"can_configure_log_retention_period"`
+	CanConfigureSubtraces                    types.Bool   `tfsdk:"can_configure_subtraces"`
+	CanInvokeAlertChannel                    types.Bool   `tfsdk:"can_invoke_alert_channel"`
+	CanConfigureLlm                          types.Bool   `tfsdk:"can_configure_llm"`
+	CanConfigureAiAgents                     types.Bool   `tfsdk:"can_configure_ai_agents"`
+	CanConfigureApdex                        types.Bool   `tfsdk:"can_configure_apdex"`
 }

--- a/internal/resources/apitoken/resource-api-token.go
+++ b/internal/resources/apitoken/resource-api-token.go
@@ -18,22 +18,66 @@ import (
 	"github.com/instana/terraform-provider-instana/internal/util"
 )
 
-// NewAPITokenResourceHandle creates the resource handle for API Tokens
+// RequireTrueIfOtherTruePlanModifier enforces that a bool attribute must be true if another field is true
+type RequireTrueIfOtherTruePlanModifier struct {
+	Field      string
+	OtherField string
+}
+
+func (m RequireTrueIfOtherTruePlanModifier) Description(_ context.Context) string {
+       return m.Field + " must be true if " + m.OtherField + " is true."
+}
+
+func (m RequireTrueIfOtherTruePlanModifier) MarkdownDescription(_ context.Context) string {
+       return m.Description(context.Background())
+}
+
+func (m RequireTrueIfOtherTruePlanModifier) PlanModifyBool(ctx context.Context, req planmodifier.BoolRequest, resp *planmodifier.BoolResponse) {
+       // If the plan is unknown, skip
+       if req.PlanValue.IsUnknown() {
+	       return
+       }
+       // Find the value of the other field in the config
+       if req.ConfigValue.IsUnknown() {
+	       return
+       }
+       // The config is the parent object, so we need to get the other field from the config object
+       // If not available, skip
+       var otherVal types.Bool
+       diags := req.Config.GetAttribute(ctx, path.Root(m.OtherField), &otherVal)
+       if diags.HasError() {
+	       return
+       }
+       // If the other field is true, this field must be true
+       if !otherVal.IsNull() && otherVal.ValueBool() {
+	       if !req.PlanValue.ValueBool() {
+		       resp.Diagnostics.AddError(
+			       m.Field+" must be true if "+m.OtherField+" is true",
+			       "The Instana backend will always set '"+m.Field+"' to true if '"+m.OtherField+"' is true. Setting this to false is not allowed and will cause the plan to fail.",
+		       )
+	       }
+       }
+}
+
+// apiTokenResource implements ResourceHandle for API tokens
+// This struct is required for method receivers below.
+type apiTokenResource struct {
+	metaData resourcehandle.ResourceMetaData
+}
+
 func NewAPITokenResourceHandle() resourcehandle.ResourceHandle[*restapi.APIToken] {
-	internalIDFieldName := APITokenFieldInternalID
-	return &apiTokenResource{
-		metaData: resourcehandle.ResourceMetaData{
-			ResourceName: ResourceInstanaAPIToken,
-			Schema: schema.Schema{
-				Description: APITokenDescResource,
-				Attributes: map[string]schema.Attribute{
-					APITokenFieldID: schema.StringAttribute{
-						Computed:    true,
-						Description: APITokenDescID,
-						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.UseStateForUnknown(),
-						},
-					},
+	       return &apiTokenResource{
+		       metaData: resourcehandle.ResourceMetaData{
+			       ResourceName: ResourceInstanaAPIToken,
+			       SchemaVersion: 3,
+			       Schema: schema.Schema{
+				       Description: APITokenDescResource,
+				       Attributes: map[string]schema.Attribute{
+					       APITokenFieldID: schema.StringAttribute{
+						       Computed:    true,
+						       Description: APITokenDescID,
+						       PlanModifiers: []planmodifier.String{},
+					       },
 					APITokenFieldAccessGrantingToken: schema.StringAttribute{
 						Computed:    true,
 						Description: APITokenDescAccessGrantingToken,
@@ -51,36 +95,6 @@ func NewAPITokenResourceHandle() resourcehandle.ResourceHandle[*restapi.APIToken
 					APITokenFieldName: schema.StringAttribute{
 						Required:    true,
 						Description: APITokenDescName,
-					},
-					APITokenFieldCanConfigureServiceMapping: schema.BoolAttribute{
-						Optional:    true,
-						Computed:    true,
-						Description: APITokenDescCanConfigureServiceMapping,
-					},
-					APITokenFieldCanConfigureEumApplications: schema.BoolAttribute{
-						Optional:    true,
-						Computed:    true,
-						Description: APITokenDescCanConfigureEumApplications,
-					},
-					APITokenFieldCanConfigureMobileAppMonitoring: schema.BoolAttribute{
-						Optional:    true,
-						Computed:    true,
-						Description: APITokenDescCanConfigureMobileAppMonitoring,
-					},
-					APITokenFieldCanConfigureUsers: schema.BoolAttribute{
-						Optional:    true,
-						Computed:    true,
-						Description: APITokenDescCanConfigureUsers,
-					},
-					APITokenFieldCanInstallNewAgents: schema.BoolAttribute{
-						Optional:    true,
-						Computed:    true,
-						Description: APITokenDescCanInstallNewAgents,
-					},
-					APITokenFieldCanConfigureIntegrations: schema.BoolAttribute{
-						Optional:    true,
-						Computed:    true,
-						Description: APITokenDescCanConfigureIntegrations,
 					},
 					APITokenFieldCanConfigureEventsAndAlerts: schema.BoolAttribute{
 						Optional:    true,
@@ -107,60 +121,20 @@ func NewAPITokenResourceHandle() resourcehandle.ResourceHandle[*restapi.APIToken
 						Computed:    true,
 						Description: APITokenDescCanConfigureMobileAppSmartAlerts,
 					},
-					APITokenFieldCanConfigureAPITokens: schema.BoolAttribute{
+					APITokenFieldCanConfigureServiceLevelCorrectionWindows: schema.BoolAttribute{
 						Optional:    true,
 						Computed:    true,
-						Description: APITokenDescCanConfigureAPITokens,
+						Description: APITokenDescCanConfigureServiceLevelCorrectionWindows,
 					},
-					APITokenFieldCanConfigureAgentRunMode: schema.BoolAttribute{
+					APITokenFieldCanConfigureServiceLevelSmartAlerts: schema.BoolAttribute{
 						Optional:    true,
 						Computed:    true,
-						Description: APITokenDescCanConfigureAgentRunMode,
+						Description: APITokenDescCanConfigureServiceLevelSmartAlerts,
 					},
-					APITokenFieldCanViewAuditLog: schema.BoolAttribute{
+					APITokenFieldCanConfigureServiceLevels: schema.BoolAttribute{
 						Optional:    true,
 						Computed:    true,
-						Description: APITokenDescCanViewAuditLog,
-					},
-					APITokenFieldCanConfigureAgents: schema.BoolAttribute{
-						Optional:    true,
-						Computed:    true,
-						Description: APITokenDescCanConfigureAgents,
-					},
-					APITokenFieldCanConfigureAuthenticationMethods: schema.BoolAttribute{
-						Optional:    true,
-						Computed:    true,
-						Description: APITokenDescCanConfigureAuthenticationMethods,
-					},
-					APITokenFieldCanConfigureApplications: schema.BoolAttribute{
-						Optional:    true,
-						Computed:    true,
-						Description: APITokenDescCanConfigureApplications,
-					},
-					APITokenFieldCanConfigureTeams: schema.BoolAttribute{
-						Optional:    true,
-						Computed:    true,
-						Description: APITokenDescCanConfigureTeams,
-					},
-					APITokenFieldCanConfigureReleases: schema.BoolAttribute{
-						Optional:    true,
-						Computed:    true,
-						Description: APITokenDescCanConfigureReleases,
-					},
-					APITokenFieldCanConfigureLogManagement: schema.BoolAttribute{
-						Optional:    true,
-						Computed:    true,
-						Description: APITokenDescCanConfigureLogManagement,
-					},
-					APITokenFieldCanCreatePublicCustomDashboards: schema.BoolAttribute{
-						Optional:    true,
-						Computed:    true,
-						Description: APITokenDescCanCreatePublicCustomDashboards,
-					},
-					APITokenFieldCanViewLogs: schema.BoolAttribute{
-						Optional:    true,
-						Computed:    true,
-						Description: APITokenDescCanViewLogs,
+						Description: APITokenDescCanConfigureServiceLevels,
 					},
 					APITokenFieldCanViewTraceDetails: schema.BoolAttribute{
 						Optional:    true,
@@ -304,11 +278,14 @@ func NewAPITokenResourceHandle() resourcehandle.ResourceHandle[*restapi.APIToken
 						Computed:    true,
 						Description: APITokenDescLimitedAlertChannelsScope,
 					},
-					APITokenFieldLimitedLinuxKvmHypervisorScope: schema.BoolAttribute{
-						Optional:    true,
-						Computed:    true,
-						Description: APITokenDescLimitedLinuxKvmHypervisorScope,
-					},
+					   APITokenFieldLimitedLinuxKvmHypervisorScope: schema.BoolAttribute{
+						   Optional:    true,
+						   Computed:    true,
+						   Description: APITokenDescLimitedLinuxKvmHypervisorScope,
+						   PlanModifiers: []planmodifier.Bool{
+							   AlwaysFalseAPITokenPlanModifier{Field: APITokenFieldLimitedLinuxKvmHypervisorScope},
+						   },
+					   },
 					APITokenFieldLimitedServiceLevelScope: schema.BoolAttribute{
 						Optional:    true,
 						Computed:    true,
@@ -325,6 +302,9 @@ func NewAPITokenResourceHandle() resourcehandle.ResourceHandle[*restapi.APIToken
 						Optional:    true,
 						Computed:    true,
 						Description: APITokenDescCanConfigurePersonalAPITokens,
+						PlanModifiers: []planmodifier.Bool{
+							AlwaysFalseAPITokenPlanModifier{Field: APITokenFieldCanConfigurePersonalAPITokens},
+						},
 					},
 					APITokenFieldCanConfigureDatabaseManagement: schema.BoolAttribute{
 						Optional:    true,
@@ -370,7 +350,14 @@ func NewAPITokenResourceHandle() resourcehandle.ResourceHandle[*restapi.APIToken
 						Optional:    true,
 						Computed:    true,
 						Description: APITokenDescCanViewSyntheticTests,
+						PlanModifiers: []planmodifier.Bool{
+							RequireTrueIfOtherTruePlanModifier{
+								Field: APITokenFieldCanViewSyntheticTests,
+								OtherField: APITokenFieldCanConfigureSyntheticTests,
+							},
+						},
 					},
+				// ...existing code...
 					APITokenFieldCanViewSyntheticLocations: schema.BoolAttribute{
 						Optional:    true,
 						Computed:    true,
@@ -461,41 +448,15 @@ func NewAPITokenResourceHandle() resourcehandle.ResourceHandle[*restapi.APIToken
 						Computed:    true,
 						Description: APITokenDescCanConfigureAiAgents,
 					},
-					APITokenFieldCanConfigureApdex: schema.BoolAttribute{
-						Optional:    true,
-						Computed:    true,
-						Description: APITokenDescCanConfigureApdex,
-					},
-					APITokenFieldCanConfigureServiceLevelCorrectionWindows: schema.BoolAttribute{
-						Optional:    true,
-						Computed:    true,
-						Description: APITokenDescCanConfigureServiceLevelCorrectionWindows,
-					},
-					APITokenFieldCanConfigureServiceLevelSmartAlerts: schema.BoolAttribute{
-						Optional:    true,
-						Computed:    true,
-						Description: APITokenDescCanConfigureServiceLevelSmartAlerts,
-					},
-					APITokenFieldCanConfigureServiceLevels: schema.BoolAttribute{
-						Optional:    true,
-						Computed:    true,
-						Description: APITokenDescCanConfigureServiceLevels,
-					},
-				},
-			},
-			SkipIDGeneration: true,
-			SchemaVersion:    3,
-			ResourceIDField:  &internalIDFieldName,
-		},
-	}
-}
-
-// ============================================================================
-// Resource Implementation
-// ============================================================================
-
-type apiTokenResource struct {
-	metaData resourcehandle.ResourceMetaData
+					  APITokenFieldCanConfigureApdex: schema.BoolAttribute{
+						  Optional:    true,
+						  Computed:    true,
+						  Description: APITokenDescCanConfigureApdex,
+					  },
+				  },
+			  },
+		  },
+	  }
 }
 
 // MetaData returns the resource metadata
@@ -545,28 +506,11 @@ func (r *apiTokenResource) UpdateState(ctx context.Context, state *tfsdk.State, 
 
 // mapPermissionsToModel maps basic permissions from API to model
 func (r *apiTokenResource) mapPermissionsToModel(apiToken *restapi.APIToken, model *APITokenModel) {
-	model.CanConfigureServiceMapping = types.BoolValue(apiToken.CanConfigureServiceMapping)
-	model.CanConfigureEumApplications = types.BoolValue(apiToken.CanConfigureEumApplications)
-	model.CanConfigureMobileAppMonitoring = types.BoolValue(apiToken.CanConfigureMobileAppMonitoring)
-	model.CanConfigureUsers = types.BoolValue(apiToken.CanConfigureUsers)
-	model.CanInstallNewAgents = types.BoolValue(apiToken.CanInstallNewAgents)
-	model.CanConfigureIntegrations = types.BoolValue(apiToken.CanConfigureIntegrations)
 	model.CanConfigureEventsAndAlerts = types.BoolValue(apiToken.CanConfigureEventsAndAlerts)
 	model.CanConfigureMaintenanceWindows = types.BoolValue(apiToken.CanConfigureMaintenanceWindows)
 	model.CanConfigureApplicationSmartAlerts = types.BoolValue(apiToken.CanConfigureApplicationSmartAlerts)
 	model.CanConfigureWebsiteSmartAlerts = types.BoolValue(apiToken.CanConfigureWebsiteSmartAlerts)
 	model.CanConfigureMobileAppSmartAlerts = types.BoolValue(apiToken.CanConfigureMobileAppSmartAlerts)
-	model.CanConfigureAPITokens = types.BoolValue(apiToken.CanConfigureAPITokens)
-	model.CanConfigureAgentRunMode = types.BoolValue(apiToken.CanConfigureAgentRunMode)
-	model.CanViewAuditLog = types.BoolValue(apiToken.CanViewAuditLog)
-	model.CanConfigureAgents = types.BoolValue(apiToken.CanConfigureAgents)
-	model.CanConfigureAuthenticationMethods = types.BoolValue(apiToken.CanConfigureAuthenticationMethods)
-	model.CanConfigureApplications = types.BoolValue(apiToken.CanConfigureApplications)
-	model.CanConfigureTeams = types.BoolValue(apiToken.CanConfigureTeams)
-	model.CanConfigureReleases = types.BoolValue(apiToken.CanConfigureReleases)
-	model.CanConfigureLogManagement = types.BoolValue(apiToken.CanConfigureLogManagement)
-	model.CanCreatePublicCustomDashboards = types.BoolValue(apiToken.CanCreatePublicCustomDashboards)
-	model.CanViewLogs = types.BoolValue(apiToken.CanViewLogs)
 	model.CanViewTraceDetails = types.BoolValue(apiToken.CanViewTraceDetails)
 	model.CanConfigureSessionSettings = types.BoolValue(apiToken.CanConfigureSessionSettings)
 	model.CanConfigureGlobalAlertPayload = types.BoolValue(apiToken.CanConfigureGlobalAlertPayload)
@@ -688,28 +632,11 @@ func (r *apiTokenResource) getAPITokenModelFromPlanOrState(ctx context.Context, 
 
 // mapPermissionsFromModel maps basic permissions from model to API object
 func (r *apiTokenResource) mapPermissionsFromModel(model APITokenModel, apiToken *restapi.APIToken) {
-	apiToken.CanConfigureServiceMapping = model.CanConfigureServiceMapping.ValueBool()
-	apiToken.CanConfigureEumApplications = model.CanConfigureEumApplications.ValueBool()
-	apiToken.CanConfigureMobileAppMonitoring = model.CanConfigureMobileAppMonitoring.ValueBool()
-	apiToken.CanConfigureUsers = model.CanConfigureUsers.ValueBool()
-	apiToken.CanInstallNewAgents = model.CanInstallNewAgents.ValueBool()
-	apiToken.CanConfigureIntegrations = model.CanConfigureIntegrations.ValueBool()
 	apiToken.CanConfigureEventsAndAlerts = model.CanConfigureEventsAndAlerts.ValueBool()
 	apiToken.CanConfigureMaintenanceWindows = model.CanConfigureMaintenanceWindows.ValueBool()
 	apiToken.CanConfigureApplicationSmartAlerts = model.CanConfigureApplicationSmartAlerts.ValueBool()
 	apiToken.CanConfigureWebsiteSmartAlerts = model.CanConfigureWebsiteSmartAlerts.ValueBool()
 	apiToken.CanConfigureMobileAppSmartAlerts = model.CanConfigureMobileAppSmartAlerts.ValueBool()
-	apiToken.CanConfigureAPITokens = model.CanConfigureAPITokens.ValueBool()
-	apiToken.CanConfigureAgentRunMode = model.CanConfigureAgentRunMode.ValueBool()
-	apiToken.CanViewAuditLog = model.CanViewAuditLog.ValueBool()
-	apiToken.CanConfigureAgents = model.CanConfigureAgents.ValueBool()
-	apiToken.CanConfigureAuthenticationMethods = model.CanConfigureAuthenticationMethods.ValueBool()
-	apiToken.CanConfigureApplications = model.CanConfigureApplications.ValueBool()
-	apiToken.CanConfigureTeams = model.CanConfigureTeams.ValueBool()
-	apiToken.CanConfigureReleases = model.CanConfigureReleases.ValueBool()
-	apiToken.CanConfigureLogManagement = model.CanConfigureLogManagement.ValueBool()
-	apiToken.CanCreatePublicCustomDashboards = model.CanCreatePublicCustomDashboards.ValueBool()
-	apiToken.CanViewLogs = model.CanViewLogs.ValueBool()
 	apiToken.CanViewTraceDetails = model.CanViewTraceDetails.ValueBool()
 	apiToken.CanConfigureSessionSettings = model.CanConfigureSessionSettings.ValueBool()
 	apiToken.CanConfigureGlobalAlertPayload = model.CanConfigureGlobalAlertPayload.ValueBool()
@@ -789,3 +716,28 @@ func (r *apiTokenResource) GetStateUpgraders(ctx context.Context) map[int64]reso
 		2: resourcehandle.CreateStateUpgraderForVersion(2),
 	}
 }
+
+// --- Plan Modifiers for backend-normalized permissions ---
+
+// AlwaysFalseAPITokenPlanModifier normalizes a bool attribute to false and emits a warning if user tries to set true
+type AlwaysFalseAPITokenPlanModifier struct {
+       Field string
+}
+
+func (m AlwaysFalseAPITokenPlanModifier) Description(_ context.Context) string {
+       return m.Field + " is always false for API tokens. The value will be normalized to false."
+}
+
+func (m AlwaysFalseAPITokenPlanModifier) MarkdownDescription(_ context.Context) string {
+       return m.Description(context.Background())
+}
+
+func (m AlwaysFalseAPITokenPlanModifier) PlanModifyBool(ctx context.Context, req planmodifier.BoolRequest, resp *planmodifier.BoolResponse) {
+       if req.PlanValue.ValueBool() {
+	       resp.Diagnostics.AddError(
+		       m.Field+" cannot be set to true for API tokens",
+		       "The Instana backend will always set '"+m.Field+"' to false for API tokens. Setting this to true is not allowed and will cause the plan to fail.",
+	       )
+       }
+}
+

--- a/internal/resources/apitoken/resource-api-token_planmodifier_test.go
+++ b/internal/resources/apitoken/resource-api-token_planmodifier_test.go
@@ -1,0 +1,90 @@
+package apitoken
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAlwaysFalseAPITokenPlanModifier_TrueValue_AddsError(t *testing.T) {
+	modifier := AlwaysFalseAPITokenPlanModifier{Field: "can_configure_personal_api_tokens"}
+	ctx := context.Background()
+	request := planmodifier.BoolRequest{
+		PlanValue: types.BoolValue(true),
+	}
+	response := &planmodifier.BoolResponse{}
+
+	modifier.PlanModifyBool(ctx, request, response)
+
+	assert.True(t, response.Diagnostics.HasError(), "Expected error when PlanValue is true")
+	if len(response.Diagnostics) > 0 {
+		assert.Contains(t, response.Diagnostics[0].Summary(), "cannot be set to true")
+	}
+}
+
+func TestAlwaysFalseAPITokenPlanModifier_FalseValue_NoError(t *testing.T) {
+	modifier := AlwaysFalseAPITokenPlanModifier{Field: "can_configure_personal_api_tokens"}
+	ctx := context.Background()
+	request := planmodifier.BoolRequest{
+		PlanValue: types.BoolValue(false),
+	}
+	response := &planmodifier.BoolResponse{}
+
+	modifier.PlanModifyBool(ctx, request, response)
+
+	assert.False(t, response.Diagnostics.HasError(), "Expected no error when PlanValue is false")
+}
+
+func TestAlwaysFalseAPITokenPlanModifier_UnknownValue(t *testing.T) {
+	modifier := AlwaysFalseAPITokenPlanModifier{Field: "can_configure_personal_api_tokens"}
+	ctx := context.Background()
+	request := planmodifier.BoolRequest{
+		PlanValue: types.BoolUnknown(),
+	}
+	response := &planmodifier.BoolResponse{}
+
+	modifier.PlanModifyBool(ctx, request, response)
+
+	assert.False(t, response.Diagnostics.HasError(), "Expected no error for unknown value")
+}
+
+func TestAlwaysFalseAPITokenPlanModifier_NilPlanValue(t *testing.T) {
+	modifier := AlwaysFalseAPITokenPlanModifier{Field: "can_configure_personal_api_tokens"}
+	ctx := context.Background()
+	request := planmodifier.BoolRequest{}
+	response := &planmodifier.BoolResponse{}
+
+	modifier.PlanModifyBool(ctx, request, response)
+
+	assert.False(t, response.Diagnostics.HasError(), "Expected no error for nil PlanValue (zero value)")
+}
+
+func TestAlwaysFalseAPITokenPlanModifier_AppendDiagnostics(t *testing.T) {
+	modifier := AlwaysFalseAPITokenPlanModifier{Field: "can_configure_personal_api_tokens"}
+	ctx := context.Background()
+	request := planmodifier.BoolRequest{
+		PlanValue: types.BoolValue(true),
+	}
+	response := &planmodifier.BoolResponse{}
+	response.Diagnostics.AddWarning("existing warning", "existing warning detail")
+
+	modifier.PlanModifyBool(ctx, request, response)
+
+	assert.True(t, response.Diagnostics.HasError(), "Expected error when PlanValue is true")
+	// Check that the warning is still present (should be 2 diagnostics: 1 warning, 1 error)
+	warningCount := 0
+	errorCount := 0
+	for _, d := range response.Diagnostics {
+		if d.Severity() == 1 { // 1 = Warning
+			warningCount++
+		}
+		if d.Severity() == 2 { // 2 = Error
+			errorCount++
+		}
+	}
+	assert.Equal(t, 1, warningCount, "Expected 1 warning diagnostic")
+	assert.Equal(t, 1, errorCount, "Expected 1 error diagnostic")
+}

--- a/internal/resources/apitoken/resource-api-token_test.go
+++ b/internal/resources/apitoken/resource-api-token_test.go
@@ -105,12 +105,7 @@ func TestUpdateState(t *testing.T) {
 			AccessGrantingToken:         "test-access-token",
 			InternalID:                  "test-internal-id",
 			Name:                        "test-token",
-			CanConfigureServiceMapping:  true,
-			CanConfigureUsers:           true,
-			CanInstallNewAgents:         true,
-			CanConfigureIntegrations:    true,
 			CanConfigureEventsAndAlerts: true,
-			CanViewAuditLog:             true,
 		}
 
 		handle := NewAPITokenResourceHandle()
@@ -125,12 +120,7 @@ func TestUpdateState(t *testing.T) {
 		diags = state.Get(ctx, &model)
 		require.False(t, diags.HasError())
 
-		assert.True(t, model.CanConfigureServiceMapping.ValueBool())
-		assert.True(t, model.CanConfigureUsers.ValueBool())
-		assert.True(t, model.CanInstallNewAgents.ValueBool())
-		assert.True(t, model.CanConfigureIntegrations.ValueBool())
 		assert.True(t, model.CanConfigureEventsAndAlerts.ValueBool())
-		assert.True(t, model.CanViewAuditLog.ValueBool())
 	})
 
 	t.Run("API token with scope limitations", func(t *testing.T) {
@@ -179,17 +169,6 @@ func TestUpdateState(t *testing.T) {
 		require.False(t, diags.HasError())
 
 		// Verify all permissions are true
-		assert.True(t, model.CanConfigureServiceMapping.ValueBool())
-		assert.True(t, model.CanConfigureEumApplications.ValueBool())
-		assert.True(t, model.CanConfigureMobileAppMonitoring.ValueBool())
-		assert.True(t, model.CanConfigureUsers.ValueBool())
-		assert.True(t, model.CanInstallNewAgents.ValueBool())
-		assert.True(t, model.CanConfigureAPITokens.ValueBool())
-		assert.True(t, model.CanViewAuditLog.ValueBool())
-		assert.True(t, model.CanConfigureAgents.ValueBool())
-		assert.True(t, model.CanConfigureApplications.ValueBool())
-		assert.True(t, model.CanConfigureTeams.ValueBool())
-		assert.True(t, model.CanViewLogs.ValueBool())
 		assert.True(t, model.CanViewTraceDetails.ValueBool())
 	})
 }
@@ -242,12 +221,7 @@ func TestMapStateToDataObject(t *testing.T) {
 			AccessGrantingToken:         types.StringValue("test-access-token"),
 			InternalID:                  types.StringValue("test-internal-id"),
 			Name:                        types.StringValue("test-token"),
-			CanConfigureServiceMapping:  types.BoolValue(true),
-			CanConfigureUsers:           types.BoolValue(true),
-			CanInstallNewAgents:         types.BoolValue(true),
-			CanConfigureIntegrations:    types.BoolValue(true),
 			CanConfigureEventsAndAlerts: types.BoolValue(true),
-			CanViewAuditLog:             types.BoolValue(true),
 		}
 
 		state := createMockState(t, ctx, model)
@@ -255,12 +229,7 @@ func TestMapStateToDataObject(t *testing.T) {
 		require.False(t, diags.HasError())
 		require.NotNil(t, apiToken)
 
-		assert.True(t, apiToken.CanConfigureServiceMapping)
-		assert.True(t, apiToken.CanConfigureUsers)
-		assert.True(t, apiToken.CanInstallNewAgents)
-		assert.True(t, apiToken.CanConfigureIntegrations)
 		assert.True(t, apiToken.CanConfigureEventsAndAlerts)
-		assert.True(t, apiToken.CanViewAuditLog)
 	})
 
 	t.Run("API token with scope limitations", func(t *testing.T) {
@@ -297,28 +266,11 @@ func TestMapStateToDataObject(t *testing.T) {
 		require.NotNil(t, apiToken)
 
 		// Verify all permissions
-		assert.True(t, apiToken.CanConfigureServiceMapping)
-		assert.True(t, apiToken.CanConfigureEumApplications)
-		assert.True(t, apiToken.CanConfigureMobileAppMonitoring)
-		assert.True(t, apiToken.CanConfigureUsers)
-		assert.True(t, apiToken.CanInstallNewAgents)
-		assert.True(t, apiToken.CanConfigureIntegrations)
 		assert.True(t, apiToken.CanConfigureEventsAndAlerts)
 		assert.True(t, apiToken.CanConfigureMaintenanceWindows)
 		assert.True(t, apiToken.CanConfigureApplicationSmartAlerts)
 		assert.True(t, apiToken.CanConfigureWebsiteSmartAlerts)
 		assert.True(t, apiToken.CanConfigureMobileAppSmartAlerts)
-		assert.True(t, apiToken.CanConfigureAPITokens)
-		assert.True(t, apiToken.CanConfigureAgentRunMode)
-		assert.True(t, apiToken.CanViewAuditLog)
-		assert.True(t, apiToken.CanConfigureAgents)
-		assert.True(t, apiToken.CanConfigureAuthenticationMethods)
-		assert.True(t, apiToken.CanConfigureApplications)
-		assert.True(t, apiToken.CanConfigureTeams)
-		assert.True(t, apiToken.CanConfigureReleases)
-		assert.True(t, apiToken.CanConfigureLogManagement)
-		assert.True(t, apiToken.CanCreatePublicCustomDashboards)
-		assert.True(t, apiToken.CanViewLogs)
 		assert.True(t, apiToken.CanViewTraceDetails)
 
 		// Verify scope limitations
@@ -401,8 +353,6 @@ func TestRoundTripConversion(t *testing.T) {
 		assert.Equal(t, originalAPIToken.Name, convertedAPIToken.Name)
 		assert.Equal(t, originalAPIToken.AccessGrantingToken, convertedAPIToken.AccessGrantingToken)
 		assert.Equal(t, originalAPIToken.InternalID, convertedAPIToken.InternalID)
-		assert.Equal(t, originalAPIToken.CanConfigureServiceMapping, convertedAPIToken.CanConfigureServiceMapping)
-		assert.Equal(t, originalAPIToken.CanConfigureUsers, convertedAPIToken.CanConfigureUsers)
 		assert.Equal(t, originalAPIToken.LimitedApplicationsScope, convertedAPIToken.LimitedApplicationsScope)
 		assert.Equal(t, originalAPIToken.CanConfigurePersonalAPITokens, convertedAPIToken.CanConfigurePersonalAPITokens)
 	})
@@ -449,9 +399,6 @@ func TestEdgeCases(t *testing.T) {
 		require.False(t, diags.HasError())
 
 		// Verify all permissions are false
-		assert.False(t, model.CanConfigureServiceMapping.ValueBool())
-		assert.False(t, model.CanConfigureUsers.ValueBool())
-		assert.False(t, model.CanInstallNewAgents.ValueBool())
 		assert.False(t, model.LimitedApplicationsScope.ValueBool())
 	})
 }
@@ -492,28 +439,11 @@ func createFullyPermissionedAPIToken() *api.APIToken {
 		AccessGrantingToken:                       "test-access-token",
 		InternalID:                                "test-internal-id",
 		Name:                                      "test-token",
-		CanConfigureServiceMapping:                true,
-		CanConfigureEumApplications:               true,
-		CanConfigureMobileAppMonitoring:           true,
-		CanConfigureUsers:                         true,
-		CanInstallNewAgents:                       true,
-		CanConfigureIntegrations:                  true,
 		CanConfigureEventsAndAlerts:               true,
 		CanConfigureMaintenanceWindows:            true,
 		CanConfigureApplicationSmartAlerts:        true,
 		CanConfigureWebsiteSmartAlerts:            true,
 		CanConfigureMobileAppSmartAlerts:          true,
-		CanConfigureAPITokens:                     true,
-		CanConfigureAgentRunMode:                  true,
-		CanViewAuditLog:                           true,
-		CanConfigureAgents:                        true,
-		CanConfigureAuthenticationMethods:         true,
-		CanConfigureApplications:                  true,
-		CanConfigureTeams:                         true,
-		CanConfigureReleases:                      true,
-		CanConfigureLogManagement:                 true,
-		CanCreatePublicCustomDashboards:           true,
-		CanViewLogs:                               true,
 		CanViewTraceDetails:                       true,
 		CanConfigureSessionSettings:               true,
 		CanConfigureGlobalAlertPayload:            true,
@@ -586,28 +516,11 @@ func createFullyPermissionedModel() APITokenModel {
 		AccessGrantingToken:                       types.StringValue("test-access-token"),
 		InternalID:                                types.StringValue("test-internal-id"),
 		Name:                                      types.StringValue("test-token"),
-		CanConfigureServiceMapping:                types.BoolValue(true),
-		CanConfigureEumApplications:               types.BoolValue(true),
-		CanConfigureMobileAppMonitoring:           types.BoolValue(true),
-		CanConfigureUsers:                         types.BoolValue(true),
-		CanInstallNewAgents:                       types.BoolValue(true),
-		CanConfigureIntegrations:                  types.BoolValue(true),
 		CanConfigureEventsAndAlerts:               types.BoolValue(true),
 		CanConfigureMaintenanceWindows:            types.BoolValue(true),
 		CanConfigureApplicationSmartAlerts:        types.BoolValue(true),
 		CanConfigureWebsiteSmartAlerts:            types.BoolValue(true),
 		CanConfigureMobileAppSmartAlerts:          types.BoolValue(true),
-		CanConfigureAPITokens:                     types.BoolValue(true),
-		CanConfigureAgentRunMode:                  types.BoolValue(true),
-		CanViewAuditLog:                           types.BoolValue(true),
-		CanConfigureAgents:                        types.BoolValue(true),
-		CanConfigureAuthenticationMethods:         types.BoolValue(true),
-		CanConfigureApplications:                  types.BoolValue(true),
-		CanConfigureTeams:                         types.BoolValue(true),
-		CanConfigureReleases:                      types.BoolValue(true),
-		CanConfigureLogManagement:                 types.BoolValue(true),
-		CanCreatePublicCustomDashboards:           types.BoolValue(true),
-		CanViewLogs:                               types.BoolValue(true),
 		CanViewTraceDetails:                       types.BoolValue(true),
 		CanConfigureSessionSettings:               types.BoolValue(true),
 		CanConfigureGlobalAlertPayload:            types.BoolValue(true),


### PR DESCRIPTION
## Summary
- Added backend normalization for specific permissions in the API Token resource.
- Introduced plan modifiers to enforce validation rules for boolean attributes.
- Updated API Token model to align with schema attributes.
- Refactored tests to cover new validation logic and removed deprecated permissions.

## Rationale
### errors encountered
Error: Provider produced inconsistent result after apply
When applying changes to an instana_api_token resource, the provider produced an unexpected new value:
`.can_configure_personal_api_tokens`: was true, but now false.
`.can_view_synthetic_tests`: was false, but now true.
`.limited_linux_kvm_hypervisor_scope`: was true, but now false.
This indicates a bug in the provider, where the backend overrides certain permission values based on internal rules, causing Terraform to detect a drift between the planned and actual state.

### commonality
These errors are all due to backend-enforced normalization of certain fields. The provider should enforce these rules at plan time to prevent such inconsistencies.

