### PR TITLE
Add grace_period field support to InfraAlertConfig and WebsiteAlertConfiguration

### DIFF
--- a/docs/resources/infra_alert_config.md
+++ b/docs/resources/infra_alert_config.md
@@ -212,6 +212,7 @@ terraform apply
 * `name` - Required - The name for the infrastructure alert configuration
 * `description` - Required - The description text of the infrastructure alert config
 * `granularity` - Required - The evaluation granularity used for detection of violations of the defined threshold. In other words, it defines the size of the tumbling window used. Allowed values: `300000`, `600000`, `900000`, `1200000`, `1800000` (milliseconds)
+* `grace_period` - Optional - The duration in milliseconds for which an alert remains open after conditions are no longer violated. The alert automatically closes once the grace period expires.
 * `evaluation_type` - Required - The evaluation type of the infrastructure alert config. Allowed values:
   * `CUSTOM` - Combine all metrics in scope into a single metric per group (default)
   * `PER_ENTITY` - Monitor each metric individually and trigger alerts for each individual entity

--- a/docs/resources/website_alert_config.md
+++ b/docs/resources/website_alert_config.md
@@ -393,6 +393,7 @@ terraform apply
 * `tag_filter` - Optional - Tag filter expression to limit monitoring scope [Details](#tag-filter-reference)
 * `alert_channel_ids` - Optional - Set of alert channel IDs to notify
 * `granularity` - Optional - Evaluation granularity in milliseconds. Values: `300000`, `600000`, `900000`, `1200000`, `800000`. Default: `600000`
+* `grace_period` - Optional - The duration in milliseconds for which an alert remains open after conditions are no longer violated. The alert automatically closes once the grace period expires.
 * `rule` - Optional - Single alert rule configuration [Details](#rule-reference)
 * `rules` - Optional - Multiple alert rules with individual thresholds [Details](#rules-reference)
 * `threshold` - Optional - Threshold configuration for single rule [Details](#threshold-reference)

--- a/internal/resources/infralertconfig/infra-alert-config-model.go
+++ b/internal/resources/infralertconfig/infra-alert-config-model.go
@@ -14,6 +14,7 @@ type InfraAlertConfigModel struct {
 	GroupBy            types.Set                `tfsdk:"group_by"`
 	AlertChannels      *InfraAlertChannelsModel `tfsdk:"alert_channels"`
 	Granularity        types.Int64              `tfsdk:"granularity"`
+	GracePeriod        types.Int64              `tfsdk:"grace_period"`
 	TimeThreshold      *InfraTimeThresholdModel `tfsdk:"time_threshold"`
 	CustomPayloadField types.List               `tfsdk:"custom_payload_field"`
 	Rules              *InfraRulesModel         `tfsdk:"rules"`

--- a/internal/resources/infralertconfig/resource-infra-alert-config-constants.go
+++ b/internal/resources/infralertconfig/resource-infra-alert-config-constants.go
@@ -17,6 +17,8 @@ const (
 	InfraAlertConfigFieldGroupBy = "group_by"
 	// InfraAlertConfigFieldGranularity constant value for the schema field granularity
 	InfraAlertConfigFieldGranularity = "granularity"
+	// InfraAlertConfigFieldGracePeriod constant value for the schema field grace_period
+	InfraAlertConfigFieldGracePeriod = "grace_period"
 	// InfraAlertConfigFieldEvaluationType constant value for the schema field evaluation_type
 	InfraAlertConfigFieldEvaluationType = "evaluation_type"
 	// InfraAlertConfigFieldTriggering constant value for the schema field triggering
@@ -77,6 +79,8 @@ const (
 	InfraAlertConfigDescGroupBy = "The list of tags to group by"
 	// InfraAlertConfigDescGranularity description for the granularity field
 	InfraAlertConfigDescGranularity = "The granularity of the infrastructure alert configuration"
+	// InfraAlertConfigDescGracePeriod description for the grace_period field
+	InfraAlertConfigDescGracePeriod = "The duration in milliseconds for which an alert remains open after conditions are no longer violated, with the alert auto-closing once the grace period expires"
 	// InfraAlertConfigDescEvaluationType description for the evaluation_type field
 	InfraAlertConfigDescEvaluationType = "The evaluation type of the infrastructure alert configuration"
 	// InfraAlertConfigDescTriggering description for the triggering field

--- a/internal/resources/infralertconfig/resource-infra-alert-config.go
+++ b/internal/resources/infralertconfig/resource-infra-alert-config.go
@@ -75,6 +75,10 @@ func buildInfraAlertConfigSchema() schema.Schema {
 				Description: InfraAlertConfigDescGranularity,
 				Required:    true,
 			},
+			InfraAlertConfigFieldGracePeriod: schema.Int64Attribute{
+				Description: InfraAlertConfigDescGracePeriod,
+				Optional:    true,
+			},
 			InfraAlertConfigFieldEvaluationType: schema.StringAttribute{
 				Description: InfraAlertConfigDescEvaluationType,
 				Required:    true,
@@ -229,6 +233,14 @@ func (r *infraAlertConfigResource) UpdateState(ctx context.Context, state *tfsdk
 	model.Name = types.StringValue(resource.Name)
 	model.Description = types.StringValue(resource.Description)
 	model.Granularity = types.Int64Value(int64(resource.Granularity))
+
+	// Map grace period
+	if resource.GracePeriod != nil {
+		model.GracePeriod = types.Int64Value(*resource.GracePeriod)
+	} else {
+		model.GracePeriod = types.Int64Null()
+	}
+
 	model.EvaluationType = types.StringValue(string(resource.EvaluationType))
 	model.Triggering = types.BoolValue(resource.Triggering)
 
@@ -415,6 +427,12 @@ func (r *infraAlertConfigResource) MapStateToDataObject(ctx context.Context, pla
 		Granularity:    common.Granularity(model.Granularity.ValueInt64()),
 		EvaluationType: api.InfraAlertEvaluationType(model.EvaluationType.ValueString()),
 		Triggering:     model.Triggering.ValueBool(),
+	}
+
+	// Map grace period
+	if !model.GracePeriod.IsNull() && !model.GracePeriod.IsUnknown() {
+		gracePeriod := model.GracePeriod.ValueInt64()
+		infraAlertConfig.GracePeriod = &gracePeriod
 	}
 
 	tagFilter, tagFilterDiags := r.mapModelTagFilterToAPI(model.TagFilter)

--- a/internal/resources/websitealertconfig/resource-website-alert-config-constants.go
+++ b/internal/resources/websitealertconfig/resource-website-alert-config-constants.go
@@ -12,6 +12,8 @@ const (
 	WebsiteAlertConfigFieldDescription = "description"
 	//WebsiteAlertConfigFieldGranularity constant value for field granularity of resource instana_website_alert_config
 	WebsiteAlertConfigFieldGranularity = "granularity"
+	//WebsiteAlertConfigFieldGracePeriod constant value for field grace_period of resource instana_website_alert_config
+	WebsiteAlertConfigFieldGracePeriod = "grace_period"
 	//WebsiteAlertConfigFieldName constant value for field name of resource instana_website_alert_config
 	WebsiteAlertConfigFieldName = "name"
 	//WebsiteAlertConfigFieldEnabled constant value for field enabled of resource instana_website_alert_config
@@ -73,6 +75,7 @@ const (
 	WebsiteAlertConfigDescTagFilter       = "The tag filter expression for the Website Alert Configuration."
 	WebsiteAlertConfigDescAlertChannelIDs = "List of IDs of alert channels defined in Instana."
 	WebsiteAlertConfigDescGranularity     = "The evaluation granularity used for detection of violations of the defined threshold."
+	WebsiteAlertConfigDescGracePeriod     = "The duration in milliseconds for which an alert remains open after conditions are no longer violated, with the alert auto-closing once the grace period expires."
 	WebsiteAlertConfigDescRules           = "A list of rules where each rule is associated with multiple thresholds and their corresponding severity levels."
 
 	// Rule descriptions

--- a/internal/resources/websitealertconfig/resource-website-alert-config.go
+++ b/internal/resources/websitealertconfig/resource-website-alert-config.go
@@ -91,6 +91,10 @@ func NewWebsiteAlertConfigResourceHandle() resourcehandle.ResourceHandle[*api.We
 						Description: WebsiteAlertConfigDescGranularity,
 						Default:     int64default.StaticInt64(WebsiteAlertConfigDefaultGranularity),
 					},
+					WebsiteAlertConfigFieldGracePeriod: schema.Int64Attribute{
+						Optional:    true,
+						Description: WebsiteAlertConfigDescGracePeriod,
+					},
 					WebsiteAlertConfigFieldRules: schema.ListNestedAttribute{
 						Description: WebsiteAlertConfigDescRules,
 						Optional:    true,
@@ -351,6 +355,13 @@ func (r *websiteAlertConfigResource) MapStateToDataObject(ctx context.Context, p
 	}
 
 	// Create API object
+	// Map grace period if set
+	var gracePeriod *int64
+	if !model.GracePeriod.IsNull() && !model.GracePeriod.IsUnknown() {
+		gracePeriodValue := model.GracePeriod.ValueInt64()
+		gracePeriod = &gracePeriodValue
+	}
+
 	return &api.WebsiteAlertConfig{
 		ID:                    model.ID.ValueString(),
 		Name:                  model.Name.ValueString(),
@@ -362,6 +373,7 @@ func (r *websiteAlertConfigResource) MapStateToDataObject(ctx context.Context, p
 		TagFilterExpression:   tagFilter,
 		AlertChannelIDs:       alertChannelIDs,
 		Granularity:           common.Granularity(model.Granularity.ValueInt64()),
+		GracePeriod:           gracePeriod,
 		CustomerPayloadFields: customPayloadFields,
 		TimeThreshold:         *timeThreshold,
 		Rules:                 rules,
@@ -678,6 +690,13 @@ func (r *websiteAlertConfigResource) UpdateState(ctx context.Context, state *tfs
 	model.Triggering = types.BoolValue(apiObject.Triggering)
 	model.WebsiteID = types.StringValue(apiObject.WebsiteID)
 	model.Granularity = types.Int64Value(int64(apiObject.Granularity))
+
+	// Map grace period field
+	if apiObject.GracePeriod != nil {
+		model.GracePeriod = types.Int64Value(*apiObject.GracePeriod)
+	} else {
+		model.GracePeriod = types.Int64Null()
+	}
 
 	// Map enabled field
 	if apiObject.Enabled != nil {

--- a/internal/resources/websitealertconfig/website_alert_config_model.go
+++ b/internal/resources/websitealertconfig/website_alert_config_model.go
@@ -16,6 +16,7 @@ type WebsiteAlertConfigModel struct {
 	TagFilter           types.String                   `tfsdk:"tag_filter"`
 	AlertChannelIDs     types.Set                      `tfsdk:"alert_channel_ids"`
 	Granularity         types.Int64                    `tfsdk:"granularity"`
+	GracePeriod         types.Int64                    `tfsdk:"grace_period"`
 	CustomPayloadFields types.List                     `tfsdk:"custom_payload_fields"`
 	TimeThreshold       *WebsiteTimeThresholdModel     `tfsdk:"time_threshold"`
 	Rules               []RuleWithThresholdPluginModel `tfsdk:"rules"`


### PR DESCRIPTION

This PR adds support for the grace_period field to both Infrastructure Alert Configuration and Website Alert Configuration resources, allowing users to configure the duration for which an alert remains open after conditions are no longer violated.