### PR TITLE
Provide default value for smart alert rule

### DIFF
--- a/docs/resources/website_alert_config.md
+++ b/docs/resources/website_alert_config.md
@@ -421,7 +421,7 @@ Exactly one of the following rule types must be configured:
 * `metric_name` - Required - Metric name (e.g., `jsErrors`)
 * `aggregation` - Optional - Aggregation function. Values: `sum`, `mean`, `max`, `min`, `p25`, `p50`, `p75`, `p90`, `p95`, `p98`, `p99`
 * `operator` - Required - Comparison operator. Values: `EQUALS`, `NOT_EQUAL`, `CONTAINS`, `NOT_CONTAIN`, `IS_EMPTY`, `NOT_EMPTY`, `IS_BLANK`, `NOT_BLANK`, `STARTS_WITH`, `ENDS_WITH`, `NOT_STARTS_WITH`, `NOT_ENDS_WITH`, `GREATER_OR_EQUAL_THAN`, `LESS_OR_EQUAL_THAN`, `GREATER_THAN`, `LESS_THAN`
-* `value` - Optional - Value to identify the specific JavaScript error
+* `value` - Optional - Value to identify the specific JavaScript error. Defaults to `Any` when `operator = "NOT_EMPTY"`
 
 #### Status Code Rule Reference
 

--- a/internal/resources/websitealertconfig/resource-website-alert-config-constants.go
+++ b/internal/resources/websitealertconfig/resource-website-alert-config-constants.go
@@ -199,6 +199,7 @@ const (
 	WebsiteAlertConfigDefaultTriggering  = false
 	WebsiteAlertConfigDefaultEnabled     = true
 	WebsiteAlertConfigDefaultGranularity = 600000
+	WebsiteAlertConfigDefaultRuleValueAny = "Any"
 )
 
 // Validation limit constants

