### PR TITLE
feat: add rbac_tags support to alerting_channel, custom_dashboard and synthetic_test resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,3 +61,5 @@ require (
 	gopkg.in/resty.v1 v1.12.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/instana/instana-go-client => ../instana-go-client

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,6 @@ github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8=
 github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
-github.com/instana/instana-go-client v1.1.0 h1:p9jNVEFnFB/sYWVFtdZxhm3gAWuMvWZzadfma1HSQyE=
-github.com/instana/instana-go-client v1.1.0/go.mod h1:aOe+HQWz3md7VSvKrdeT+aso7sxzobWuXvyaTwIos3Q=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=
 github.com/jhump/protoreflect v1.17.0/go.mod h1:h9+vUUL38jiBzck8ck+6G/aeMX8Z4QUY/NiJPwPNi+8=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/internal/resources/alertingchannel/alert-channel-constants.go
+++ b/internal/resources/alertingchannel/alert-channel-constants.go
@@ -112,6 +112,13 @@ const (
 	AlertingChannelFieldChannelSlackApp = "slack_app"
 	//AlertingChannelSlackAppFieldAppID const for the appId field of the Slack App alerting channel
 	AlertingChannelSlackAppFieldAppID = "app_id"
+	// AlertingChannelFieldRbacTags const for schema field rbac_tags
+	AlertingChannelFieldRbacTags = "rbac_tags"
+	// AlertingChannelFieldRbacTagID const for schema field rbac_tags.id
+	AlertingChannelFieldRbacTagID = "id"
+	// AlertingChannelFieldRbacTagDisplayName const for schema field rbac_tags.display_name
+	AlertingChannelFieldRbacTagDisplayName = "display_name"
+
 	//AlertingChannelSlackAppFieldTeamID const for the teamId field of the Slack App alerting channel
 	AlertingChannelSlackAppFieldTeamID = "team_id"
 	//AlertingChannelSlackAppFieldTeamName const for the teamName field of the Slack App alerting channel
@@ -224,6 +231,11 @@ const (
 	AlertingChannelDescMsTeamsAppServiceURL        = "The Service URL of the MS Teams App alerting channel"
 	AlertingChannelDescMsTeamsAppTenantID          = "The Tenant ID of the MS Teams App alerting channel"
 	AlertingChannelDescMsTeamsAppTenantName        = "The Tenant Name of the MS Teams App alerting channel"
+
+	// RBAC Tags descriptions
+	AlertingChannelDescRbacTags           = "RBAC tags (teams) the alerting channel is assigned to."
+	AlertingChannelDescRbacTagID          = "ID of the RBAC tag (team)."
+	AlertingChannelDescRbacTagDisplayName = "Display name of the RBAC tag (team)."
 
 	// Error messages
 	AlertingChannelErrUnsupportedType       = "Unsupported alerting channel type"

--- a/internal/resources/alertingchannel/alert-channel-model.go
+++ b/internal/resources/alertingchannel/alert-channel-model.go
@@ -9,6 +9,7 @@ import (
 type AlertingChannelModel struct {
 	ID                    types.String                       `tfsdk:"id"`
 	Name                  types.String                       `tfsdk:"name"`
+	RbacTags              []AlertingChannelRbacTagModel      `tfsdk:"rbac_tags"`
 	Email                 *shared.EmailModel                 `tfsdk:"email"`
 	OpsGenie              *shared.OpsGenieModel              `tfsdk:"ops_genie"`
 	PagerDuty             *shared.PagerDutyModel             `tfsdk:"pager_duty"`
@@ -25,4 +26,10 @@ type AlertingChannelModel struct {
 	WatsonAIOpsWebhook    *shared.WatsonAIOpsWebhookModel    `tfsdk:"watson_aiops_webhook"`
 	SlackApp              *shared.SlackAppModel              `tfsdk:"slack_app"`
 	MsTeamsApp            *shared.MsTeamsAppModel            `tfsdk:"ms_teams_app"`
+}
+
+// AlertingChannelRbacTagModel represents an RBAC tag (team assignment) of an alerting channel
+type AlertingChannelRbacTagModel struct {
+	ID          types.String `tfsdk:"id"`
+	DisplayName types.String `tfsdk:"display_name"`
 }

--- a/internal/resources/alertingchannel/resource-alerting-channel.go
+++ b/internal/resources/alertingchannel/resource-alerting-channel.go
@@ -41,6 +41,22 @@ func NewAlertingChannelResourceHandle() resourcehandle.ResourceHandle[*api.Alert
 						Required:    true,
 						Description: AlertingChannelDescName,
 					},
+					AlertingChannelFieldRbacTags: schema.ListNestedAttribute{
+						Description: AlertingChannelDescRbacTags,
+						Optional:    true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								AlertingChannelFieldRbacTagID: schema.StringAttribute{
+									Required:    true,
+									Description: AlertingChannelDescRbacTagID,
+								},
+								AlertingChannelFieldRbacTagDisplayName: schema.StringAttribute{
+									Required:    true,
+									Description: AlertingChannelDescRbacTagDisplayName,
+								},
+							},
+						},
+					},
 					AlertingChannelFieldChannelEmail: schema.SingleNestedAttribute{
 						Optional:    true,
 						Description: AlertingChannelDescEmail,
@@ -401,6 +417,19 @@ func (r *alertingChannelResource) UpdateState(ctx context.Context, state *tfsdk.
 	// Create base model with common fields
 	model := r.createBaseModel(alertingChannel)
 
+	// The Instana alerting channel API does not echo rbacTags back in its
+	// Create/Update response. On Create/Update (plan != nil) keep the value
+	// from the plan to avoid an "inconsistent result" error. On Read
+	// (plan == nil) populate from the API response.
+	if plan != nil {
+		var planModel AlertingChannelModel
+		diags.Append(plan.Get(ctx, &planModel)...)
+		if diags.HasError() {
+			return diags
+		}
+		model.RbacTags = planModel.RbacTags
+	}
+
 	// Map channel-specific data based on channel type
 	channelDiags := r.mapChannelTypeToModel(ctx, alertingChannel, &model)
 	if channelDiags.HasError() {
@@ -412,12 +441,43 @@ func (r *alertingChannelResource) UpdateState(ctx context.Context, state *tfsdk.
 	return diags
 }
 
-// createBaseModel creates the base model with common fields (ID and Name)
+// createBaseModel creates the base model with common fields (ID, Name and RbacTags)
 func (r *alertingChannelResource) createBaseModel(alertingChannel *api.AlertingChannel) AlertingChannelModel {
 	return AlertingChannelModel{
-		ID:   types.StringValue(alertingChannel.ID),
-		Name: types.StringValue(alertingChannel.Name),
+		ID:       types.StringValue(alertingChannel.ID),
+		Name:     types.StringValue(alertingChannel.Name),
+		RbacTags: r.mapRbacTagsToModel(alertingChannel.RbacTags),
 	}
+}
+
+// mapRbacTagsToModel converts RbacTags from the API to the model slice
+func (r *alertingChannelResource) mapRbacTagsToModel(rbacTags []api.RbacTag) []AlertingChannelRbacTagModel {
+	if len(rbacTags) == 0 {
+		return nil
+	}
+	models := make([]AlertingChannelRbacTagModel, len(rbacTags))
+	for i, tag := range rbacTags {
+		models[i] = AlertingChannelRbacTagModel{
+			ID:          types.StringValue(tag.ID),
+			DisplayName: types.StringValue(tag.DisplayName),
+		}
+	}
+	return models
+}
+
+// mapRbacTagsFromModel converts RbacTags from the model slice to the API format
+func (r *alertingChannelResource) mapRbacTagsFromModel(models []AlertingChannelRbacTagModel) []api.RbacTag {
+	if len(models) == 0 {
+		return nil
+	}
+	tags := make([]api.RbacTag, len(models))
+	for i, m := range models {
+		tags[i] = api.RbacTag{
+			ID:          m.ID.ValueString(),
+			DisplayName: m.DisplayName.ValueString(),
+		}
+	}
+	return tags
 }
 
 // mapChannelTypeToModel maps the API channel data to the appropriate model field based on channel type
@@ -996,7 +1056,13 @@ func (r *alertingChannelResource) MapStateToDataObject(ctx context.Context, plan
 	id, name := r.extractCommonFields(model)
 
 	// Map the configured channel type to API object
-	return r.mapConfiguredChannelType(ctx, model, id, name)
+	channel, diags := r.mapConfiguredChannelType(ctx, model, id, name)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	// Apply rbac_tags from the model
+	return r.applyRbacTags(channel, model), diags
 }
 
 // getModelFromPlanOrState retrieves the model from either plan or state
@@ -1023,7 +1089,8 @@ func (r *alertingChannelResource) extractCommonFields(model AlertingChannelModel
 	return id, name
 }
 
-// mapConfiguredChannelType determines which channel type is configured and maps it to API object
+// mapConfiguredChannelType determines which channel type is configured and maps it to API object.
+// It also sets RbacTags from the model on the returned object.
 func (r *alertingChannelResource) mapConfiguredChannelType(ctx context.Context, model AlertingChannelModel, id, name string) (*api.AlertingChannel, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
@@ -1083,6 +1150,12 @@ func (r *alertingChannelResource) mapConfiguredChannelType(ctx context.Context, 
 		AlertingChannelErrInvalidConfigMsg,
 	)
 	return nil, diags
+}
+
+// applyRbacTags sets RbacTags on the channel object and returns it
+func (r *alertingChannelResource) applyRbacTags(channel *api.AlertingChannel, model AlertingChannelModel) *api.AlertingChannel {
+	channel.RbacTags = r.mapRbacTagsFromModel(model.RbacTags)
+	return channel
 }
 
 // GetStateUpgraders returns the state upgraders for this resource

--- a/internal/resources/customdashboard/custom-dashboard-model.go
+++ b/internal/resources/customdashboard/custom-dashboard-model.go
@@ -10,6 +10,7 @@ type CustomDashboardModel struct {
 	ID          types.String         `tfsdk:"id"`
 	Title       types.String         `tfsdk:"title"`
 	AccessRules []AccessRuleModel    `tfsdk:"access_rule"`
+	RbacTags    []RbacTagModel       `tfsdk:"rbac_tags"`
 	Widgets     jsontypes.Normalized `tfsdk:"widgets"`
 }
 
@@ -18,4 +19,10 @@ type AccessRuleModel struct {
 	AccessType   types.String `tfsdk:"access_type"`
 	RelatedID    types.String `tfsdk:"related_id"`
 	RelationType types.String `tfsdk:"relation_type"`
+}
+
+// RbacTagModel represents an RBAC tag of the custom dashboard
+type RbacTagModel struct {
+	DisplayName types.String `tfsdk:"display_name"`
+	ID          types.String `tfsdk:"id"`
 }

--- a/internal/resources/customdashboard/resource-custom-dashboard-constants.go
+++ b/internal/resources/customdashboard/resource-custom-dashboard-constants.go
@@ -18,6 +18,12 @@ const (
 	CustomDashboardFieldAccessRuleRelationType = "relation_type"
 	//CustomDashboardFieldWidgets constant value for the schema field widgets
 	CustomDashboardFieldWidgets = "widgets"
+	//CustomDashboardFieldRbacTags constant value for the schema field rbac_tags
+	CustomDashboardFieldRbacTags = "rbac_tags"
+	//CustomDashboardFieldRbacTagDisplayName constant value for the schema field rbac_tags.display_name
+	CustomDashboardFieldRbacTagDisplayName = "display_name"
+	//CustomDashboardFieldRbacTagID constant value for the schema field rbac_tags.id
+	CustomDashboardFieldRbacTagID = "id"
 )
 
 // Resource description
@@ -35,6 +41,11 @@ const CustomDashboardDescAccessRule = "The access rules applied to the custom da
 const CustomDashboardDescAccessRuleAccessType = "The access type of the given access rule."
 const CustomDashboardDescAccessRuleRelatedID = "The id of the related entity (user, api_token, etc.) of the given access rule."
 const CustomDashboardDescAccessRuleRelationType = "The relation type of the given access rule."
+
+// Field descriptions - RBAC Tags
+const CustomDashboardDescRbacTags = "RBAC tags (teams) the custom dashboard is assigned to."
+const CustomDashboardDescRbacTagDisplayName = "Display name of the RBAC tag (team)."
+const CustomDashboardDescRbacTagID = "ID of the RBAC tag (team)."
 
 // Error messages
 const CustomDashboardErrMarshalWidgets = "Error marshaling widgets"

--- a/internal/resources/customdashboard/resource-custom-dashboard.go
+++ b/internal/resources/customdashboard/resource-custom-dashboard.go
@@ -81,6 +81,22 @@ func NewCustomDashboardResourceHandle() resourcehandle.ResourceHandle[*api.Custo
 							},
 						},
 					},
+					CustomDashboardFieldRbacTags: schema.ListNestedAttribute{
+						Description: CustomDashboardDescRbacTags,
+						Optional:    true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								CustomDashboardFieldRbacTagID: schema.StringAttribute{
+									Required:    true,
+									Description: CustomDashboardDescRbacTagID,
+								},
+								CustomDashboardFieldRbacTagDisplayName: schema.StringAttribute{
+									Required:    true,
+									Description: CustomDashboardDescRbacTagDisplayName,
+								},
+							},
+						},
+					},
 				},
 			},
 			SchemaVersion: 2,
