### PR TITLE
Validate backend-normalized API token permissions in provider

### DIFF
--- a/docs/resources/api_token.md
+++ b/docs/resources/api_token.md
@@ -239,7 +239,6 @@ All scope limitation attributes are optional and default to `false`:
 * `limited_xen_server_scope` - Limits the scope to Xen Server
 * `limited_windows_hypervisor_scope` - Limits the scope to Windows Hypervisor
 * `limited_alert_channels_scope` - Limits the scope to alert channels
-* `limited_linux_kvm_hypervisor_scope` - Limits the scope to Linux KVM Hypervisor
 * `limited_service_level_scope` - Limits the scope to service levels
 * `limited_ai_gateway_scope` - Limits the scope to AI Gateway
 
@@ -247,7 +246,6 @@ All scope limitation attributes are optional and default to `false`:
 
 All additional permission attributes are optional and default to `false`:
 
-* `can_configure_personal_api_tokens` - Enables permission to configure personal API tokens
 * `can_configure_database_management` - Enables permission to configure database management
 * `can_configure_automation_actions` - Enables permission to configure automation actions
 * `can_configure_automation_policies` - Enables permission to configure automation policies
@@ -256,10 +254,10 @@ All additional permission attributes are optional and default to `false`:
 * `can_configure_synthetic_tests` - Enables permission to configure synthetic tests
 * `can_configure_synthetic_locations` - Enables permission to configure synthetic locations
 * `can_configure_synthetic_credentials` - Enables permission to configure synthetic credentials
-* `can_view_synthetic_tests` - Enables permission to view synthetic tests
-* `can_view_synthetic_locations` - Enables permission to view synthetic locations
-* `can_view_synthetic_test_results` - Enables permission to view synthetic test results
-* `can_use_synthetic_credentials` - Enables permission to use synthetic credentials
+* `can_view_synthetic_tests` - Enables permission to view synthetic tests (**must be true if `can_configure_synthetic_tests` is true**)
+* `can_view_synthetic_locations` - Enables permission to view synthetic locations (**must be true if `can_configure_synthetic_tests`    or     `can_configure_synthetic_locations` is true**)
+* `can_view_synthetic_test_results` - Enables permission to view synthetic test results (**must be true if `can_configure_synthetic_tests` is true**)
+* `can_use_synthetic_credentials` - Enables permission to use synthetic credentials (**must be true if `can_configure_synthetic_credentials` is true**)
 * `can_configure_bizops` - Enables permission to configure business operations
 * `can_view_business_processes` - Enables permission to view business processes
 * `can_view_business_process_details` - Enables permission to view business process details
