### PR TITLE
Add Apdex smart alert support to instana_slo_alert_config

### DIFF
--- a/docs/resources/slo_alert_config.md
+++ b/docs/resources/slo_alert_config.md
@@ -243,8 +243,8 @@ terraform apply
 * `description` - Required - The description of the SLO Alert configuration
 * `severity` - Required - The severity of the alert when triggered. Must be `5` for warning or `10` for critical
 * `alert_type` - Required - The type of Smart Alert. Allowed values: `status`, `error_budget`, `burn_rate_v2`, `apdex_score`
-* `slo_ids` - Optional - A set of SLO IDs to monitor. Mutually exclusive with `apdex_ids`. Required when using SLO alert types (`status`, `error_budget`, `burn_rate_v2`)
-* `apdex_ids` - Optional - A set of Apdex configuration IDs to monitor. Mutually exclusive with `slo_ids`. Required when `alert_type` is `apdex_score`
+* `slo_ids` - Optional - A set of SLO IDs to monitor. Mutually exclusive with `apdex_ids`. Optional when using SLO alert types (`status`, `error_budget`, `burn_rate_v2`)
+* `apdex_ids` - Optional - A set of Apdex configuration IDs to monitor. Mutually exclusive with `slo_ids`. Optional when `alert_type` is `apdex_score`
 * `alert_channel_ids` - Required - A set of alert channel IDs to send notifications to
 * `triggering` - Optional - Flag to indicate whether to trigger an incident. Default: `false`
 * `threshold` - Optional - Configuration block defining the threshold for the alert condition. Required for `status`, `error_budget`, and `apdex_score` alert types [Details](#threshold-reference)

--- a/docs/resources/slo_alert_config.md
+++ b/docs/resources/slo_alert_config.md
@@ -1,6 +1,6 @@
-# SLO Smart Alert Configuration Resource
+# SLO & Apdex Smart Alert Configuration Resource
 
-Management of Smart Alerts for Service Level Objectives (SLOs) to trigger notifications when specific thresholds are surpassed, such as SLO status, the percentage of error budget consumed, or the error budget burn rate. Additionally, you can customize the alert by selecting one or more alert channels, adding custom payloads, or setting time-based thresholds.
+Management of Smart Alerts for Service Level Objectives (SLOs) and Apdex configurations to trigger notifications when specific thresholds are surpassed, such as SLO status, the percentage of error budget consumed, the error budget burn rate, or the Apdex score. Additionally, you can customize the alert by selecting one or more alert channels, adding custom payloads, or setting time-based thresholds.
 
 API Documentation: <https://instana.github.io/openapi/#tag/Service-Levels-Alert-Configuration>
 
@@ -165,6 +165,34 @@ resource "instana_slo_alert_config" "burn_rate_single" {
   }
 }
 ```
+
+### Apdex Score Alert
+
+Monitor Apdex score and alert when it falls below a threshold. Use `alert_type = "apdex_score"` with `apdex_ids` referencing one or more Apdex configuration IDs. `slo_ids` and `apdex_ids` are mutually exclusive — leave `slo_ids` empty (or omit it) for Apdex alerts:
+
+```hcl
+resource "instana_slo_alert_config" "apdex_score_alert" {
+  name = "Apdex Score Alert"
+  description = "Alert when Apdex score drops below 0.95"
+  severity = 5
+  triggering = false
+  alert_type = "apdex_score"
+  apdex_ids = ["APDKf9ClVQLTkKSVDUPaQLJhg"] # replace with valid apdex config ids
+  alert_channel_ids = [] # replace with valid channel ids
+
+  threshold = {
+    type = "staticThreshold"
+    operator = "<="
+    value = 0.95
+  }
+
+  time_threshold = {
+    warm_up = 60000
+    cool_down = 60000
+  }
+}
+```
+
 ## Generating Configuration from Existing Resources
 
 If you have already created a SLO alert configuration in Instana and want to generate the Terraform configuration for it, you can use Terraform's import block feature with the `-generate-config-out` flag.
@@ -214,13 +242,14 @@ terraform apply
 * `name` - Required - The name of the SLO Alert configuration (max 256 characters)
 * `description` - Required - The description of the SLO Alert configuration
 * `severity` - Required - The severity of the alert when triggered. Must be `5` for warning or `10` for critical
-* `alert_type` - Required - The type of Smart Alert. Allowed values: `status`, `error_budget`, `burn_rate_v2`
-* `slo_ids` - Required - A set of SLO IDs to monitor. Must contain at least one ID
+* `alert_type` - Required - The type of Smart Alert. Allowed values: `status`, `error_budget`, `burn_rate_v2`, `apdex_score`
+* `slo_ids` - Optional - A set of SLO IDs to monitor. Mutually exclusive with `apdex_ids`. Required when using SLO alert types (`status`, `error_budget`, `burn_rate_v2`)
+* `apdex_ids` - Optional - A set of Apdex configuration IDs to monitor. Mutually exclusive with `slo_ids`. Required when `alert_type` is `apdex_score`
 * `alert_channel_ids` - Required - A set of alert channel IDs to send notifications to
 * `triggering` - Optional - Flag to indicate whether to trigger an incident. Default: `false`
-* `threshold` - Optional - Configuration block defining the threshold for the alert condition. Required for `status` and `error_budget` alert types [Details](#threshold-reference)
+* `threshold` - Optional - Configuration block defining the threshold for the alert condition. Required for `status`, `error_budget`, and `apdex_score` alert types [Details](#threshold-reference)
 * `time_threshold` - Required - Configuration block defining the time threshold for triggering and suppressing alerts [Details](#time-threshold-reference)
-* `burn_rate_config` - Optional - List of burn rate configurations and alerting windows. Required for `alert_type` set to `burn_rate_v2` [Details](#burn-rate-config-reference)
+* `burn_rate_config` - Optional - List of burn rate configurations and alerting windows. Required for `alert_type` set to `burn_rate_v2`. Not applicable for `apdex_score` [Details](#burn-rate-config-reference)
 * `custom_payload_fields` - Optional - List of custom payload fields to include in the alert notification [Details](#custom-payload-fields-reference)
 
 ### Threshold Reference
@@ -229,7 +258,7 @@ The alert is triggered when the threshold is evaluated by the value and operator
 
 * `type` - Optional - The type of threshold. Default: `staticThreshold`. Allowed values: `staticThreshold`
 * `operator` - Required - The operator used to evaluate the threshold. Allowed values: `>`, `>=`, `=`, `<=`, `<`
-* `value` - Required - The threshold value for the alert condition (float)
+* `value` - Required - The threshold value for the alert condition (float). For `apdex_score` alerts this is a value between `0.0` and `1.0`
 
 ### Time Threshold Reference
 
@@ -240,7 +269,7 @@ If the alert is triggered, after the warm-up period, a notification will be gene
 
 ### Burn Rate Config Reference
 
-The `burn_rate_config` block is applicable only for burn rate alerts (i.e., when `alert_type` = `burn_rate_v2`). This setting is required in such cases.
+The `burn_rate_config` block is applicable only for burn rate alerts (i.e., when `alert_type` = `burn_rate_v2`). This setting is required in such cases. It is **not** applicable for `apdex_score` alerts.
 
 Currently, two types of burn rate alert configurations are supported:
 - **Single Window, Single Threshold**: Uses a single threshold and a single alerting window
@@ -270,11 +299,11 @@ Each burn rate configuration object contains:
 
 ## Attributes Reference
 
-* `id` - The ID of the SLO alert configuration
+* `id` - The ID of the alert configuration
 
 ## Import
 
-SLO alert configurations can be imported using the `id`, e.g.:
+SLO and Apdex alert configurations can be imported using the `id`, e.g.:
 
 ```bash
 $ terraform import instana_slo_alert_config.example 60845e4e5e6b9cf8fc2868da