--- a/internal/resources/websitealertconfig/resource-website-alert-config.go
+++ b/internal/resources/websitealertconfig/resource-website-alert-config.go
@@ -535,6 +535,10 @@ func (r *websiteAlertConfigResource) mapSpecificJsErrorRule(specificJsErrorModel
 	if !specificJsErrorModel.Value.IsNull() && !specificJsErrorModel.Value.IsUnknown() {
 		value := specificJsErrorModel.Value.ValueString()
 		valuePtr = &value
+	} else if operator == common.NotEmptyOperator {
+		// For NOT_EMPTY, Instana UI expects an explicit "Any" value.
+		defaultValue := WebsiteAlertConfigDefaultRuleValueAny
+		valuePtr = &defaultValue
 	}
 
 	return &api.WebsiteAlertRule{
@@ -834,11 +838,17 @@ func (r *websiteAlertConfigResource) mapRuleToState(ctx context.Context, rule *a
 		}
 		websiteAlertRuleModel.StatusCode = &websiteAlertRuleConfigModel
 	case WebsiteAlertConfigAlertTypeSpecificJsError:
+		value := rule.Value
+		if rule.Operator != nil && *rule.Operator == common.NotEmptyOperator && (value == nil || *value == "") {
+			defaultValue := WebsiteAlertConfigDefaultRuleValueAny
+			value = &defaultValue
+		}
+
 		websiteAlertRuleConfigModel := WebsiteAlertRuleConfigCompleteModel{
 			MetricName:  types.StringValue(rule.MetricName),
 			Aggregation: types.StringValue(string(*rule.Aggregation)),
 			Operator:    types.StringValue(string(*rule.Operator)),
-			Value:       util.SetStringPointerToState(rule.Value),
+			Value:       util.SetStringPointerToState(value),
 		}
 		websiteAlertRuleModel.SpecificJsError = &websiteAlertRuleConfigModel
 

--- a/internal/resources/websitealertconfig/resource-website-alert-config_test.go
+++ b/internal/resources/websitealertconfig/resource-website-alert-config_test.go
@@ -819,6 +819,61 @@ func TestMapStateToDataObject_AllRuleTypes(t *testing.T) {
 		assert.NotNil(t, result.TimeThreshold.UserPercentage)
 		assert.NotNil(t, result.TimeThreshold.Users)
 	})
+
+	t.Run("should default specific js error value to Any when operator is NOT_EMPTY", func(t *testing.T) {
+		model := WebsiteAlertConfigModel{
+			ID:          types.StringValue("test-id"),
+			Name:        types.StringValue("Test"),
+			Description: types.StringValue("Desc"),
+			Triggering:  types.BoolValue(true),
+			WebsiteID:   types.StringValue("website-1"),
+			TagFilter:   types.StringNull(),
+			Granularity: types.Int64Value(600000),
+			Rules: []RuleWithThresholdPluginModel{
+				{
+					Rule: &WebsiteAlertRuleModel{
+						SpecificJsError: &WebsiteAlertRuleConfigCompleteModel{
+							MetricName:  types.StringValue("jsErrors"),
+							Aggregation: types.StringValue("SUM"),
+							Operator:    types.StringValue("NOT_EMPTY"),
+							Value:       types.StringNull(),
+						},
+					},
+					ThresholdOperator: types.StringValue(">="),
+					Thresholds: &shared.ThresholdAllPluginModel{
+						Warning: &shared.ThresholdAllTypeModel{
+							Static: &shared.StaticTypeModel{
+								Value: types.Float64Value(1),
+							},
+						},
+					},
+				},
+			},
+			TimeThreshold: &WebsiteTimeThresholdModel{
+				ViolationsInSequence: &WebsiteViolationsInSequenceModel{
+					TimeWindow: types.Int64Value(300000),
+				},
+			},
+		}
+
+		alertChannelIds, _ := types.SetValueFrom(ctx, types.StringType, []string{"channel-1"})
+		model.AlertChannelIDs = alertChannelIds
+		model.CustomPayloadFields = types.ListNull(shared.GetCustomPayloadFieldType())
+
+		state := &tfsdk.State{
+			Schema: resource.metaData.Schema,
+		}
+		diags := state.Set(ctx, model)
+		require.False(t, diags.HasError())
+
+		result, resultDiags := resource.MapStateToDataObject(ctx, nil, state)
+
+		assert.False(t, resultDiags.HasError())
+		assert.NotNil(t, result)
+		assert.Len(t, result.Rules, 1)
+		require.NotNil(t, result.Rules[0].Rule.Value)
+		assert.Equal(t, WebsiteAlertConfigDefaultRuleValueAny, *result.Rules[0].Rule.Value)
+	})
 }
 
 func TestUpdateState_AllRuleTypes(t *testing.T) {
@@ -999,6 +1054,60 @@ func TestUpdateState_AllRuleTypes(t *testing.T) {
 		assert.Len(t, model.Rules, 1)
 		assert.NotNil(t, model.Rules[0].Rule.SpecificJsError)
 		assert.NotNil(t, model.TimeThreshold.UserImpactOfViolationsInSequence)
+	})
+
+	t.Run("should normalize specific js error value to Any when API omits value for NOT_EMPTY", func(t *testing.T) {
+		severity := 5
+		aggregation := common.Aggregation("SUM")
+		operator := common.NotEmptyOperator
+		apiObject := &api.WebsiteAlertConfig{
+			ID:          "api-id",
+			Name:        "JS Error Alert",
+			Description: "JS Error Description",
+			Severity:    &severity,
+			Triggering:  true,
+			WebsiteID:   "website-1",
+			Granularity: 600000,
+			TimeThreshold: api.WebsiteTimeThreshold{
+				Type:       "violationsInSequence",
+				TimeWindow: func() *int64 { v := int64(300000); return &v }(),
+			},
+			CustomerPayloadFields: []common.CustomPayloadField[any]{},
+			Rules: []api.WebsiteAlertRuleWithThresholds{
+				{
+					Rule: &api.WebsiteAlertRule{
+						AlertType:   "specificJsError",
+						MetricName:  "jsErrors",
+						Aggregation: &aggregation,
+						Operator:    &operator,
+						Value:       nil,
+					},
+					ThresholdOperator: ">=",
+					Thresholds: map[common.AlertSeverity]common.ThresholdRule{
+						common.WarningSeverity: {
+							Type:  "staticThreshold",
+							Value: func() *float64 { v := float64(1); return &v }(),
+						},
+					},
+				},
+			},
+		}
+
+		state := &tfsdk.State{
+			Schema: resource.metaData.Schema,
+		}
+
+		initializeEmptyState(t, ctx, state)
+
+		diags := resource.UpdateState(ctx, state, nil, apiObject)
+		assert.False(t, diags.HasError())
+
+		var model WebsiteAlertConfigModel
+		diags = state.Get(ctx, &model)
+		assert.False(t, diags.HasError())
+		assert.Len(t, model.Rules, 1)
+		require.NotNil(t, model.Rules[0].Rule.SpecificJsError)
+		assert.Equal(t, WebsiteAlertConfigDefaultRuleValueAny, model.Rules[0].Rule.SpecificJsError.Value.ValueString())
 	})
 }
 


### PR DESCRIPTION
Omitting a value for `value` causes the a configuration to be set that breaks the GUI as the value for the "Value" field is missing.

<img width="1359" height="1285" alt="image" src="https://github.com/user-attachments/assets/1d63be8d-a4f7-4776-add7-5c73affbd696" />


Since this field is declared optional in the docs, defaulting to "Any" provides a safe default that doesn't break anyone's workflow...