@@ -297,6 +295,22 @@ $ terraform import instana_api_token.my_token 60845e4e5e6b9cf8fc2868da
 ```
 
 ## Notes
+
+### ⚠️ Backend-Normalized and Derived Permissions
+
+Some permissions are always normalized or derived by the Instana backend. The provider enforces these rules at plan time:
+
+- `can_configure_personal_api_tokens`: Always false for API tokens. Setting to true will cause a plan-time error.
+- `limited_linux_kvm_hypervisor_scope`: Always false. Setting to true will cause a plan-time error.
+- `can_view_synthetic_tests`: Must be true if `can_configure_synthetic_tests` is true. Setting to false in this case will cause a plan-time error.
+- `can_view_synthetic_locations`: Must be true if `can_configure_synthetic_locations` is true. Setting to false in this case will cause a plan-time error.
+- `can_view_synthetic_locations`: Must be true if `can_configure_synthetic_tests` is true. Setting to false in this case will cause a plan-time error.
+- `can_view_synthetic_test_results`: Must be true if `can_configure_synthetic_tests` is true. Setting to false in this case will cause a plan-time error.
+- `can_use_synthetic_credentials`: Must be true if `can_configure_synthetic_credentials` is true. Setting to false in this case will cause a plan-time error.
+
+
+
+If you see a plan-time error for these fields, update your Terraform configuration to match the backend-normalized value and re-run `terraform plan`.
 
 ### Token Security
 

--- a/internal/resources/apitoken/resource-api-token.go
+++ b/internal/resources/apitoken/resource-api-token.go
@@ -2,6 +2,7 @@ package apitoken
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -9,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	restapi "github.com/instana/instana-go-client/api"
@@ -308,6 +310,9 @@ func NewAPITokenResourceHandle() resourcehandle.ResourceHandle[*restapi.APIToken
 						Optional:    true,
 						Computed:    true,
 						Description: APITokenDescLimitedLinuxKvmHypervisorScope,
+						Validators: []validator.Bool{
+							FalseOnlyValidator{},
+						},
 					},
 					APITokenFieldLimitedServiceLevelScope: schema.BoolAttribute{
 						Optional:    true,
@@ -325,6 +330,9 @@ func NewAPITokenResourceHandle() resourcehandle.ResourceHandle[*restapi.APIToken
 						Optional:    true,
 						Computed:    true,
 						Description: APITokenDescCanConfigurePersonalAPITokens,
+						Validators: []validator.Bool{
+							FalseOnlyValidator{},
+						},
 					},
 					APITokenFieldCanConfigureDatabaseManagement: schema.BoolAttribute{
 						Optional:    true,
@@ -370,21 +378,50 @@ func NewAPITokenResourceHandle() resourcehandle.ResourceHandle[*restapi.APIToken
 						Optional:    true,
 						Computed:    true,
 						Description: APITokenDescCanViewSyntheticTests,
+						Validators: []validator.Bool{
+							ViewPermissionValidator{
+								RequiredBy: []string{
+									APITokenFieldCanConfigureSyntheticTests,
+								},
+							},
+						},
 					},
 					APITokenFieldCanViewSyntheticLocations: schema.BoolAttribute{
 						Optional:    true,
 						Computed:    true,
 						Description: APITokenDescCanViewSyntheticLocations,
+						Validators: []validator.Bool{
+							ViewPermissionValidator{
+								RequiredBy: []string{
+									APITokenFieldCanConfigureSyntheticLocations,
+									APITokenFieldCanConfigureSyntheticTests,
+								},
+							},
+						},
 					},
 					APITokenFieldCanViewSyntheticTestResults: schema.BoolAttribute{
 						Optional:    true,
 						Computed:    true,
 						Description: APITokenDescCanViewSyntheticTestResults,
+						Validators: []validator.Bool{
+							ViewPermissionValidator{
+								RequiredBy: []string{
+									APITokenFieldCanConfigureSyntheticTests,
+								},
+							},
+						},
 					},
 					APITokenFieldCanUseSyntheticCredentials: schema.BoolAttribute{
 						Optional:    true,
 						Computed:    true,
 						Description: APITokenDescCanUseSyntheticCredentials,
+						Validators: []validator.Bool{
+							ViewPermissionValidator{
+								RequiredBy: []string{
+									APITokenFieldCanConfigureSyntheticCredentials,
+								},
+							},
+						},
 					},
 					APITokenFieldCanConfigureBizops: schema.BoolAttribute{
 						Optional:    true,
@@ -787,5 +824,93 @@ func (r *apiTokenResource) mapAdditionalPermissionsFromModel(model APITokenModel
 func (r *apiTokenResource) GetStateUpgraders(ctx context.Context) map[int64]resource.StateUpgrader {
 	return map[int64]resource.StateUpgrader{
 		2: resourcehandle.CreateStateUpgraderForVersion(2),
+	}
+}
+
+type ViewPermissionValidator struct {
+	RequiredBy []string
+}
+
+func (v ViewPermissionValidator) Description(ctx context.Context) string {
+	return "validates that view permission cannot be false when dependent permissions are enabled"
+}
+
+func (v ViewPermissionValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v ViewPermissionValidator) ValidateBool(
+	ctx context.Context,
+	req validator.BoolRequest,
+	resp *validator.BoolResponse,
+) {
+	if req.ConfigValue.IsUnknown() || req.ConfigValue.IsNull() {
+		return
+	}
+
+	viewValue := req.ConfigValue.ValueBool()
+
+	// Only validate when view=false
+	if viewValue {
+		return
+	}
+
+	for _, attr := range v.RequiredBy {
+		var value types.Bool
+
+		diags := req.Config.GetAttribute(
+			ctx,
+			path.Root(attr),
+			&value,
+		)
+		resp.Diagnostics.Append(diags...)
+
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		if !value.IsNull() &&
+			!value.IsUnknown() &&
+			value.ValueBool() {
+
+			resp.Diagnostics.AddAttributeError(
+				req.Path,
+				"Invalid Permission Configuration",
+				fmt.Sprintf(
+					"%s cannot be false because %s is true.",
+					req.Path.String(),
+					attr,
+				),
+			)
+			return
+		}
+	}
+}
+
+type FalseOnlyValidator struct{}
+
+func (v FalseOnlyValidator) Description(ctx context.Context) string {
+	return "value must be false"
+}
+
+func (v FalseOnlyValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v FalseOnlyValidator) ValidateBool(
+	ctx context.Context,
+	req validator.BoolRequest,
+	resp *validator.BoolResponse,
+) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	if req.ConfigValue.ValueBool() {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Invalid Value",
+			"This attribute can only be set to false.",
+		)
 	}
 }

--- a/internal/resources/apitoken/resource-api-token_test.go
+++ b/internal/resources/apitoken/resource-api-token_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/instana/instana-go-client/api"
@@ -454,6 +457,227 @@ func TestEdgeCases(t *testing.T) {
 		assert.False(t, model.CanInstallNewAgents.ValueBool())
 		assert.False(t, model.LimitedApplicationsScope.ValueBool())
 	})
+}
+
+func TestFalseOnlyValidator(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("allows false", func(t *testing.T) {
+		resp := runFalseOnlyValidator(
+			t,
+			ctx,
+			types.BoolValue(false),
+		)
+
+		assert.False(t, resp.Diagnostics.HasError())
+	})
+
+	t.Run("rejects true", func(t *testing.T) {
+		resp := runFalseOnlyValidator(
+			t,
+			ctx,
+			types.BoolValue(true),
+		)
+
+		require.True(t, resp.Diagnostics.HasError())
+		assert.Contains(t, diagnosticsToString(resp.Diagnostics), "Invalid Value")
+		assert.Contains(t, diagnosticsToString(resp.Diagnostics), "This attribute can only be set to false.")
+	})
+
+	t.Run("ignores null", func(t *testing.T) {
+		resp := runFalseOnlyValidator(
+			t,
+			ctx,
+			types.BoolNull(),
+		)
+
+		assert.False(t, resp.Diagnostics.HasError())
+	})
+
+	t.Run("ignores unknown", func(t *testing.T) {
+		resp := runFalseOnlyValidator(
+			t,
+			ctx,
+			types.BoolUnknown(),
+		)
+
+		assert.False(t, resp.Diagnostics.HasError())
+	})
+}
+
+func TestViewPermissionValidator(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("allows true even when dependency is true", func(t *testing.T) {
+		resp := runViewPermissionValidator(
+			t,
+			ctx,
+			APITokenModel{
+				CanConfigureSyntheticTests: types.BoolValue(true),
+				CanViewSyntheticTests:      types.BoolValue(true),
+			},
+			APITokenFieldCanViewSyntheticTests,
+			types.BoolValue(true),
+			[]string{APITokenFieldCanConfigureSyntheticTests},
+		)
+
+		assert.False(t, resp.Diagnostics.HasError())
+	})
+
+	t.Run("allows false when dependency is false", func(t *testing.T) {
+		resp := runViewPermissionValidator(
+			t,
+			ctx,
+			APITokenModel{
+				CanConfigureSyntheticTests: types.BoolValue(false),
+				CanViewSyntheticTests:      types.BoolValue(false),
+			},
+			APITokenFieldCanViewSyntheticTests,
+			types.BoolValue(false),
+			[]string{APITokenFieldCanConfigureSyntheticTests},
+		)
+
+		assert.False(t, resp.Diagnostics.HasError())
+	})
+
+	t.Run("rejects false when dependency is true", func(t *testing.T) {
+		resp := runViewPermissionValidator(
+			t,
+			ctx,
+			APITokenModel{
+				CanConfigureSyntheticTests: types.BoolValue(true),
+				CanViewSyntheticTests:      types.BoolValue(false),
+			},
+			APITokenFieldCanViewSyntheticTests,
+			types.BoolValue(false),
+			[]string{APITokenFieldCanConfigureSyntheticTests},
+		)
+
+		require.True(t, resp.Diagnostics.HasError())
+		assert.Contains(t, diagnosticsToString(resp.Diagnostics), "Invalid Permission Configuration")
+		assert.Contains(t, diagnosticsToString(resp.Diagnostics), APITokenFieldCanViewSyntheticTests+" cannot be false because "+APITokenFieldCanConfigureSyntheticTests+" is true.")
+	})
+
+	t.Run("rejects false when any dependency is true", func(t *testing.T) {
+		resp := runViewPermissionValidator(
+			t,
+			ctx,
+			APITokenModel{
+				CanConfigureSyntheticLocations: types.BoolValue(false),
+				CanConfigureSyntheticTests:     types.BoolValue(true),
+				CanViewSyntheticLocations:      types.BoolValue(false),
+			},
+			APITokenFieldCanViewSyntheticLocations,
+			types.BoolValue(false),
+			[]string{
+				APITokenFieldCanConfigureSyntheticLocations,
+				APITokenFieldCanConfigureSyntheticTests,
+			},
+		)
+
+		require.True(t, resp.Diagnostics.HasError())
+		assert.Contains(t, diagnosticsToString(resp.Diagnostics), "Invalid Permission Configuration")
+		assert.Contains(t, diagnosticsToString(resp.Diagnostics), APITokenFieldCanViewSyntheticLocations+" cannot be false because "+APITokenFieldCanConfigureSyntheticTests+" is true.")
+	})
+
+	t.Run("ignores null", func(t *testing.T) {
+		resp := runViewPermissionValidator(
+			t,
+			ctx,
+			APITokenModel{
+				CanConfigureSyntheticTests: types.BoolValue(true),
+				CanViewSyntheticTests:      types.BoolNull(),
+			},
+			APITokenFieldCanViewSyntheticTests,
+			types.BoolNull(),
+			[]string{APITokenFieldCanConfigureSyntheticTests},
+		)
+
+		assert.False(t, resp.Diagnostics.HasError())
+	})
+
+	t.Run("ignores unknown", func(t *testing.T) {
+		resp := runViewPermissionValidator(
+			t,
+			ctx,
+			APITokenModel{
+				CanConfigureSyntheticTests: types.BoolValue(true),
+				CanViewSyntheticTests:      types.BoolUnknown(),
+			},
+			APITokenFieldCanViewSyntheticTests,
+			types.BoolUnknown(),
+			[]string{APITokenFieldCanConfigureSyntheticTests},
+		)
+
+		assert.False(t, resp.Diagnostics.HasError())
+	})
+}
+
+func runFalseOnlyValidator(
+	t *testing.T,
+	ctx context.Context,
+	configValue types.Bool,
+) validator.BoolResponse {
+	t.Helper()
+
+	resp := validator.BoolResponse{}
+	FalseOnlyValidator{}.ValidateBool(
+		ctx,
+		validator.BoolRequest{
+			ConfigValue: configValue,
+			Path:        path.Root(APITokenFieldCanConfigurePersonalAPITokens),
+		},
+		&resp,
+	)
+
+	return resp
+}
+
+func runViewPermissionValidator(
+	t *testing.T,
+	ctx context.Context,
+	model APITokenModel,
+	attributeName string,
+	configValue types.Bool,
+	requiredBy []string,
+) validator.BoolResponse {
+	t.Helper()
+
+	handle := NewAPITokenResourceHandle()
+	plan := &tfsdk.Plan{
+		Schema: handle.MetaData().Schema,
+	}
+
+	diags := plan.Set(ctx, model)
+	require.False(t, diags.HasError())
+
+	config := tfsdk.Config{
+		Raw:    plan.Raw,
+		Schema: plan.Schema,
+	}
+
+	resp := validator.BoolResponse{}
+	ViewPermissionValidator{RequiredBy: requiredBy}.ValidateBool(
+		ctx,
+		validator.BoolRequest{
+			Config:      config,
+			ConfigValue: configValue,
+			Path:        path.Root(attributeName),
+		},
+		&resp,
+	)
+
+	return resp
+}
+
+func diagnosticsToString(diags diag.Diagnostics) string {
+	result := ""
+
+	for _, diagnostic := range diags {
+		result += diagnostic.Summary() + " " + diagnostic.Detail() + "\n"
+	}
+
+	return result
 }
 
 // Helper functions


### PR DESCRIPTION
# Summary
Backend normalizes certain API token permissions during create/update, which can cause Terraform to see a different value after apply than what was configured. This change adds upfront provider validation for those known normalization rules so invalid combinations fail during planning instead of surfacing as inconsistent-result-after-apply errors.

## Changes
- add provider validation for permissions that are normalized by the backend
- reject attributes that are effectively forced to false
- reject invalid synthetic permission combinations where a dependent view permission cannot be false when the related configure permission is true
- add unit tests for the new validation behavior