@@ -283,13 +312,16 @@ $ terraform import instana_slo_alert_config.example 60845e4e5e6b9cf8fc2868da
 ## Notes
 
 * The ID is auto-generated by Instana
+* **`slo_ids` and `apdex_ids` are mutually exclusive** — only one may be non-empty at a time or both can be empty.
 * Use `status` alert type to monitor SLO compliance status
 * Use `error_budget` alert type to monitor error budget consumption percentage
 * Use `burn_rate_v2` alert type to monitor the rate at which error budget is being consumed
+* Use `apdex_score` alert type to monitor Apdex score for application or website entities, Apdex alerts use the `SCORE` metric
+* For `apdex_score` alerts, the `threshold.value` is a float between `0.0` (worst) and `1.0` (perfect). Typical production targets are `0.9` or higher
 * Burn rate alerts with multiple windows trigger only when ALL configured windows breach their thresholds (AND logic)
 * The `warm_up` period prevents alert flapping by requiring sustained violations
 * The `cool_down` period prevents premature alert closure
 * Custom payload fields can include both static values and dynamic tag values
 * Severity level 5 is for warnings, severity level 10 is for critical alerts
-* Multiple SLOs can be monitored with a single alert configuration
+* Multiple SLOs (or multiple Apdex configurations) can be monitored with a single alert configuration
 * The `triggering` flag controls whether the alert creates incidents in Instana

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.18.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.36.1
-	github.com/instana/instana-go-client v1.1.0
+	github.com/instana/instana-go-client v1.1.1
 	github.com/rs/xid v1.5.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,8 @@ github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8
 github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
 github.com/instana/instana-go-client v1.1.0 h1:p9jNVEFnFB/sYWVFtdZxhm3gAWuMvWZzadfma1HSQyE=
 github.com/instana/instana-go-client v1.1.0/go.mod h1:aOe+HQWz3md7VSvKrdeT+aso7sxzobWuXvyaTwIos3Q=
