### PR TITLE
Add Instana Modules section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ A comprehensive reference setup example is available to help you get started wit
 
 For detailed setup instructions and usage, see the [Reference Setup README](./examples/reference-setup/README.md).
 
+## Instana Modules
+
+The following Terraform modules are available to simplify the deployment and management of Instana agents on AWS infrastructure:
+
+| Module Name | Description | Terraform Registry | GitHub Repository |
+|-------------|-------------|-------------------|-------------------|
+| **instana-ec2-agent** | Terraform module for deploying Instana agents on AWS EC2 instances | [View on Registry](https://registry.terraform.io/modules/instana/instana-ec2-agent/aws/latest) | [View on GitHub](https://github.com/instana/terraform-aws-instana-ec2-agent) |
+| **instana-ecs-agent** | Terraform module for deploying Instana agents on AWS ECS clusters | [View on Registry](https://registry.terraform.io/modules/instana/instana-ecs-agent/aws/latest) | [View on GitHub](https://github.com/instana/terraform-aws-instana-ecs-agent) |
+
+---
+
 ---
 
 ## Migration Guide


### PR DESCRIPTION
## Summary

This PR adds a comprehensive **Instana Modules** section to the README.md file, documenting the available Terraform modules for deploying Instana agents on AWS infrastructure.

## Changes

- Added new "Instana Modules" section after the Examples section
- Created a well-formatted markdown table with the following columns:
  - Module Name
  - Description
  - Terraform Registry (with clickable links)
  - GitHub Repository (with clickable links)

## Modules Documented

1. **instana-ec2-agent**: Terraform module for deploying Instana agents on AWS EC2 instances
   - Registry: https://registry.terraform.io/modules/instana/instana-ec2-agent/aws/latest
   - GitHub: https://github.com/instana/terraform-aws-instana-ec2-agent

2. **instana-ecs-agent**: Terraform module for deploying Instana agents on AWS ECS clusters
   - Registry: https://registry.terraform.io/modules/instana/instana-ecs-agent/aws/latest
   - GitHub: https://github.com/instana/terraform-aws-instana-ecs-agent

## Benefits

- Improves discoverability of official Instana Terraform modules
- Provides direct links to both Terraform Registry and GitHub repositories
- Maintains consistent documentation style with the rest of the README
- Helps users quickly find the right module for their AWS infrastructure