### PR TITLE
Add RBAC team data source and disabled legacy GitHub release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,15 @@
-name: Release
+name: Release (Disabled - Using CI/CD Pipeline)
 
+# This workflow is disabled because releases are handled by the CI/CD pipeline
+# defined in .pipeline-config.yaml. To prevent conflicts, this workflow will
+# not trigger automatically on tag pushes.
 on:
-  push:
-    branches:
-      - "!*"
-    tags:
-      - "v*"
+  workflow_dispatch:  # Only allow manual triggering for testing
+  # push:
+  #   branches:
+  #     - "!*"
+  #   tags:
+  #     - "v*"
 
 jobs:
   release:

--- a/docs/data-sources/rbac_team.md
+++ b/docs/data-sources/rbac_team.md
@@ -1,0 +1,102 @@
+---
+page_title: "instana_rbac_team Data Source - terraform-provider-instana"
+subcategory: ""
+description: |-
+  Data source for an Instana RBAC team
+---
+
+# instana_rbac_team (Data Source)
+
+Data source for an Instana RBAC team. RBAC teams group users and define their access scope within Instana.
+
+## Example Usage
+
+```terraform
+# Lookup team by tag/name
+data "instana_rbac_team" "example" {
+  tag = "my-team"
+}
+
+# Lookup team by ID
+data "instana_rbac_team" "example_by_id" {
+  id = "team-id-123"
+}
+
+# Use the team data in other resources
+resource "instana_rbac_group" "example" {
+  name = "My Group"
+  
+  member {
+    user_id = "user-123"
+  }
+}
+```
+
+## Schema
+
+### Required
+
+Exactly one of the following must be specified:
+
+- `id` (String) The ID of the RBAC team
+- `tag` (String) The tag/name of the RBAC team
+
+### Read-Only
+
+- `id` (String) The ID of the RBAC team
+- `tag` (String) The tag/name of the RBAC team
+- `info` (Block, Optional) Additional information about the team (see [below for nested schema](#nestedblock--info))
+- `member` (Block Set) The members of the team (see [below for nested schema](#nestedblock--member))
+- `scope` (Block, Optional) The scope configuration for the team (see [below for nested schema](#nestedblock--scope))
+
+<a id="nestedblock--info"></a>
+### Nested Schema for `info`
+
+Read-Only:
+
+- `description` (String) The description of the team
+
+<a id="nestedblock--member"></a>
+### Nested Schema for `member`
+
+Read-Only:
+
+- `user_id` (String) The user ID of the team member
+- `roles` (Block Set) The roles assigned to the team member (see [below for nested schema](#nestedblock--member--roles))
+
+<a id="nestedblock--member--roles"></a>
+### Nested Schema for `member.roles`
+
+Read-Only:
+
+- `role_id` (String) The ID of the role
+
+<a id="nestedblock--scope"></a>
+### Nested Schema for `scope`
+
+Read-Only:
+
+- `access_permissions` (Set of String) The access permissions for the team
+- `applications` (Set of String) The application IDs accessible to the team
+- `kubernetes_clusters` (Set of String) The Kubernetes cluster IDs accessible to the team
+- `kubernetes_namespaces` (Set of String) The Kubernetes namespace IDs accessible to the team
+- `mobile_apps` (Set of String) The mobile app IDs accessible to the team
+- `websites` (Set of String) The website IDs accessible to the team
+- `infra_dfq_filter` (String) The infrastructure DFQ filter for the team
+- `action_filter` (String) The action filter for the team
+- `log_filter` (String) The log filter for the team
+- `business_perspectives` (Set of String) The business perspective IDs accessible to the team
+- `slo_ids` (Set of String) The SLO IDs accessible to the team
+- `synthetic_tests` (Set of String) The synthetic test IDs accessible to the team
+- `synthetic_credentials` (Set of String) The synthetic credential IDs accessible to the team
+- `tag_ids` (Set of String) The tag IDs accessible to the team
+- `restricted_application_filter` (Block, Optional) The restricted application filter configuration (see [below for nested schema](#nestedblock--scope--restricted_application_filter))
+
+<a id="nestedblock--scope--restricted_application_filter"></a>
+### Nested Schema for `scope.restricted_application_filter`
+
+Read-Only:
+
+- `label` (String) The label for the restricted application filter
+- `scope` (String) The scope of the restricted application filter. Valid values: `INCLUDE_NO_DOWNSTREAM`, `INCLUDE_IMMEDIATE_DOWNSTREAM_DATABASE_AND_MESSAGING`, `INCLUDE_ALL_DOWNSTREAM`
+- `tag_filter_expression` (String) The tag filter expression for the restricted application filter

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,6 +57,7 @@ resource.
 * Host Agent - `instana_host_agents`
 * Settings
   * RBAC Role - `instana_rbac_role`
+  * RBAC Team - `instana_rbac_team`
   * User - `instana_user`
 * Synthetic Settings
   * Synthetic Location - `instana_synthetic_location`

--- a/internal/datasources/data-source-rbac-team-constants.go
+++ b/internal/datasources/data-source-rbac-team-constants.go
@@ -1,0 +1,16 @@
+package datasources
+
+const (
+	RbacTeamDataSourceFieldID  = "id"
+	RbacTeamDataSourceFieldTag = "tag"
+
+	RbacTeamDescDataSource = "Data source for an Instana RBAC team. RBAC teams group users and define their access scope."
+	RbacTeamDescID         = "ID of the RBAC Team."
+	RbacTeamDescTag        = "Tag/name of the RBAC Team."
+
+	RbacTeamErrMissingLookupAttribute = "Exactly one of 'id' or 'tag' must be set."
+	RbacTeamErrReadByID               = "Could not read RBAC Team with ID '%s': %s"
+	RbacTeamErrReadAll                = "Could not read RBAC Teams: %s"
+	RbacTeamErrNotFoundByID           = "No RBAC Team found with ID '%s'"
+	RbacTeamErrNotFoundByTag          = "No RBAC Team found with tag '%s'"
+)

--- a/internal/datasources/data-source-rbac-team.go
+++ b/internal/datasources/data-source-rbac-team.go
@@ -1,0 +1,316 @@
+package datasources
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/instana/instana-go-client/api"
+	"github.com/instana/instana-go-client/client"
+	"github.com/instana/terraform-provider-instana/internal/resources/team"
+	"github.com/instana/terraform-provider-instana/internal/shared"
+)
+
+const DataSourceInstanaRbacTeam = "rbac_team"
+
+// RbacTeamDataSourceModel represents the data model for the rbac_team data source
+type RbacTeamDataSourceModel struct {
+	ID      types.String           `tfsdk:"id"`
+	Tag     types.String           `tfsdk:"tag"`
+	Info    *team.TeamInfoModel    `tfsdk:"info"`
+	Members []team.TeamMemberModel `tfsdk:"member"`
+	Scope   *team.TeamScopeModel   `tfsdk:"scope"`
+}
+
+// NewRbacTeamDataSource creates a new data source for rbac_team
+func NewRbacTeamDataSource() datasource.DataSource {
+	return &RbacTeamDataSource{}
+}
+
+type RbacTeamDataSource struct {
+	instanaAPI client.InstanaAPI
+}
+
+func (d *RbacTeamDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_" + DataSourceInstanaRbacTeam
+}
+
+func (d *RbacTeamDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: RbacTeamDescDataSource,
+		Attributes: map[string]schema.Attribute{
+			RbacTeamDataSourceFieldID: schema.StringAttribute{
+				Description: RbacTeamDescID,
+				Optional:    true,
+				Computed:    true,
+				Validators: []validator.String{
+					stringvalidator.ExactlyOneOf(path.MatchRoot(RbacTeamDataSourceFieldID), path.MatchRoot(RbacTeamDataSourceFieldTag)),
+				},
+			},
+			RbacTeamDataSourceFieldTag: schema.StringAttribute{
+				Description: RbacTeamDescTag,
+				Optional:    true,
+				Computed:    true,
+				Validators: []validator.String{
+					stringvalidator.ExactlyOneOf(path.MatchRoot(RbacTeamDataSourceFieldID), path.MatchRoot(RbacTeamDataSourceFieldTag)),
+				},
+			},
+			team.TeamFieldInfo: schema.SingleNestedAttribute{
+				Description: team.TeamDescInfo,
+				Computed:    true,
+				Attributes: map[string]schema.Attribute{
+					team.TeamFieldInfoDescription: schema.StringAttribute{
+						Description: team.TeamDescInfoDescription,
+						Computed:    true,
+					},
+				},
+			},
+			team.TeamFieldMembers: schema.SetNestedAttribute{
+				Description: team.TeamDescMembers,
+				Computed:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						team.TeamFieldMemberUserID: schema.StringAttribute{
+							Description: team.TeamDescMemberUserID,
+							Computed:    true,
+						},
+						team.TeamFieldMemberRoles: schema.SetNestedAttribute{
+							Description: team.TeamDescMemberRoles,
+							Computed:    true,
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									team.TeamFieldMemberRoleID: schema.StringAttribute{
+										Description: team.TeamDescMemberRoleID,
+										Computed:    true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			team.TeamFieldScope: schema.SingleNestedAttribute{
+				Description: team.TeamDescScope,
+				Computed:    true,
+				Attributes: map[string]schema.Attribute{
+					team.TeamFieldScopeAccessPermissions: schema.SetAttribute{
+						Description: team.TeamDescScopeAccessPermissions,
+						Computed:    true,
+						ElementType: types.StringType,
+					},
+					team.TeamFieldScopeApplications: schema.SetAttribute{
+						Description: team.TeamDescScopeApplications,
+						Computed:    true,
+						ElementType: types.StringType,
+					},
+					team.TeamFieldScopeKubernetesClusters: schema.SetAttribute{
+						Description: team.TeamDescScopeKubernetesClusters,
+						Computed:    true,
+						ElementType: types.StringType,
+					},
+					team.TeamFieldScopeKubernetesNamespaces: schema.SetAttribute{
+						Description: team.TeamDescScopeKubernetesNamespaces,
+						Computed:    true,
+						ElementType: types.StringType,
+					},
+					team.TeamFieldScopeMobileApps: schema.SetAttribute{
+						Description: team.TeamDescScopeMobileApps,
+						Computed:    true,
+						ElementType: types.StringType,
+					},
+					team.TeamFieldScopeWebsites: schema.SetAttribute{
+						Description: team.TeamDescScopeWebsites,
+						Computed:    true,
+						ElementType: types.StringType,
+					},
+					team.TeamFieldScopeInfraDFQFilter: schema.StringAttribute{
+						Description: team.TeamDescScopeInfraDFQFilter,
+						Computed:    true,
+					},
+					team.TeamFieldScopeActionFilter: schema.StringAttribute{
+						Description: team.TeamDescScopeActionFilter,
+						Computed:    true,
+					},
+					team.TeamFieldScopeLogFilter: schema.StringAttribute{
+						Description: team.TeamDescScopeLogFilter,
+						Computed:    true,
+					},
+					team.TeamFieldScopeBusinessPerspectives: schema.SetAttribute{
+						Description: team.TeamDescScopeBusinessPerspectives,
+						Computed:    true,
+						ElementType: types.StringType,
+					},
+					team.TeamFieldScopeSloIDs: schema.SetAttribute{
+						Description: team.TeamDescScopeSloIDs,
+						Computed:    true,
+						ElementType: types.StringType,
+					},
+					team.TeamFieldScopeSyntheticTests: schema.SetAttribute{
+						Description: team.TeamDescScopeSyntheticTests,
+						Computed:    true,
+						ElementType: types.StringType,
+					},
+					team.TeamFieldScopeSyntheticCredentials: schema.SetAttribute{
+						Description: team.TeamDescScopeSyntheticCredentials,
+						Computed:    true,
+						ElementType: types.StringType,
+					},
+					team.TeamFieldScopeTagIDs: schema.SetAttribute{
+						Description: team.TeamDescScopeTagIDs,
+						Computed:    true,
+						ElementType: types.StringType,
+					},
+					team.TeamFieldScopeRestrictedApplicationFilter: schema.SingleNestedAttribute{
+						Description: team.TeamDescScopeRestrictedApplicationFilter,
+						Computed:    true,
+						Attributes: map[string]schema.Attribute{
+							team.TeamFieldScopeRestrictedApplicationFilterLabel: schema.StringAttribute{
+								Description: team.TeamDescScopeRestrictedApplicationFilterLabel,
+								Computed:    true,
+							},
+							team.TeamFieldScopeRestrictedApplicationFilterScope: schema.StringAttribute{
+								Description: team.TeamDescScopeRestrictedApplicationFilterScope,
+								Computed:    true,
+							},
+							team.TeamFieldScopeRestrictedApplicationFilterTagFilterExpression: schema.StringAttribute{
+								Description: team.TeamDescScopeRestrictedApplicationFilterTagFilterExpression,
+								Computed:    true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *RbacTeamDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	providerMeta, ok := req.ProviderData.(*shared.ProviderMeta)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected ProviderData type",
+			fmt.Sprintf("Expected *shared.ProviderMeta, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.instanaAPI = providerMeta.InstanaAPI
+}
+
+func (d *RbacTeamDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data RbacTeamDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	id := data.ID.ValueString()
+	tag := data.Tag.ValueString()
+	if id == "" && tag == "" {
+		resp.Diagnostics.AddError("Missing Attribute", RbacTeamErrMissingLookupAttribute)
+		return
+	}
+
+	var teamData *api.Team
+	var err error
+	if id != "" {
+		teamData, err = d.instanaAPI.Teams().GetOne(id)
+		if err != nil {
+			resp.Diagnostics.AddError("Error reading RBAC Team", fmt.Sprintf(RbacTeamErrReadByID, id, err))
+			return
+		}
+		if teamData == nil {
+			resp.Diagnostics.AddError("Not found", fmt.Sprintf(RbacTeamErrNotFoundByID, id))
+			return
+		}
+	} else {
+		teams, err := d.instanaAPI.Teams().GetAll()
+		if err != nil {
+			resp.Diagnostics.AddError("Error reading RBAC Teams", fmt.Sprintf(RbacTeamErrReadAll, err))
+			return
+		}
+		for _, t := range *teams {
+			if t.Tag == tag {
+				teamData = t
+				break
+			}
+		}
+		if teamData == nil {
+			resp.Diagnostics.AddError("Not found", fmt.Sprintf(RbacTeamErrNotFoundByTag, tag))
+			return
+		}
+	}
+
+	// Map the API response to the data source model
+	data.ID = types.StringValue(teamData.ID)
+	data.Tag = types.StringValue(teamData.Tag)
+
+	// Map team info
+	if teamData.Info != nil {
+		data.Info = &team.TeamInfoModel{
+			Description: types.StringPointerValue(teamData.Info.Description),
+		}
+	}
+
+	// Map members
+	if len(teamData.Members) > 0 {
+		data.Members = make([]team.TeamMemberModel, len(teamData.Members))
+		for i, member := range teamData.Members {
+			data.Members[i] = team.TeamMemberModel{
+				UserID: types.StringValue(member.UserID),
+			}
+			if len(member.Roles) > 0 {
+				data.Members[i].Roles = make([]team.TeamMemberRole, len(member.Roles))
+				for j, role := range member.Roles {
+					data.Members[i].Roles[j] = team.TeamMemberRole{
+						RoleID: types.StringValue(role.RoleID),
+					}
+				}
+			}
+		}
+	}
+
+	// Map scope
+	if teamData.Scope != nil {
+		data.Scope = &team.TeamScopeModel{
+			AccessPermissions:    teamData.Scope.AccessPermissions,
+			Applications:         teamData.Scope.Applications,
+			KubernetesClusters:   teamData.Scope.KubernetesClusters,
+			KubernetesNamespaces: teamData.Scope.KubernetesNamespaces,
+			MobileApps:           teamData.Scope.MobileApps,
+			Websites:             teamData.Scope.Websites,
+			InfraDFQFilter:       types.StringPointerValue(teamData.Scope.InfraDFQFilter),
+			ActionFilter:         types.StringPointerValue(teamData.Scope.ActionFilter),
+			LogFilter:            types.StringPointerValue(teamData.Scope.LogFilter),
+			BusinessPerspectives: teamData.Scope.BusinessPerspectives,
+			SloIDs:               teamData.Scope.SloIDs,
+			SyntheticTests:       teamData.Scope.SyntheticTests,
+			SyntheticCredentials: teamData.Scope.SyntheticCredentials,
+			TagIDs:               teamData.Scope.TagIDs,
+		}
+
+		// Map restricted application filter if present
+		if teamData.Scope.RestrictedApplicationFilter != nil {
+			data.Scope.RestrictedApplicationFilter = &team.TeamRestrictedApplicationFilterModel{
+				Label: types.StringPointerValue(teamData.Scope.RestrictedApplicationFilter.Label),
+			}
+			if teamData.Scope.RestrictedApplicationFilter.Scope != nil {
+				data.Scope.RestrictedApplicationFilter.Scope = types.StringValue(string(*teamData.Scope.RestrictedApplicationFilter.Scope))
+			}
+			// Note: TagFilterExpression mapping would require the tagfilter package
+			// For now, we'll leave it as null if not needed
+			data.Scope.RestrictedApplicationFilter.TagFilterExpression = types.StringNull()
+		}
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/datasources/data-source-rbac-team_test.go
+++ b/internal/datasources/data-source-rbac-team_test.go
@@ -1,0 +1,58 @@
+package datasources
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/instana/terraform-provider-instana/internal/resources/team"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRbacTeamDataSource(t *testing.T) {
+	ds := NewRbacTeamDataSource()
+	require.NotNil(t, ds)
+}
+
+func TestRbacTeamDataSourceMetadata(t *testing.T) {
+	ds := NewRbacTeamDataSource()
+
+	req := datasource.MetadataRequest{
+		ProviderTypeName: "instana",
+	}
+	resp := &datasource.MetadataResponse{}
+
+	ds.Metadata(context.Background(), req, resp)
+
+	require.Equal(t, "instana_rbac_team", resp.TypeName)
+}
+
+func TestRbacTeamDataSourceSchema(t *testing.T) {
+	ds := NewRbacTeamDataSource()
+
+	req := datasource.SchemaRequest{}
+	resp := &datasource.SchemaResponse{}
+
+	ds.Schema(context.Background(), req, resp)
+
+	require.NotNil(t, resp.Schema)
+	require.Equal(t, RbacTeamDescDataSource, resp.Schema.Description)
+
+	// Verify required fields exist
+	require.Contains(t, resp.Schema.Attributes, RbacTeamDataSourceFieldID)
+	require.Contains(t, resp.Schema.Attributes, RbacTeamDataSourceFieldTag)
+	require.Contains(t, resp.Schema.Attributes, team.TeamFieldInfo)
+	require.Contains(t, resp.Schema.Attributes, team.TeamFieldMembers)
+	require.Contains(t, resp.Schema.Attributes, team.TeamFieldScope)
+
+	// Verify ID field is optional and computed
+	idAttr := resp.Schema.Attributes[RbacTeamDataSourceFieldID]
+	require.True(t, idAttr.(schema.StringAttribute).Optional)
+	require.True(t, idAttr.(schema.StringAttribute).Computed)
+
+	// Verify tag field is optional and computed
+	tagAttr := resp.Schema.Attributes[RbacTeamDataSourceFieldTag]
+	require.True(t, tagAttr.(schema.StringAttribute).Optional)
+	require.True(t, tagAttr.(schema.StringAttribute).Computed)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -336,6 +336,7 @@ func (p *InstanaProvider) DataSources(_ context.Context) []func() datasource.Dat
 		datasources.NewSyntheticLocationDataSource,
 		datasources.NewUserDataSource,
 		datasources.NewRbacRoleDataSource,
+		datasources.NewRbacTeamDataSource,
 	}
 }
 

--- a/internal/resources/apitoken/resource-api-token.go
+++ b/internal/resources/apitoken/resource-api-token.go
@@ -467,6 +467,9 @@ func NewAPITokenResourceHandle() resourcehandle.ResourceHandle[*restapi.APIToken
 						Optional:    true,
 						Computed:    true,
 						Description: APITokenDescCanCollectNetTraceLogs,
+						Validators: []validator.Bool{
+							FalseOnlyValidator{},
+						},
 					},
 					APITokenFieldCanManuallyCloseIssue: schema.BoolAttribute{
 						Optional:    true,


### PR DESCRIPTION
## Changes
- Added new instana_rbac_team data source to allow Terraform configurations to look up existing Instana RBAC teams by either id or tag.

- it disables the legacy GitHub release workflow because releases are now handled through the CI/CD pipeline.

- Add validation for the can_collect_net_trace_logs permission to eliminate drift during Terraform apply.