@@ -154,6 +170,17 @@ func (r *customDashboardResource) UpdateState(ctx context.Context, state *tfsdk.
 	// Map access rules
 	model.AccessRules = r.mapAccessRulesToState(dashboard.AccessRules)
 
+	// Map RBAC tags (team assignments). The Instana create/update API does not
+	// echo rbacTags back in its response, so on Create/Update (plan != nil) we
+	// keep the configured value to avoid an "inconsistent result" error. On
+	// Read (plan == nil) we populate from the API. This mirrors the widgets
+	// handling above.
+	if plan != nil {
+		// keep model.RbacTags as provided by the plan
+	} else {
+		model.RbacTags = r.mapRbacTagsToState(dashboard.RbacTags)
+	}
+
 	// Set the entire model to state
 	diags.Append(state.Set(ctx, model)...)
 	return diags
@@ -177,9 +204,22 @@ func (r *customDashboardResource) mapAccessRulesToState(accessRules []model.Acce
 	return models
 }
 
-// ============================================================================
-// State to API Mapping
-// ============================================================================
+// mapRbacTagsToState converts RBAC tags from API format to state models
+func (r *customDashboardResource) mapRbacTagsToState(rbacTags []api.RbacTag) []RbacTagModel {
+	if len(rbacTags) == 0 {
+		return nil
+	}
+
+	models := make([]RbacTagModel, len(rbacTags))
+	for i, tag := range rbacTags {
+		models[i] = RbacTagModel{
+			DisplayName: types.StringValue(tag.DisplayName),
+			ID:          types.StringValue(tag.ID),
+		}
+	}
+
+	return models
+}
 
 // MapStateToDataObject converts Terraform state to API data object
 func (r *customDashboardResource) MapStateToDataObject(ctx context.Context, plan *tfsdk.Plan, state *tfsdk.State) (*api.CustomDashboard, diag.Diagnostics) {
@@ -217,6 +257,7 @@ func (r *customDashboardResource) MapStateToDataObject(ctx context.Context, plan
 		ID:          id,
 		Title:       model.Title.ValueString(),
 		AccessRules: accessRules,
+		RbacTags:    r.mapRbacTagsFromState(model.RbacTags),
 		Widgets:     widgets,
 	}, diags
 }
@@ -248,6 +289,23 @@ func (r *customDashboardResource) mapAccessRulesFromState(accessRuleModels []Acc
 	}
 
 	return accessRules
+}
+
+// mapRbacTagsFromState converts RBAC tag models from state to API format
+func (r *customDashboardResource) mapRbacTagsFromState(rbacTagModels []RbacTagModel) []api.RbacTag {
+	if len(rbacTagModels) == 0 {
+		return nil
+	}
+
+	rbacTags := make([]api.RbacTag, len(rbacTagModels))
+	for i, tagModel := range rbacTagModels {
+		rbacTags[i] = api.RbacTag{
+			DisplayName: tagModel.DisplayName.ValueString(),
+			ID:          tagModel.ID.ValueString(),
+		}
+	}
+
+	return rbacTags
 }
 
 // GetStateUpgraders returns the state upgraders for this resource