+github.com/instana/instana-go-client v1.1.1 h1:g6U459jz0tLTBo0PyYroij7lYOquSwcbbOQDi+s/9Bc=
+github.com/instana/instana-go-client v1.1.1/go.mod h1:aOe+HQWz3md7VSvKrdeT+aso7sxzobWuXvyaTwIos3Q=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=
 github.com/jhump/protoreflect v1.17.0/go.mod h1:h9+vUUL38jiBzck8ck+6G/aeMX8Z4QUY/NiJPwPNi+8=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/internal/resources/sloalertconfig/resource-slo-alert-config-constants.go
+++ b/internal/resources/sloalertconfig/resource-slo-alert-config-constants.go
@@ -15,6 +15,7 @@ const (
 	SloAlertConfigFieldThresholdOperator               = "operator"
 	SloAlertConfigFieldThresholdValue                  = "value"
 	SloAlertConfigFieldSloIds                          = "slo_ids"
+	SloAlertConfigFieldApdexIds                        = "apdex_ids"
 	SloAlertConfigFieldAlertChannelIds                 = "alert_channel_ids"
 	SloAlertConfigFieldTimeThreshold                   = "time_threshold"
 	SloAlertConfigFieldTimeThresholdWarmUp             = "warm_up"
@@ -30,6 +31,8 @@ const (
 	SloAlertConfigStatus      = "status"
 	SloAlertConfigErrorBudget = "error_budget"
 	SloAlertConfigBurnRateV2  = "burn_rate_v2"
+	// SloAlertConfigApdexScore is the Terraform alert_type value for Apdex smart alerts
+	SloAlertConfigApdexScore = "apdex_score"
 
 	// Resource description constants
 
@@ -46,9 +49,11 @@ const (
 	// SloAlertConfigDescTriggering is the description for the triggering field
 	SloAlertConfigDescTriggering = "Optional flag to indicate whether also an Incident is triggered or not. The default is false"
 	// SloAlertConfigDescAlertType is the description for the alert_type field
-	SloAlertConfigDescAlertType = "What do you want to be alerted on? (Type of Smart Alert: status, error_budget, burn_rate_v2)"
+	SloAlertConfigDescAlertType = "What do you want to be alerted on? (Type of Smart Alert: status, error_budget, burn_rate_v2, apdex_score)"
 	// SloAlertConfigDescSloIds is the description for the slo_ids field
-	SloAlertConfigDescSloIds = "The SLO IDs that are monitored"
+	SloAlertConfigDescSloIds = "The SLO IDs that are monitored. Mutually exclusive with apdex_ids."
+	// SloAlertConfigDescApdexIds is the description for the apdex_ids field
+	SloAlertConfigDescApdexIds = "The Apdex configuration IDs that are monitored. Mutually exclusive with slo_ids. Optional when alert_type is apdex_score."
 	// SloAlertConfigDescAlertChannelIds is the description for the alert_channel_ids field
 	SloAlertConfigDescAlertChannelIds = "The IDs of the Alert Channels"
 	// SloAlertConfigDescThreshold is the description for the threshold block
@@ -98,6 +103,8 @@ const (
 	APIAlertTypeServiceLevelsObjective = "SERVICE_LEVELS_OBJECTIVE"
 	// APIAlertTypeErrorBudget represents the ERROR_BUDGET API alert type
 	APIAlertTypeErrorBudget = "ERROR_BUDGET"
+	// APIAlertTypeApdex represents the APDEX API alert type
+	APIAlertTypeApdex = "APDEX"
 
 	// API Metric constants
 
@@ -109,6 +116,8 @@ const (
 	APIMetricBurnRate = "BURN_RATE"
 	// APIMetricBurnRateV2 represents the BURN_RATE_V2 API metric
 	APIMetricBurnRateV2 = "BURN_RATE_V2"
+	// APIMetricScore represents the SCORE API metric used for Apdex smart alerts
+	APIMetricScore = "SCORE"
 
 	// Threshold operator constants
 
@@ -146,6 +155,8 @@ const (
 	SchemaFieldAlertType = "alert_type"
 	// SchemaFieldSloIds represents the slo_ids field identifier
 	SchemaFieldSloIds = "slo_ids"
+	// SchemaFieldApdexIds represents the apdex_ids field identifier
+	SchemaFieldApdexIds = "apdex_ids"
 	// SchemaFieldAlertChannelIds represents the alert_channel_ids field identifier
 	SchemaFieldAlertChannelIds = "alert_channel_ids"
 	// SchemaFieldCustomPayloadFields represents the custom_payload_fields field identifier
@@ -200,4 +211,8 @@ const (
 	AlertTypeBurnRateV2Alt1 = "burnRateV2"
 	// AlertTypeBurnRateV2Alt2 represents alternative naming for burn_rate_v2
 	AlertTypeBurnRateV2Alt2 = "BurnRateV2"
+	// AlertTypeApdexScoreAlt1 represents alternative naming for apdex_score
+	AlertTypeApdexScoreAlt1 = "apdexScore"
+	// AlertTypeApdexScoreAlt2 represents alternative naming for apdex_score
+	AlertTypeApdexScoreAlt2 = "ApdexScore"
 )

--- a/internal/resources/sloalertconfig/resource-slo-alert-config.go
+++ b/internal/resources/sloalertconfig/resource-slo-alert-config.go
@@ -329,8 +329,8 @@ func (r *sloAlertConfigResource) UpdateState(ctx context.Context, state *tfsdk.S
 
 	model.Threshold = r.mapThresholdToState(sloAlertConfig.Threshold)
 	model.TimeThreshold = r.mapTimeThresholdToState(sloAlertConfig.TimeThreshold)
-	model.SloIds = r.mapStringSliceToSet(sloAlertConfig.SloIds)
-	model.ApdexIds = r.mapStringSliceToSet(sloAlertConfig.ApdexIds)
+	model.SloIds = r.mapStringSliceToSetPreservingNull(model.SloIds, sloAlertConfig.SloIds)
+	model.ApdexIds = r.mapStringSliceToSetPreservingNull(model.ApdexIds, sloAlertConfig.ApdexIds)
 	model.AlertChannelIds = r.mapStringSliceToSet(sloAlertConfig.AlertChannelIds)
 
 	if len(model.BurnRateConfig) == 0 {
@@ -411,6 +411,22 @@ func (r *sloAlertConfigResource) mapTimeThresholdToState(timeThreshold api.SloAl
 
 // mapStringSliceToSet converts a string slice to a Terraform set
 func (r *sloAlertConfigResource) mapStringSliceToSet(values []string) types.Set {
+	attrValues := make([]attr.Value, 0, len(values))
+	for _, value := range values {
+		attrValues = append(attrValues, types.StringValue(value))
+	}
+	return types.SetValueMust(types.StringType, attrValues)
+}
+
+// mapStringSliceToSetPreservingNull converts a string slice to a Terraform set,
+// but preserves null if the original value was null and the API returns nil/empty
+func (r *sloAlertConfigResource) mapStringSliceToSetPreservingNull(originalSet types.Set, values []string) types.Set {
+	// If the original was null and API returns nil or empty, keep it null
+	if originalSet.IsNull() && (values == nil || len(values) == 0) {
+		return types.SetNull(types.StringType)
+	}
+
+	// Otherwise, convert to set (even if empty)
 	attrValues := make([]attr.Value, 0, len(values))
 	for _, value := range values {
 		attrValues = append(attrValues, types.StringValue(value))

--- a/internal/resources/sloalertconfig/resource-slo-alert-config.go
+++ b/internal/resources/sloalertconfig/resource-slo-alert-config.go
@@ -49,6 +49,7 @@ func buildSloAlertConfigSchema() schema.Schema {
 			SchemaFieldTriggering:          buildTriggeringAttribute(),
 			SchemaFieldAlertType:           buildAlertTypeAttribute(),
 			SchemaFieldSloIds:              buildSloIdsAttribute(),
+			SchemaFieldApdexIds:            buildApdexIdsAttribute(),
 			SchemaFieldAlertChannelIds:     buildAlertChannelIdsAttribute(),
 			SchemaFieldCustomPayloadFields: shared.GetCustomPayloadFieldsSchema(),
 			SchemaFieldThreshold:           buildThresholdAttribute(),
@@ -111,7 +112,7 @@ func buildAlertTypeAttribute() schema.StringAttribute {
 		Required:    true,
 		Description: SloAlertConfigDescAlertType,
 		Validators: []validator.String{
-			stringvalidator.OneOf(SloAlertConfigStatus, SloAlertConfigErrorBudget, SloAlertConfigBurnRateV2),
+			stringvalidator.OneOf(SloAlertConfigStatus, SloAlertConfigErrorBudget, SloAlertConfigBurnRateV2, SloAlertConfigApdexScore),
 		},
 	}
 }
@@ -119,8 +120,17 @@ func buildAlertTypeAttribute() schema.StringAttribute {
 // buildSloIdsAttribute creates the slo_ids field schema attribute
 func buildSloIdsAttribute() schema.SetAttribute {
 	return schema.SetAttribute{
-		Required:    true,
+		Optional:    true,
 		Description: SloAlertConfigDescSloIds,
+		ElementType: types.StringType,
+	}
+}
+
+// buildApdexIdsAttribute creates the apdex_ids field schema attribute
+func buildApdexIdsAttribute() schema.SetAttribute {
+	return schema.SetAttribute{
+		Optional:    true,
+		Description: SloAlertConfigDescApdexIds,
 		ElementType: types.StringType,
 	}
 }
@@ -320,6 +330,7 @@ func (r *sloAlertConfigResource) UpdateState(ctx context.Context, state *tfsdk.S
 	model.Threshold = r.mapThresholdToState(sloAlertConfig.Threshold)
 	model.TimeThreshold = r.mapTimeThresholdToState(sloAlertConfig.TimeThreshold)
 	model.SloIds = r.mapStringSliceToSet(sloAlertConfig.SloIds)
+	model.ApdexIds = r.mapStringSliceToSet(sloAlertConfig.ApdexIds)
 	model.AlertChannelIds = r.mapStringSliceToSet(sloAlertConfig.AlertChannelIds)
 
 	if len(model.BurnRateConfig) == 0 {
@@ -359,6 +370,10 @@ func (r *sloAlertConfigResource) mapAPIAlertTypeToTerraform(rule api.SloAlertRul
 		if rule.Metric == APIMetricBurnRate {
 			return SloAlertConfigErrorBudget
 		}
+	}
+
+	if rule.AlertType == APIAlertTypeApdex && rule.Metric == APIMetricScore {
+		return SloAlertConfigApdexScore
 	}
 
 	return ""
@@ -440,6 +455,9 @@ func (r *sloAlertConfigResource) MapStateToDataObject(ctx context.Context, plan 
 	sloIds, sloIdsDiags := r.mapSetToStringSlice(ctx, model.SloIds)
 	diags.Append(sloIdsDiags...)
 
+	apdexIds, apdexIdsDiags := r.mapSetToStringSlice(ctx, model.ApdexIds)
+	diags.Append(apdexIdsDiags...)
+
 	alertChannelIds, channelIdsDiags := r.mapSetToStringSlice(ctx, model.AlertChannelIds)
 	diags.Append(channelIdsDiags...)
 
@@ -463,6 +481,7 @@ func (r *sloAlertConfigResource) MapStateToDataObject(ctx context.Context, plan 
 		Threshold:             threshold,
 		TimeThreshold:         timeThreshold,
 		SloIds:                sloIds,
+		ApdexIds:              apdexIds,
 		AlertChannelIds:       alertChannelIds,
 		CustomerPayloadFields: customPayloadFields,
 		BurnRateConfigs:       &burnRateConfigs,
@@ -510,6 +529,11 @@ func (r *sloAlertConfigResource) mapAlertTypeToAPIRule(terraformAlertType string
 			AlertType: APIAlertTypeErrorBudget,
 			Metric:    APIMetricBurnRateV2,
 		}, diags
+	case SloAlertConfigApdexScore:
+		return api.SloAlertRule{
+			AlertType: APIAlertTypeApdex,
+			Metric:    APIMetricScore,
+		}, diags
 	default:
 		diags.AddError(
 			SloAlertConfigErrMappingAlertType,
@@ -528,6 +552,8 @@ func (r *sloAlertConfigResource) normalizeAlertType(alertType string) string {
 		return SloAlertConfigStatus
 	case AlertTypeBurnRateV2Alt1, AlertTypeBurnRateV2Alt2:
 		return SloAlertConfigBurnRateV2
+	case AlertTypeApdexScoreAlt1, AlertTypeApdexScoreAlt2:
+		return SloAlertConfigApdexScore
 	default:
 		return alertType
 	}

--- a/internal/resources/sloalertconfig/resource-slo-alert-config_test.go
+++ b/internal/resources/sloalertconfig/resource-slo-alert-config_test.go
@@ -421,6 +421,7 @@ func TestMapStateToDataObject_StatusAlertType(t *testing.T) {
 			types.StringValue("slo-1"),
 			types.StringValue("slo-2"),
 		}),
+		ApdexIds: types.SetNull(types.StringType),
 		AlertChannelIds: types.SetValueMust(types.StringType, []attr.Value{
 			types.StringValue("channel-1"),
 		}),
@@ -476,6 +477,7 @@ func TestMapStateToDataObject_ErrorBudgetAlertType(t *testing.T) {
 		SloIds: types.SetValueMust(types.StringType, []attr.Value{
 			types.StringValue("slo-3"),
 		}),
+		ApdexIds: types.SetNull(types.StringType),
 		AlertChannelIds: types.SetValueMust(types.StringType, []attr.Value{
 			types.StringValue("channel-2"),
 			types.StringValue("channel-3"),
@@ -522,6 +524,7 @@ func TestMapStateToDataObject_BurnRateV2AlertType(t *testing.T) {
 			types.StringValue("slo-4"),
 			types.StringValue("slo-5"),
 		}),
+		ApdexIds: types.SetNull(types.StringType),
 		AlertChannelIds: types.SetValueMust(types.StringType, []attr.Value{
 			types.StringValue("channel-4"),
 		}),
@@ -638,12 +641,13 @@ func TestMapStateToDataObject_WithNormalizedAlertTypes(t *testing.T) {
 				SloIds: types.SetValueMust(types.StringType, []attr.Value{
 					types.StringValue("slo-1"),
 				}),
+				ApdexIds: types.SetNull(types.StringType),
 				AlertChannelIds: types.SetValueMust(types.StringType, []attr.Value{
 					types.StringValue("channel-1"),
 				}),
 				CustomPayload: types.ListNull(shared.GetCustomPayloadFieldType()),
 			}
-
+	
 			if tc.inputAlertType != "burn_rate_v2" && tc.inputAlertType != "burnRateV2" && tc.inputAlertType != "BurnRateV2" {
 				model.Threshold = &SloAlertThresholdModel{
 					Type:     types.StringValue("staticThreshold"),
@@ -683,6 +687,7 @@ func TestMapStateToDataObject_InvalidAlertType(t *testing.T) {
 		SloIds: types.SetValueMust(types.StringType, []attr.Value{
 			types.StringValue("slo-1"),
 		}),
+		ApdexIds: types.SetNull(types.StringType),
 		AlertChannelIds: types.SetValueMust(types.StringType, []attr.Value{
 			types.StringValue("channel-1"),
 		}),
@@ -716,6 +721,7 @@ func TestMapStateToDataObject_InvalidDuration(t *testing.T) {
 		SloIds: types.SetValueMust(types.StringType, []attr.Value{
 			types.StringValue("slo-1"),
 		}),
+		ApdexIds: types.SetNull(types.StringType),
 		AlertChannelIds: types.SetValueMust(types.StringType, []attr.Value{
 			types.StringValue("channel-1"),
 		}),
@@ -758,6 +764,7 @@ func TestMapStateToDataObject_InvalidThresholdValue(t *testing.T) {
 		SloIds: types.SetValueMust(types.StringType, []attr.Value{
 			types.StringValue("slo-1"),
 		}),
+		ApdexIds: types.SetNull(types.StringType),
 		AlertChannelIds: types.SetValueMust(types.StringType, []attr.Value{
 			types.StringValue("channel-1"),
 		}),
@@ -805,6 +812,7 @@ func TestMapStateToDataObject_WithNullThresholdType(t *testing.T) {
 		SloIds: types.SetValueMust(types.StringType, []attr.Value{
 			types.StringValue("slo-1"),
 		}),
+		ApdexIds: types.SetNull(types.StringType),
 		AlertChannelIds: types.SetValueMust(types.StringType, []attr.Value{
 			types.StringValue("channel-1"),
 		}),
@@ -840,6 +848,7 @@ func TestMapStateToDataObject_BurnRateV2WithoutBurnRateConfig(t *testing.T) {
 		SloIds: types.SetValueMust(types.StringType, []attr.Value{
 			types.StringValue("slo-1"),
 		}),
+		ApdexIds: types.SetNull(types.StringType),
 		AlertChannelIds: types.SetValueMust(types.StringType, []attr.Value{
 			types.StringValue("channel-1"),
 		}),
@@ -883,6 +892,7 @@ func TestMapStateToDataObject_FromState(t *testing.T) {
 		SloIds: types.SetValueMust(types.StringType, []attr.Value{
 			types.StringValue("slo-1"),
 		}),
+		ApdexIds: types.SetNull(types.StringType),
 		AlertChannelIds: types.SetValueMust(types.StringType, []attr.Value{
 			types.StringValue("channel-1"),
 		}),
@@ -925,6 +935,7 @@ func TestMapStateToDataObject_WithEmptyID(t *testing.T) {
 		SloIds: types.SetValueMust(types.StringType, []attr.Value{
 			types.StringValue("slo-1"),
 		}),
+		ApdexIds: types.SetNull(types.StringType),
 		AlertChannelIds: types.SetValueMust(types.StringType, []attr.Value{
 			types.StringValue("channel-1"),
 		}),
@@ -968,18 +979,19 @@ func TestMapStateToDataObject_WithDifferentOperators(t *testing.T) {
 				SloIds: types.SetValueMust(types.StringType, []attr.Value{
 					types.StringValue("slo-1"),
 				}),
+				ApdexIds: types.SetNull(types.StringType),
 				AlertChannelIds: types.SetValueMust(types.StringType, []attr.Value{
 					types.StringValue("channel-1"),
 				}),
 				CustomPayload: types.ListNull(shared.GetCustomPayloadFieldType()),
 			}
-
+	
 			state := createMockState(t, model)
-
+	
 			apiConfig, diags := resource.MapStateToDataObject(ctx, nil, &state)
 			require.False(t, diags.HasError())
 			require.NotNil(t, apiConfig)
-
+	
 			assert.Equal(t, operator, apiConfig.Threshold.Operator)
 		})
 	}
@@ -1016,6 +1028,173 @@ func TestNewSloAlertConfigResourceHandle(t *testing.T) {
 	assert.Equal(t, ResourceInstanaSloAlertConfig, metaData.ResourceName)
 }
 
+// TestUpdateState_ApdexScoreAlertType verifies that an API config with APDEX rule
+// is correctly mapped to Terraform state with alert_type "apdex_score" and apdex_ids.
+func TestUpdateState_ApdexScoreAlertType(t *testing.T) {
+	ctx := context.Background()
+	resource := NewSloAlertConfigResourceHandle()
+
+	apiConfig := &api.SloAlertConfig{
+		ID:          "apdex-alert-id",
+		Name:        "Apdex Score Alert",
+		Description: "Apdex Score Description",
+		Severity:    5,
+		Triggering:  false,
+		Enabled:     true,
+		Rule: api.SloAlertRule{
+			AlertType: "APDEX",
+			Metric:    "SCORE",
+		},
+		Threshold: &api.SloAlertThreshold{
+			Type:     "static",
+			Operator: "<",
+			Value:    0.8,
+		},
+		TimeThreshold: api.SloAlertTimeThreshold{
+			TimeWindow: 300000,
+			Expiry:     600000,
+		},
+		SloIds:                []string{},
+		ApdexIds:              []string{"apdex-1", "apdex-2"},
+		AlertChannelIds:       []string{"channel-1"},
+		CustomerPayloadFields: []common.CustomPayloadField[any]{},
+		BurnRateConfigs:       &[]api.BurnRateConfig{},
+	}
+
+	state := tfsdk.State{
+		Schema: resource.MetaData().Schema,
+	}
+	initializeEmptyState(ctx, &state)
+
+	diags := resource.UpdateState(ctx, &state, nil, apiConfig)
+	require.False(t, diags.HasError())
+
+	var model SloAlertConfigModel
+	diags = state.Get(ctx, &model)
+	require.False(t, diags.HasError())
+
+	assert.Equal(t, "apdex-alert-id", model.ID.ValueString())
+	assert.Equal(t, "Apdex Score Alert", model.Name.ValueString())
+	assert.Equal(t, "apdex_score", model.AlertType.ValueString())
+	assert.Equal(t, int64(5), model.Severity.ValueInt64())
+	assert.False(t, model.Triggering.ValueBool())
+	assert.NotNil(t, model.Threshold)
+	assert.Equal(t, "staticThreshold", model.Threshold.Type.ValueString())
+	assert.Equal(t, "<", model.Threshold.Operator.ValueString())
+	assert.Equal(t, 0.80, model.Threshold.Value.ValueFloat64())
+	assert.Equal(t, int64(300000), model.TimeThreshold.WarmUp.ValueInt64())
+	assert.Equal(t, int64(600000), model.TimeThreshold.CoolDown.ValueInt64())
+	assert.Equal(t, 2, len(model.ApdexIds.Elements()))
+	assert.Equal(t, 0, len(model.SloIds.Elements()))
+}
+
+// TestMapStateToDataObject_ApdexScoreAlertType verifies that a Terraform model with
+// alert_type "apdex_score" and apdex_ids is correctly mapped to an API SloAlertConfig.
+func TestMapStateToDataObject_ApdexScoreAlertType(t *testing.T) {
+	ctx := context.Background()
+	resource := NewSloAlertConfigResourceHandle()
+
+	model := SloAlertConfigModel{
+		ID:          types.StringValue("apdex-alert-id"),
+		Name:        types.StringValue("Apdex Score Alert"),
+		Description: types.StringValue("Apdex Score Description"),
+		Severity:    types.Int64Value(5),
+		Triggering:  types.BoolValue(false),
+		AlertType:   types.StringValue("apdex_score"),
+		Threshold: &SloAlertThresholdModel{
+			Type:     types.StringValue("staticThreshold"),
+			Operator: types.StringValue("<"),
+			Value:    types.Float64Value(0.8),
+		},
+		TimeThreshold: &SloAlertTimeThresholdModel{
+			WarmUp:   types.Int64Value(300000),
+			CoolDown: types.Int64Value(600000),
+		},
+		SloIds: types.SetValueMust(types.StringType, []attr.Value{}),
+		ApdexIds: types.SetValueMust(types.StringType, []attr.Value{
+			types.StringValue("apdex-1"),
+			types.StringValue("apdex-2"),
+		}),
+		AlertChannelIds: types.SetValueMust(types.StringType, []attr.Value{
+			types.StringValue("channel-1"),
+		}),
+		BurnRateConfig: nil,
+		CustomPayload:  types.ListNull(shared.GetCustomPayloadFieldType()),
+	}
+
+	state := createMockState(t, model)
+
+	apiConfig, diags := resource.MapStateToDataObject(ctx, nil, &state)
+	require.False(t, diags.HasError())
+	require.NotNil(t, apiConfig)
+
+	assert.Equal(t, "apdex-alert-id", apiConfig.ID)
+	assert.Equal(t, "Apdex Score Alert", apiConfig.Name)
+	assert.Equal(t, "APDEX", apiConfig.Rule.AlertType)
+	assert.Equal(t, "SCORE", apiConfig.Rule.Metric)
+	assert.NotNil(t, apiConfig.Threshold)
+	assert.Equal(t, "<", apiConfig.Threshold.Operator)
+	assert.Equal(t, 0.8, apiConfig.Threshold.Value)
+	assert.Len(t, apiConfig.ApdexIds, 2)
+	assert.Len(t, apiConfig.SloIds, 0)
+	assert.Equal(t, 300000, apiConfig.TimeThreshold.TimeWindow)
+	assert.Equal(t, 600000, apiConfig.TimeThreshold.Expiry)
+}
+
+// TestMapStateToDataObject_ApdexScoreNormalizedAliases verifies that camelCase aliases
+// for apdex_score are correctly normalized.
+func TestMapStateToDataObject_ApdexScoreNormalizedAliases(t *testing.T) {
+	ctx := context.Background()
+	resource := NewSloAlertConfigResourceHandle()
+
+	testCases := []struct {
+		name           string
+		inputAlertType string
+	}{
+		{"apdexScore alias", "apdexScore"},
+		{"ApdexScore alias", "ApdexScore"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			model := SloAlertConfigModel{
+				ID:          types.StringValue("test-id"),
+				Name:        types.StringValue("Test Alert"),
+				Description: types.StringValue("Test Description"),
+				Severity:    types.Int64Value(5),
+				Triggering:  types.BoolValue(false),
+				AlertType:   types.StringValue(tc.inputAlertType),
+				Threshold: &SloAlertThresholdModel{
+					Type:     types.StringValue("staticThreshold"),
+					Operator: types.StringValue("<"),
+					Value:    types.Float64Value(0.9),
+				},
+				TimeThreshold: &SloAlertTimeThresholdModel{
+					WarmUp:   types.Int64Value(300000),
+					CoolDown: types.Int64Value(600000),
+				},
+				SloIds: types.SetValueMust(types.StringType, []attr.Value{}),
+				ApdexIds: types.SetValueMust(types.StringType, []attr.Value{
+					types.StringValue("apdex-1"),
+				}),
+				AlertChannelIds: types.SetValueMust(types.StringType, []attr.Value{
+					types.StringValue("channel-1"),
+				}),
+				CustomPayload: types.ListNull(shared.GetCustomPayloadFieldType()),
+			}
+
+			state := createMockState(t, model)
+
+			apiConfig, diags := resource.MapStateToDataObject(ctx, nil, &state)
+			require.False(t, diags.HasError())
+			require.NotNil(t, apiConfig)
+
+			assert.Equal(t, "APDEX", apiConfig.Rule.AlertType)
+			assert.Equal(t, "SCORE", apiConfig.Rule.Metric)
+		})
+	}
+}
+
 // Helper functions
 
 func initializeEmptyState(ctx context.Context, state *tfsdk.State) {
@@ -1028,6 +1207,7 @@ func initializeEmptyState(ctx context.Context, state *tfsdk.State) {
 		AlertType:       types.StringNull(),
 		Threshold:       nil,
 		SloIds:          types.SetNull(types.StringType),
+		ApdexIds:        types.SetNull(types.StringType),
 		AlertChannelIds: types.SetNull(types.StringType),
 		TimeThreshold:   nil,
 		BurnRateConfig:  nil,

--- a/internal/resources/sloalertconfig/slo-alert-config-model.go
+++ b/internal/resources/sloalertconfig/slo-alert-config-model.go
@@ -15,6 +15,7 @@ type SloAlertConfigModel struct {
 	AlertType       types.String                  `tfsdk:"alert_type"`
 	Threshold       *SloAlertThresholdModel       `tfsdk:"threshold"`
 	SloIds          types.Set                     `tfsdk:"slo_ids"`
+	ApdexIds        types.Set                     `tfsdk:"apdex_ids"`
 	AlertChannelIds types.Set                     `tfsdk:"alert_channel_ids"`
 	TimeThreshold   *SloAlertTimeThresholdModel   `tfsdk:"time_threshold"`
 	BurnRateConfig  []SloAlertBurnRateConfigModel `tfsdk:"burn_rate_config"`


### PR DESCRIPTION
This PR extends the `instana_slo_alert_config` resource to support **Apdex smart alerts** alongside the existing SLO alert.

A new alert type, `apdex_score`, has been added and mapped to the existing API model using:

- `alertType: APDEX`
- `metric: SCORE`

The same existing endpoint is reused, so no new REST resource is required.

## Changes

- Added support for `alert_type = "apdex_score"`.
- Added new `apdex_ids` field as `Optional` `Set<String>`.
- Made `slo_ids` optional instead of required, since Apdex alerts do not carry SLO IDs.
- Added unit tests covering Apdex state mapping, API object mapping, etc.