--- a/internal/resources/syntheticalertconfig/resource-synthetic-alert-config.go
+++ b/internal/resources/syntheticalertconfig/resource-synthetic-alert-config.go
@@ -455,9 +455,9 @@ func (r *syntheticAlertConfigResource) mapTagFilterFromModel(model *SyntheticAle
 	return r.createDefaultTagFilter(), diags
 }
 
-// hasTagFilterValue checks if the model has a tag filter value
+// hasTagFilterValue checks if the model has a non-empty tag filter value
 func (r *syntheticAlertConfigResource) hasTagFilterValue(model *SyntheticAlertConfigModel) bool {
-	return !model.TagFilter.IsNull() && !model.TagFilter.IsUnknown()
+	return !model.TagFilter.IsNull() && !model.TagFilter.IsUnknown() && model.TagFilter.ValueString() != ""
 }
 
 // parseTagFilterExpression parses the tag filter expression string

--- a/internal/resources/synthetictest/resource-synthetic-test.go
+++ b/internal/resources/synthetictest/resource-synthetic-test.go
@@ -603,13 +603,13 @@ func buildBaseSchema() map[string]schema.Attribute {
 			Description: SyntheticTestDescRbacTags,
 			NestedObject: schema.NestedAttributeObject{
 				Attributes: map[string]schema.Attribute{
-					SyntheticTestFieldName: schema.StringAttribute{
+					"id": schema.StringAttribute{
 						Required:    true,
-						Description: SyntheticTestDescTagName,
+						Description: "ID of the RBAC tag",
 					},
-					SyntheticTestFieldValue: schema.StringAttribute{
+					"display_name": schema.StringAttribute{
 						Required:    true,
-						Description: SyntheticTestDescTagValue,
+						Description: "Display name of the RBAC tag",
 					},
 				},
 			},
@@ -794,17 +794,17 @@ func (r *syntheticTestResource) mapLocationsFromModel(ctx context.Context, model
 }
 
 // mapRbacTagsFromModel maps RBAC tags from model
-func (r *syntheticTestResource) mapRbacTagsFromModel(ctx context.Context, model SyntheticTestModel) ([]api.ApiTag, diag.Diagnostics) {
+func (r *syntheticTestResource) mapRbacTagsFromModel(ctx context.Context, model SyntheticTestModel) ([]api.RbacTag, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	var rbacTags []api.ApiTag
+	var rbacTags []api.RbacTag
 	if !model.RbacTags.IsNull() && !model.RbacTags.IsUnknown() {
 		var rbacTagModels []RbacTagModel
 		diags.Append(model.RbacTags.ElementsAs(ctx, &rbacTagModels, false)...)
 		if !diags.HasError() {
 			for _, tagModel := range rbacTagModels {
-				rbacTags = append(rbacTags, api.ApiTag{
-					Name:  tagModel.Name.ValueString(),
-					Value: tagModel.Value.ValueString(),
+				rbacTags = append(rbacTags, api.RbacTag{
+					DisplayName: tagModel.DisplayName.ValueString(),
+					ID:          tagModel.ID.ValueString(),
 				})
 			}
 		}
@@ -1289,7 +1289,8 @@ func (r *syntheticTestResource) mapCustomPropertiesToModel(apiObject *api.Synthe
 		}
 		return types.MapValueMust(types.StringType, customPropertiesMap)
 	}
-	return types.MapNull(types.StringType)
+	// Return empty map (not null) to stay consistent with plan when custom_properties = {}
+	return types.MapValueMust(types.StringType, map[string]attr.Value{})
 }
 
 // mapLocationsToModel maps locations array to model
@@ -1306,33 +1307,28 @@ func (r *syntheticTestResource) mapLocationsToModel(apiObject *api.SyntheticTest
 
 // mapRbacTagsToModel maps RBAC tags to model
 func (r *syntheticTestResource) mapRbacTagsToModel(apiObject *api.SyntheticTest) types.Set {
+	tagAttrTypes := map[string]attr.Type{
+		"display_name": types.StringType,
+		"id":           types.StringType,
+	}
 	if len(apiObject.RbacTags) > 0 {
 		rbacTagValues := make([]attr.Value, len(apiObject.RbacTags))
 		for i, tag := range apiObject.RbacTags {
 			tagObj, _ := types.ObjectValue(
-				map[string]attr.Type{
-					SyntheticTestFieldName:  types.StringType,
-					SyntheticTestFieldValue: types.StringType,
-				},
+				tagAttrTypes,
 				map[string]attr.Value{
-					SyntheticTestFieldName:  types.StringValue(tag.Name),
-					SyntheticTestFieldValue: types.StringValue(tag.Value),
+					"display_name": types.StringValue(tag.DisplayName),
+					"id":           types.StringValue(tag.ID),
 				},
 			)
 			rbacTagValues[i] = tagObj
 		}
 		return types.SetValueMust(
-			types.ObjectType{AttrTypes: map[string]attr.Type{
-				SyntheticTestFieldName:  types.StringType,
-				SyntheticTestFieldValue: types.StringType,
-			}},
+			types.ObjectType{AttrTypes: tagAttrTypes},
 			rbacTagValues,
 		)
 	}
-	return types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
-		SyntheticTestFieldName:  types.StringType,
-		SyntheticTestFieldValue: types.StringType,
-	}})
+	return types.SetNull(types.ObjectType{AttrTypes: tagAttrTypes})
 }
 
 // mapHttpActionConfigToModel maps HTTP Action configuration to model

--- a/internal/resources/synthetictest/resource-synthetic-test_test.go
+++ b/internal/resources/synthetictest/resource-synthetic-test_test.go
@@ -161,8 +161,8 @@ func TestMapStateToDataObject(t *testing.T) {
 			PlaybackMode:     types.StringValue("Simultaneous"),
 			TestFrequency:    types.Int64Null(),
 			RbacTags: types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
-				"name":  types.StringType,
-				"value": types.StringType,
+				"id":           types.StringType,
+				"display_name": types.StringType,
 			}}),
 			HttpAction: &HttpActionConfigModel{
 				MarkSyntheticCall: types.BoolValue(false),
@@ -224,8 +224,8 @@ func TestMapStateToDataObject(t *testing.T) {
 			PlaybackMode:     types.StringValue("Simultaneous"),
 			TestFrequency:    types.Int64Null(),
 			RbacTags: types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
-				"name":  types.StringType,
-				"value": types.StringType,
+				"id":           types.StringType,
+				"display_name": types.StringType,
 			}}),
 			HttpScript: &HttpScriptConfigModel{
 				MarkSyntheticCall: types.BoolValue(false),
@@ -270,8 +270,8 @@ func TestMapStateToDataObject(t *testing.T) {
 			PlaybackMode:     types.StringValue("Simultaneous"),
 			TestFrequency:    types.Int64Null(),
 			RbacTags: types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
-				"name":  types.StringType,
-				"value": types.StringType,
+				"id":           types.StringType,
+				"display_name": types.StringType,
 			}}),
 			BrowserScript: &BrowserScriptConfigModel{
 				MarkSyntheticCall: types.BoolValue(false),
@@ -318,8 +318,8 @@ func TestMapStateToDataObject(t *testing.T) {
 			PlaybackMode:     types.StringValue("Simultaneous"),
 			TestFrequency:    types.Int64Null(),
 			RbacTags: types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
-				"name":  types.StringType,
-				"value": types.StringType,
+				"id":           types.StringType,
+				"display_name": types.StringType,
 			}}),
 			DNS: &DNSConfigModel{
 				MarkSyntheticCall: types.BoolValue(false),
@@ -375,8 +375,8 @@ func TestMapStateToDataObject(t *testing.T) {
 			PlaybackMode:     types.StringValue("Simultaneous"),
 			TestFrequency:    types.Int64Null(),
 			RbacTags: types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
-				"name":  types.StringType,
-				"value": types.StringType,
+				"id":           types.StringType,
+				"display_name": types.StringType,
 			}}),
 			SSLCertificate: &SSLCertificateConfigModel{
 				MarkSyntheticCall:    types.BoolValue(false),
@@ -427,8 +427,8 @@ func TestMapStateToDataObject(t *testing.T) {
 			PlaybackMode:     types.StringValue("Simultaneous"),
 			TestFrequency:    types.Int64Null(),
 			RbacTags: types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
-				"name":  types.StringType,
-				"value": types.StringType,
+				"id":           types.StringType,
+				"display_name": types.StringType,
 			}}),
 			WebpageAction: &WebpageActionConfigModel{
 				MarkSyntheticCall: types.BoolValue(false),
@@ -473,8 +473,8 @@ func TestMapStateToDataObject(t *testing.T) {
 			PlaybackMode:     types.StringValue("Simultaneous"),
 			TestFrequency:    types.Int64Null(),
 			RbacTags: types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
-				"name":  types.StringType,
-				"value": types.StringType,
+				"id":           types.StringType,
+				"display_name": types.StringType,
 			}}),
 			WebpageScript: &WebpageScriptConfigModel{
 				MarkSyntheticCall: types.BoolValue(false),
@@ -520,8 +520,8 @@ func TestMapStateToDataObject(t *testing.T) {
 			PlaybackMode:     types.StringValue("Simultaneous"),
 			TestFrequency:    types.Int64Null(),
 			RbacTags: types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
-				"name":  types.StringType,
-				"value": types.StringType,
+				"id":           types.StringType,
+				"display_name": types.StringType,
 			}}),
 		}
 
@@ -556,8 +556,8 @@ func TestMapStateToDataObject(t *testing.T) {
 			PlaybackMode:     types.StringValue("Simultaneous"),
 			TestFrequency:    types.Int64Null(),
 			RbacTags: types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
-				"name":  types.StringType,
-				"value": types.StringType,
+				"id":           types.StringType,
+				"display_name": types.StringType,
 			}}),
 			HttpAction: &HttpActionConfigModel{
 				MarkSyntheticCall: types.BoolValue(false),
@@ -609,12 +609,12 @@ func TestMapStateToDataObject(t *testing.T) {
 		rbacTags := []attr.Value{
 			types.ObjectValueMust(
 				map[string]attr.Type{
-					"name":  types.StringType,
-					"value": types.StringType,
+					"id":           types.StringType,
+					"display_name": types.StringType,
 				},
 				map[string]attr.Value{
-					"name":  types.StringValue("dept"),
-					"value": types.StringValue("eng"),
+					"id":           types.StringValue("dept"),
+					"display_name": types.StringValue("eng"),
 				},
 			),
 		}
@@ -630,8 +630,8 @@ func TestMapStateToDataObject(t *testing.T) {
 			CustomProperties: types.MapNull(types.StringType),
 			RbacTags: types.SetValueMust(
 				types.ObjectType{AttrTypes: map[string]attr.Type{
-					"name":  types.StringType,
-					"value": types.StringType,
+					"id":           types.StringType,
+					"display_name": types.StringType,
 				}},
 				rbacTags,
 			),
@@ -708,8 +708,8 @@ func TestMapStateToDataObject(t *testing.T) {
 			PlaybackMode:     types.StringValue("Simultaneous"),
 			TestFrequency:    types.Int64Null(),
 			RbacTags: types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
-				"name":  types.StringType,
-				"value": types.StringType,
+				"id":           types.StringType,
+				"display_name": types.StringType,
 			}}),
 			HttpAction: &HttpActionConfigModel{
 				MarkSyntheticCall: types.BoolValue(false),
@@ -783,8 +783,8 @@ func TestMapStateToDataObject(t *testing.T) {
 			PlaybackMode:     types.StringValue("Simultaneous"),
 			TestFrequency:    types.Int64Null(),
 			RbacTags: types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
-				"name":  types.StringType,
-				"value": types.StringType,
+				"id":           types.StringType,
+				"display_name": types.StringType,
 			}}),
 			DNS: &DNSConfigModel{
 				MarkSyntheticCall: types.BoolValue(false),
@@ -850,8 +850,8 @@ func TestMapStateToDataObject(t *testing.T) {
 			PlaybackMode:     types.StringValue("Simultaneous"),
 			TestFrequency:    types.Int64Null(),
 			RbacTags: types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
-				"name":  types.StringType,
-				"value": types.StringType,
+				"id":           types.StringType,
+				"display_name": types.StringType,
 			}}),
 			HttpAction: &HttpActionConfigModel{
 				MarkSyntheticCall: types.BoolValue(false),
@@ -917,8 +917,8 @@ func TestMapStateToDataObject(t *testing.T) {
 			PlaybackMode:     types.StringValue("Simultaneous"),
 			TestFrequency:    types.Int64Null(),
 			RbacTags: types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
-				"name":  types.StringType,
-				"value": types.StringType,
+				"id":           types.StringType,
+				"display_name": types.StringType,
 			}}),
 			SSLCertificate: &SSLCertificateConfigModel{
 				MarkSyntheticCall:    types.BoolValue(false),
@@ -1559,7 +1559,7 @@ func TestUpdateState(t *testing.T) {
 			Applications: []string{},
 			MobileApps:   []string{},
 			Websites:     []string{},
-			RbacTags:     []api.ApiTag{},
+			RbacTags:     []api.RbacTag{},
 			Configuration: api.SyntheticTestConfig{
 				MarkSyntheticCall: false,
 				Retries:           0,
@@ -1654,7 +1654,8 @@ func TestUpdateState(t *testing.T) {
 		var model SyntheticTestModel
 		diags = state.Get(ctx, &model)
 		assert.False(t, diags.HasError())
-		assert.True(t, model.CustomProperties.IsNull())
+		assert.False(t, model.CustomProperties.IsNull())
+		assert.Equal(t, 0, len(model.CustomProperties.Elements()))
 	})
 
 	t.Run("should update state with HTTP Action empty Headers and ExpectJson", func(t *testing.T) {
@@ -1789,8 +1790,8 @@ func TestUpdateState(t *testing.T) {
 			CustomProperties: map[string]string{
 				"env": "prod",
 			},
-			RbacTags: []api.ApiTag{
-				{Name: "dept", Value: "eng"},
+			RbacTags: []api.RbacTag{
+				{ID: "dept", DisplayName: "eng"},
 			},
 			Configuration: api.SyntheticTestConfig{
 				MarkSyntheticCall: false,
@@ -1856,8 +1857,8 @@ func TestMapStateToDataObjectEdgeCases(t *testing.T) {
 			PlaybackMode:     types.StringValue("Simultaneous"),
 			TestFrequency:    types.Int64Null(),
 			RbacTags: types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
-				"name":  types.StringType,
-				"value": types.StringType,
+				"id":           types.StringType,
+				"display_name": types.StringType,
 			}}),
 			HttpAction: &HttpActionConfigModel{
 				MarkSyntheticCall: types.BoolValue(false),
@@ -2147,8 +2148,8 @@ func TestMapConfigurationOptionalFields(t *testing.T) {
 			PlaybackMode:     types.StringValue("Simultaneous"),
 			TestFrequency:    types.Int64Null(),
 			RbacTags: types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
-				"name":  types.StringType,
-				"value": types.StringType,
+				"id":           types.StringType,
+				"display_name": types.StringType,
 			}}),
 			HttpScript: &HttpScriptConfigModel{
 				MarkSyntheticCall: types.BoolValue(false),
@@ -2197,8 +2198,8 @@ func TestMapConfigurationOptionalFields(t *testing.T) {
 			PlaybackMode:     types.StringValue("Simultaneous"),
 			TestFrequency:    types.Int64Null(),
 			RbacTags: types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
-				"name":  types.StringType,
-				"value": types.StringType,
+				"id":           types.StringType,
+				"display_name": types.StringType,
 			}}),
 			BrowserScript: &BrowserScriptConfigModel{
 				MarkSyntheticCall: types.BoolValue(false),
@@ -2249,8 +2250,8 @@ func TestMapConfigurationOptionalFields(t *testing.T) {
 			PlaybackMode:     types.StringValue("Simultaneous"),
 			TestFrequency:    types.Int64Null(),
 			RbacTags: types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
-				"name":  types.StringType,
-				"value": types.StringType,
+				"id":           types.StringType,
+				"display_name": types.StringType,
 			}}),
 			DNS: &DNSConfigModel{
 				MarkSyntheticCall: types.BoolValue(false),
@@ -2308,8 +2309,8 @@ func TestMapConfigurationOptionalFields(t *testing.T) {
 			PlaybackMode:     types.StringValue("Simultaneous"),
 			TestFrequency:    types.Int64Null(),
 			RbacTags: types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
-				"name":  types.StringType,
-				"value": types.StringType,
+				"id":           types.StringType,
+				"display_name": types.StringType,
 			}}),
 			SSLCertificate: &SSLCertificateConfigModel{
 				MarkSyntheticCall:    types.BoolValue(false),
@@ -2473,7 +2474,7 @@ func initializeEmptyState(t *testing.T, ctx context.Context, state *tfsdk.State)
 		Locations:        types.SetNull(types.StringType),
 		PlaybackMode:     types.StringNull(),
 		TestFrequency:    types.Int64Null(),
-		RbacTags:         types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{"name": types.StringType, "value": types.StringType}}),
+		RbacTags:         types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{"id": types.StringType, "display_name": types.StringType}}),
 		HttpAction:       nil,
 		HttpScript:       nil,
 		BrowserScript:    nil,

--- a/internal/resources/synthetictest/synthetic-test-model.go
+++ b/internal/resources/synthetictest/synthetic-test-model.go
@@ -30,8 +30,8 @@ type SyntheticTestModel struct {
 
 // RbacTagModel represents an RBAC tag
 type RbacTagModel struct {
-	Name  types.String `tfsdk:"name"`
-	Value types.String `tfsdk:"value"`
+	DisplayName types.String `tfsdk:"display_name"`
+	ID          types.String `tfsdk:"id"`
 }
 
 // MultipleScriptsModel represents multiple scripts configuration

--- a/internal/shared/custom-payload-field.go
+++ b/internal/shared/custom-payload-field.go
@@ -118,9 +118,10 @@ func GetStaticOnlyCustomPayloadFieldsSchema() schema.ListNestedAttribute {
 func CustomPayloadFieldsToTerraform(ctx context.Context, fields []model.CustomPayloadField[any]) (types.List, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	// If no fields, return null list
+	// If no fields, return empty list (not null) to avoid "inconsistent result" errors
+	// when Terraform planned an empty list and the API returns no fields.
 	if len(fields) == 0 {
-		return types.ListNull(GetCustomPayloadFieldType()), diags
+		return types.ListValueMust(GetCustomPayloadFieldType(), []attr.Value{}), diags
 	}
 
 	// Convert API fields to a slice of maps that can be used with ObjectValueFrom


### PR DESCRIPTION
## Summary

This PR reflects **my local changes** made to unblock our team's use of RBAC tag (team) assignment for resources that currently don't support it. We are actively using these resources and will definitely need RBAC tag support to properly manage access control across our Instana setup.

I implemented these changes locally so we can use them — sharing them here in case they are useful to others or to the maintainers.

---

## What this PR does

### New `rbac_tags` block for three resources

```hcl
rbac_tags {
  id           = "team-id"
  display_name = "My Team"
}
```

- **`instana_alerting_channel`** — new `rbac_tags` nested block
- **`instana_custom_dashboard`** — new `rbac_tags` nested block
- **`instana_synthetic_test`** — aligned `rbac_tags` with `RbacTag` struct (`id`/`display_name` fields)

### Bug fix

- **`CustomPayloadFieldsToTerraform`** — fixed returning `null` instead of an empty list when no custom payload fields are present. This caused `Provider produced inconsistent result after apply` errors for `instana_slo_alert_config` and `instana_synthetic_alert_config` when `custom_payload_fields` was not configured.

---

## Note to maintainers

**Please, do not feel obligated to merge this.** Feel free to close it, cancel it, adjust the approach, or use it as a reference — whatever fits best with the project direction.

That said — it would be really valuable if `rbac_tags` were officially supported across **all** resources. For teams like ours, assigning teams to every resource is essential for access control. Right now only some resources support it, which creates inconsistency.

---

## Dependencies

Requires Go client changes:
**instana/instana-go-client#6**

> **Note:** The `go.mod` currently contains a local `replace` directive pointing to the local Go client — this needs to be updated to the released version before any potential merge.