### PR TITLE
Rbac tags addition and custom payload fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,3 +61,5 @@ require (
 	gopkg.in/resty.v1 v1.12.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/instana/instana-go-client => ../instana-go-client

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.18.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.36.1
-	github.com/instana/instana-go-client v1.1.1
+	github.com/instana/instana-go-client v1.1.2
 	github.com/rs/xid v1.5.0
 	github.com/stretchr/testify v1.11.1
 )
@@ -61,5 +61,3 @@ require (
 	gopkg.in/resty.v1 v1.12.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/instana/instana-go-client => ../instana-go-client

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8=
 github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
+github.com/instana/instana-go-client v1.1.2 h1:pS6gXc64xZpn4rg7N+E5zc5t2urB8RNn0oMmGIQGfY0=
+github.com/instana/instana-go-client v1.1.2/go.mod h1:aOe+HQWz3md7VSvKrdeT+aso7sxzobWuXvyaTwIos3Q=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=
 github.com/jhump/protoreflect v1.17.0/go.mod h1:h9+vUUL38jiBzck8ck+6G/aeMX8Z4QUY/NiJPwPNi+8=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/go.sum
+++ b/go.sum
@@ -67,10 +67,6 @@ github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8=
 github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
-github.com/instana/instana-go-client v1.1.0 h1:p9jNVEFnFB/sYWVFtdZxhm3gAWuMvWZzadfma1HSQyE=
-github.com/instana/instana-go-client v1.1.0/go.mod h1:aOe+HQWz3md7VSvKrdeT+aso7sxzobWuXvyaTwIos3Q=
-github.com/instana/instana-go-client v1.1.1 h1:g6U459jz0tLTBo0PyYroij7lYOquSwcbbOQDi+s/9Bc=
-github.com/instana/instana-go-client v1.1.1/go.mod h1:aOe+HQWz3md7VSvKrdeT+aso7sxzobWuXvyaTwIos3Q=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=
 github.com/jhump/protoreflect v1.17.0/go.mod h1:h9+vUUL38jiBzck8ck+6G/aeMX8Z4QUY/NiJPwPNi+8=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/internal/resources/alertingchannel/alert-channel-constants.go
+++ b/internal/resources/alertingchannel/alert-channel-constants.go
@@ -112,6 +112,13 @@ const (
 	AlertingChannelFieldChannelSlackApp = "slack_app"
 	//AlertingChannelSlackAppFieldAppID const for the appId field of the Slack App alerting channel
 	AlertingChannelSlackAppFieldAppID = "app_id"
+	// AlertingChannelFieldRbacTags const for schema field rbac_tags
+	AlertingChannelFieldRbacTags = "rbac_tags"
+	// AlertingChannelFieldRbacTagID const for schema field rbac_tags.id
+	AlertingChannelFieldRbacTagID = "id"
+	// AlertingChannelFieldRbacTagDisplayName const for schema field rbac_tags.display_name
+	AlertingChannelFieldRbacTagDisplayName = "display_name"
+
 	//AlertingChannelSlackAppFieldTeamID const for the teamId field of the Slack App alerting channel
 	AlertingChannelSlackAppFieldTeamID = "team_id"
 	//AlertingChannelSlackAppFieldTeamName const for the teamName field of the Slack App alerting channel
@@ -224,6 +231,11 @@ const (
 	AlertingChannelDescMsTeamsAppServiceURL        = "The Service URL of the MS Teams App alerting channel"
 	AlertingChannelDescMsTeamsAppTenantID          = "The Tenant ID of the MS Teams App alerting channel"
 	AlertingChannelDescMsTeamsAppTenantName        = "The Tenant Name of the MS Teams App alerting channel"
+
+	// RBAC Tags descriptions
+	AlertingChannelDescRbacTags           = "RBAC tags (teams) the alerting channel is assigned to."
+	AlertingChannelDescRbacTagID          = "ID of the RBAC tag (team)."
+	AlertingChannelDescRbacTagDisplayName = "Display name of the RBAC tag (team)."
 
 	// Error messages
 	AlertingChannelErrUnsupportedType       = "Unsupported alerting channel type"

--- a/internal/resources/alertingchannel/alert-channel-model.go
+++ b/internal/resources/alertingchannel/alert-channel-model.go
@@ -9,6 +9,7 @@ import (
 type AlertingChannelModel struct {
 	ID                    types.String                       `tfsdk:"id"`
 	Name                  types.String                       `tfsdk:"name"`
+	RbacTags              []AlertingChannelRbacTagModel      `tfsdk:"rbac_tags"`
 	Email                 *shared.EmailModel                 `tfsdk:"email"`
 	OpsGenie              *shared.OpsGenieModel              `tfsdk:"ops_genie"`
 	PagerDuty             *shared.PagerDutyModel             `tfsdk:"pager_duty"`
@@ -25,4 +26,10 @@ type AlertingChannelModel struct {
 	WatsonAIOpsWebhook    *shared.WatsonAIOpsWebhookModel    `tfsdk:"watson_aiops_webhook"`
 	SlackApp              *shared.SlackAppModel              `tfsdk:"slack_app"`
 	MsTeamsApp            *shared.MsTeamsAppModel            `tfsdk:"ms_teams_app"`
+}
+
+// AlertingChannelRbacTagModel represents an RBAC tag (team assignment) of an alerting channel
+type AlertingChannelRbacTagModel struct {
+	ID          types.String `tfsdk:"id"`
+	DisplayName types.String `tfsdk:"display_name"`
 }

--- a/internal/resources/alertingchannel/alert-channel-model.go
+++ b/internal/resources/alertingchannel/alert-channel-model.go
@@ -9,7 +9,7 @@ import (
 type AlertingChannelModel struct {
 	ID                    types.String                       `tfsdk:"id"`
 	Name                  types.String                       `tfsdk:"name"`
-	RbacTags              []AlertingChannelRbacTagModel      `tfsdk:"rbac_tags"`
+	RbacTags              types.List                         `tfsdk:"rbac_tags"`
 	Email                 *shared.EmailModel                 `tfsdk:"email"`
 	OpsGenie              *shared.OpsGenieModel              `tfsdk:"ops_genie"`
 	PagerDuty             *shared.PagerDutyModel             `tfsdk:"pager_duty"`

--- a/internal/resources/alertingchannel/resource-alerting-channel.go
+++ b/internal/resources/alertingchannel/resource-alerting-channel.go
@@ -41,6 +41,22 @@ func NewAlertingChannelResourceHandle() resourcehandle.ResourceHandle[*api.Alert
 						Required:    true,
 						Description: AlertingChannelDescName,
 					},
+					AlertingChannelFieldRbacTags: schema.ListNestedAttribute{
+						Description: AlertingChannelDescRbacTags,
+						Optional:    true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								AlertingChannelFieldRbacTagID: schema.StringAttribute{
+									Required:    true,
+									Description: AlertingChannelDescRbacTagID,
+								},
+								AlertingChannelFieldRbacTagDisplayName: schema.StringAttribute{
+									Required:    true,
+									Description: AlertingChannelDescRbacTagDisplayName,
+								},
+							},
+						},
+					},
 					AlertingChannelFieldChannelEmail: schema.SingleNestedAttribute{
 						Optional:    true,
 						Description: AlertingChannelDescEmail,
@@ -401,6 +417,19 @@ func (r *alertingChannelResource) UpdateState(ctx context.Context, state *tfsdk.
 	// Create base model with common fields
 	model := r.createBaseModel(alertingChannel)
 
+	// The Instana alerting channel API does not echo rbacTags back in its
+	// Create/Update response. On Create/Update (plan != nil) keep the value
+	// from the plan to avoid an "inconsistent result" error. On Read
+	// (plan == nil) populate from the API response.
+	if plan != nil {
+		var planModel AlertingChannelModel
+		diags.Append(plan.Get(ctx, &planModel)...)
+		if diags.HasError() {
+			return diags
+		}
+		model.RbacTags = planModel.RbacTags
+	}
+
 	// Map channel-specific data based on channel type
 	channelDiags := r.mapChannelTypeToModel(ctx, alertingChannel, &model)
 	if channelDiags.HasError() {
@@ -412,12 +441,43 @@ func (r *alertingChannelResource) UpdateState(ctx context.Context, state *tfsdk.
 	return diags
 }
 
-// createBaseModel creates the base model with common fields (ID and Name)
+// createBaseModel creates the base model with common fields (ID, Name and RbacTags)
 func (r *alertingChannelResource) createBaseModel(alertingChannel *api.AlertingChannel) AlertingChannelModel {
 	return AlertingChannelModel{
-		ID:   types.StringValue(alertingChannel.ID),
-		Name: types.StringValue(alertingChannel.Name),
+		ID:       types.StringValue(alertingChannel.ID),
+		Name:     types.StringValue(alertingChannel.Name),
+		RbacTags: r.mapRbacTagsToModel(alertingChannel.RbacTags),
 	}
+}
+
+// mapRbacTagsToModel converts RbacTags from the API to the model slice
+func (r *alertingChannelResource) mapRbacTagsToModel(rbacTags []api.RbacTag) []AlertingChannelRbacTagModel {
+	if len(rbacTags) == 0 {
+		return nil
+	}
+	models := make([]AlertingChannelRbacTagModel, len(rbacTags))
+	for i, tag := range rbacTags {
+		models[i] = AlertingChannelRbacTagModel{
+			ID:          types.StringValue(tag.ID),
+			DisplayName: types.StringValue(tag.DisplayName),
+		}
+	}
+	return models
+}
+
+// mapRbacTagsFromModel converts RbacTags from the model slice to the API format
+func (r *alertingChannelResource) mapRbacTagsFromModel(models []AlertingChannelRbacTagModel) []api.RbacTag {
+	if len(models) == 0 {
+		return nil
+	}
+	tags := make([]api.RbacTag, len(models))
+	for i, m := range models {
+		tags[i] = api.RbacTag{
+			ID:          m.ID.ValueString(),
+			DisplayName: m.DisplayName.ValueString(),
+		}
+	}
+	return tags
 }
 
 // mapChannelTypeToModel maps the API channel data to the appropriate model field based on channel type
@@ -996,7 +1056,13 @@ func (r *alertingChannelResource) MapStateToDataObject(ctx context.Context, plan
 	id, name := r.extractCommonFields(model)
 
 	// Map the configured channel type to API object
-	return r.mapConfiguredChannelType(ctx, model, id, name)
+	channel, diags := r.mapConfiguredChannelType(ctx, model, id, name)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	// Apply rbac_tags from the model
+	return r.applyRbacTags(channel, model), diags
 }
 
 // getModelFromPlanOrState retrieves the model from either plan or state
@@ -1023,7 +1089,8 @@ func (r *alertingChannelResource) extractCommonFields(model AlertingChannelModel
 	return id, name
 }
 
-// mapConfiguredChannelType determines which channel type is configured and maps it to API object
+// mapConfiguredChannelType determines which channel type is configured and maps it to API object.
+// It also sets RbacTags from the model on the returned object.
 func (r *alertingChannelResource) mapConfiguredChannelType(ctx context.Context, model AlertingChannelModel, id, name string) (*api.AlertingChannel, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
@@ -1083,6 +1150,12 @@ func (r *alertingChannelResource) mapConfiguredChannelType(ctx context.Context, 
 		AlertingChannelErrInvalidConfigMsg,
 	)
 	return nil, diags
+}
+
+// applyRbacTags sets RbacTags on the channel object and returns it
+func (r *alertingChannelResource) applyRbacTags(channel *api.AlertingChannel, model AlertingChannelModel) *api.AlertingChannel {
+	channel.RbacTags = r.mapRbacTagsFromModel(model.RbacTags)
+	return channel
 }
 
 // GetStateUpgraders returns the state upgraders for this resource

--- a/internal/resources/alertingchannel/resource-alerting-channel.go
+++ b/internal/resources/alertingchannel/resource-alerting-channel.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -44,6 +45,7 @@ func NewAlertingChannelResourceHandle() resourcehandle.ResourceHandle[*api.Alert
 					AlertingChannelFieldRbacTags: schema.ListNestedAttribute{
 						Description: AlertingChannelDescRbacTags,
 						Optional:    true,
+						Computed:    true,
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								AlertingChannelFieldRbacTagID: schema.StringAttribute{
@@ -421,14 +423,14 @@ func (r *alertingChannelResource) UpdateState(ctx context.Context, state *tfsdk.
 	// Create/Update response. On Create/Update (plan != nil) keep the value
 	// from the plan to avoid an "inconsistent result" error. On Read
 	// (plan == nil) populate from the API response.
-	if plan != nil {
-		var planModel AlertingChannelModel
-		diags.Append(plan.Get(ctx, &planModel)...)
-		if diags.HasError() {
-			return diags
-		}
-		model.RbacTags = planModel.RbacTags
-	}
+	// if plan != nil {
+	// 	var planModel AlertingChannelModel
+	// 	diags.Append(plan.Get(ctx, &planModel)...)
+	// 	if diags.HasError() {
+	// 		return diags
+	// 	}
+	// 	model.RbacTags = planModel.RbacTags
+	// }
 
 	// Map channel-specific data based on channel type
 	channelDiags := r.mapChannelTypeToModel(ctx, alertingChannel, &model)
@@ -450,28 +452,54 @@ func (r *alertingChannelResource) createBaseModel(alertingChannel *api.AlertingC
 	}
 }
 
-// mapRbacTagsToModel converts RbacTags from the API to the model slice
-func (r *alertingChannelResource) mapRbacTagsToModel(rbacTags []api.RbacTag) []AlertingChannelRbacTagModel {
+// mapRbacTagsToModel converts RbacTags from the API to the model List
+func (r *alertingChannelResource) mapRbacTagsToModel(rbacTags []api.RbacTag) types.List {
+	tagAttrTypes := map[string]attr.Type{
+		AlertingChannelFieldRbacTagID:          types.StringType,
+		AlertingChannelFieldRbacTagDisplayName: types.StringType,
+	}
+
+	// Always initialize with empty list, even if data is null or empty
 	if len(rbacTags) == 0 {
-		return nil
+		emptyList, _ := types.ListValue(
+			types.ObjectType{AttrTypes: tagAttrTypes},
+			[]attr.Value{},
+		)
+		return emptyList
 	}
-	models := make([]AlertingChannelRbacTagModel, len(rbacTags))
+
+	tagValues := make([]attr.Value, len(rbacTags))
 	for i, tag := range rbacTags {
-		models[i] = AlertingChannelRbacTagModel{
-			ID:          types.StringValue(tag.ID),
-			DisplayName: types.StringValue(tag.DisplayName),
-		}
+		tagObj, _ := types.ObjectValue(
+			tagAttrTypes,
+			map[string]attr.Value{
+				AlertingChannelFieldRbacTagID:          types.StringValue(tag.ID),
+				AlertingChannelFieldRbacTagDisplayName: types.StringValue(tag.DisplayName),
+			},
+		)
+		tagValues[i] = tagObj
 	}
-	return models
+
+	list, _ := types.ListValue(types.ObjectType{AttrTypes: tagAttrTypes}, tagValues)
+	return list
 }
 
-// mapRbacTagsFromModel converts RbacTags from the model slice to the API format
-func (r *alertingChannelResource) mapRbacTagsFromModel(models []AlertingChannelRbacTagModel) []api.RbacTag {
-	if len(models) == 0 {
-		return nil
+// mapRbacTagsFromModel converts RbacTags from the model List to the API format
+func (r *alertingChannelResource) mapRbacTagsFromModel(rbacTagsList types.List) []api.RbacTag {
+	// Always initialize with empty array, even if data is null or empty
+	if rbacTagsList.IsNull() || rbacTagsList.IsUnknown() {
+		return []api.RbacTag{}
 	}
-	tags := make([]api.RbacTag, len(models))
-	for i, m := range models {
+
+	var tagModels []AlertingChannelRbacTagModel
+	rbacTagsList.ElementsAs(context.Background(), &tagModels, false)
+
+	if len(tagModels) == 0 {
+		return []api.RbacTag{}
+	}
+
+	tags := make([]api.RbacTag, len(tagModels))
+	for i, m := range tagModels {
 		tags[i] = api.RbacTag{
 			ID:          m.ID.ValueString(),
 			DisplayName: m.DisplayName.ValueString(),

--- a/internal/resources/alertingchannel/resource-alerting-channel_test.go
+++ b/internal/resources/alertingchannel/resource-alerting-channel_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/instana/instana-go-client/api"
@@ -436,9 +437,19 @@ func TestMapStateToDataObject(t *testing.T) {
 		emails := []string{"test@example.com"}
 		emailsSet, _ := types.SetValueFrom(ctx, types.StringType, emails)
 
+		tagAttrTypes := map[string]attr.Type{
+			AlertingChannelFieldRbacTagID:          types.StringType,
+			AlertingChannelFieldRbacTagDisplayName: types.StringType,
+		}
+		emptyList, _ := types.ListValue(
+			types.ObjectType{AttrTypes: tagAttrTypes},
+			[]attr.Value{},
+		)
+
 		model := AlertingChannelModel{
-			ID:   types.StringValue("test-id"),
-			Name: types.StringValue("test-name"),
+			ID:       types.StringValue("test-id"),
+			Name:     types.StringValue("test-name"),
+			RbacTags: emptyList,
 			Email: &shared.EmailModel{
 				Emails: emailsSet,
 			},
@@ -455,9 +466,19 @@ func TestMapStateToDataObject(t *testing.T) {
 		tags := []string{"tag1"}
 		tagsList, _ := types.SetValueFrom(ctx, types.StringType, tags)
 
+		tagAttrTypes := map[string]attr.Type{
+			AlertingChannelFieldRbacTagID:          types.StringType,
+			AlertingChannelFieldRbacTagDisplayName: types.StringType,
+		}
+		emptyList, _ := types.ListValue(
+			types.ObjectType{AttrTypes: tagAttrTypes},
+			[]attr.Value{},
+		)
+
 		model := AlertingChannelModel{
-			ID:   types.StringValue("test-id"),
-			Name: types.StringValue("test-name"),
+			ID:       types.StringValue("test-id"),
+			Name:     types.StringValue("test-name"),
+			RbacTags: emptyList,
 			OpsGenie: &shared.OpsGenieModel{
 				APIKey: types.StringValue("api-key"),
 				Region: types.StringValue("EU"),
@@ -473,9 +494,19 @@ func TestMapStateToDataObject(t *testing.T) {
 	})
 
 	t.Run("PagerDuty channel", func(t *testing.T) {
+		tagAttrTypes := map[string]attr.Type{
+			AlertingChannelFieldRbacTagID:          types.StringType,
+			AlertingChannelFieldRbacTagDisplayName: types.StringType,
+		}
+		emptyList, _ := types.ListValue(
+			types.ObjectType{AttrTypes: tagAttrTypes},
+			[]attr.Value{},
+		)
+
 		model := AlertingChannelModel{
-			ID:   types.StringValue("test-id"),
-			Name: types.StringValue("test-name"),
+			ID:       types.StringValue("test-id"),
+			Name:     types.StringValue("test-name"),
+			RbacTags: emptyList,
 			PagerDuty: &shared.PagerDutyModel{
 				ServiceIntegrationKey: types.StringValue("integration-key"),
 			},
@@ -489,9 +520,19 @@ func TestMapStateToDataObject(t *testing.T) {
 	})
 
 	t.Run("Slack channel", func(t *testing.T) {
+		tagAttrTypes := map[string]attr.Type{
+			AlertingChannelFieldRbacTagID:          types.StringType,
+			AlertingChannelFieldRbacTagDisplayName: types.StringType,
+		}
+		emptyList, _ := types.ListValue(
+			types.ObjectType{AttrTypes: tagAttrTypes},
+			[]attr.Value{},
+		)
+
 		model := AlertingChannelModel{
-			ID:   types.StringValue("test-id"),
-			Name: types.StringValue("test-name"),
+			ID:       types.StringValue("test-id"),
+			Name:     types.StringValue("test-name"),
+			RbacTags: emptyList,
 			Slack: &shared.SlackModel{
 				WebhookURL: types.StringValue("https://slack.com/webhook"),
 			},
@@ -505,9 +546,19 @@ func TestMapStateToDataObject(t *testing.T) {
 	})
 
 	t.Run("Splunk channel", func(t *testing.T) {
+		tagAttrTypes := map[string]attr.Type{
+			AlertingChannelFieldRbacTagID:          types.StringType,
+			AlertingChannelFieldRbacTagDisplayName: types.StringType,
+		}
+		emptyList, _ := types.ListValue(
+			types.ObjectType{AttrTypes: tagAttrTypes},
+			[]attr.Value{},
+		)
+
 		model := AlertingChannelModel{
-			ID:   types.StringValue("test-id"),
-			Name: types.StringValue("test-name"),
+			ID:       types.StringValue("test-id"),
+			Name:     types.StringValue("test-name"),
+			RbacTags: emptyList,
 			Splunk: &shared.SplunkModel{
 				URL:   types.StringValue("https://splunk.com"),
 				Token: types.StringValue("token"),
@@ -522,9 +573,19 @@ func TestMapStateToDataObject(t *testing.T) {
 	})
 
 	t.Run("VictorOps channel", func(t *testing.T) {
+		tagAttrTypes := map[string]attr.Type{
+			AlertingChannelFieldRbacTagID:          types.StringType,
+			AlertingChannelFieldRbacTagDisplayName: types.StringType,
+		}
+		emptyList, _ := types.ListValue(
+			types.ObjectType{AttrTypes: tagAttrTypes},
+			[]attr.Value{},
+		)
+
 		model := AlertingChannelModel{
-			ID:   types.StringValue("test-id"),
-			Name: types.StringValue("test-name"),
+			ID:       types.StringValue("test-id"),
+			Name:     types.StringValue("test-name"),
+			RbacTags: emptyList,
 			VictorOps: &shared.VictorOpsModel{
 				APIKey:     types.StringValue("api-key"),
 				RoutingKey: types.StringValue("routing-key"),
@@ -542,9 +603,19 @@ func TestMapStateToDataObject(t *testing.T) {
 		urls := []string{"https://webhook.com"}
 		urlsSet, _ := types.SetValueFrom(ctx, types.StringType, urls)
 
+		tagAttrTypes := map[string]attr.Type{
+			AlertingChannelFieldRbacTagID:          types.StringType,
+			AlertingChannelFieldRbacTagDisplayName: types.StringType,
+		}
+		emptyList, _ := types.ListValue(
+			types.ObjectType{AttrTypes: tagAttrTypes},
+			[]attr.Value{},
+		)
+
 		model := AlertingChannelModel{
-			ID:   types.StringValue("test-id"),
-			Name: types.StringValue("test-name"),
+			ID:       types.StringValue("test-id"),
+			Name:     types.StringValue("test-name"),
+			RbacTags: emptyList,
 			Webhook: &shared.WebhookModel{
 				WebhookURLs: urlsSet,
 				HTTPHeaders: types.MapNull(types.StringType),
@@ -559,9 +630,19 @@ func TestMapStateToDataObject(t *testing.T) {
 	})
 
 	t.Run("Office365 channel", func(t *testing.T) {
+		tagAttrTypes := map[string]attr.Type{
+			AlertingChannelFieldRbacTagID:          types.StringType,
+			AlertingChannelFieldRbacTagDisplayName: types.StringType,
+		}
+		emptyList, _ := types.ListValue(
+			types.ObjectType{AttrTypes: tagAttrTypes},
+			[]attr.Value{},
+		)
+
 		model := AlertingChannelModel{
-			ID:   types.StringValue("test-id"),
-			Name: types.StringValue("test-name"),
+			ID:       types.StringValue("test-id"),
+			Name:     types.StringValue("test-name"),
+			RbacTags: emptyList,
 			Office365: &shared.WebhookBasedModel{
 				WebhookURL: types.StringValue("https://office365.com/webhook"),
 			},
@@ -575,9 +656,19 @@ func TestMapStateToDataObject(t *testing.T) {
 	})
 
 	t.Run("GoogleChat channel", func(t *testing.T) {
+		tagAttrTypes := map[string]attr.Type{
+			AlertingChannelFieldRbacTagID:          types.StringType,
+			AlertingChannelFieldRbacTagDisplayName: types.StringType,
+		}
+		emptyList, _ := types.ListValue(
+			types.ObjectType{AttrTypes: tagAttrTypes},
+			[]attr.Value{},
+		)
+
 		model := AlertingChannelModel{
-			ID:   types.StringValue("test-id"),
-			Name: types.StringValue("test-name"),
+			ID:       types.StringValue("test-id"),
+			Name:     types.StringValue("test-name"),
+			RbacTags: emptyList,
 			GoogleChat: &shared.WebhookBasedModel{
 				WebhookURL: types.StringValue("https://chat.google.com/webhook"),
 			},
@@ -591,9 +682,19 @@ func TestMapStateToDataObject(t *testing.T) {
 	})
 
 	t.Run("ServiceNow channel", func(t *testing.T) {
+		tagAttrTypes := map[string]attr.Type{
+			AlertingChannelFieldRbacTagID:          types.StringType,
+			AlertingChannelFieldRbacTagDisplayName: types.StringType,
+		}
+		emptyList, _ := types.ListValue(
+			types.ObjectType{AttrTypes: tagAttrTypes},
+			[]attr.Value{},
+		)
+
 		model := AlertingChannelModel{
-			ID:   types.StringValue("test-id"),
-			Name: types.StringValue("test-name"),
+			ID:       types.StringValue("test-id"),
+			Name:     types.StringValue("test-name"),
+			RbacTags: emptyList,
 			ServiceNow: &shared.ServiceNowModel{
 				ServiceNowURL: types.StringValue("https://servicenow.com"),
 				Username:      types.StringValue("user"),
@@ -609,9 +710,19 @@ func TestMapStateToDataObject(t *testing.T) {
 	})
 
 	t.Run("ServiceNowApplication channel", func(t *testing.T) {
+		tagAttrTypes := map[string]attr.Type{
+			AlertingChannelFieldRbacTagID:          types.StringType,
+			AlertingChannelFieldRbacTagDisplayName: types.StringType,
+		}
+		emptyList, _ := types.ListValue(
+			types.ObjectType{AttrTypes: tagAttrTypes},
+			[]attr.Value{},
+		)
+
 		model := AlertingChannelModel{
-			ID:   types.StringValue("test-id"),
-			Name: types.StringValue("test-name"),
+			ID:       types.StringValue("test-id"),
+			Name:     types.StringValue("test-name"),
+			RbacTags: emptyList,
 			ServiceNowApplication: &shared.ServiceNowApplicationModel{
 				ServiceNowURL: types.StringValue("https://servicenow.com"),
 				Username:      types.StringValue("user"),
@@ -630,9 +741,19 @@ func TestMapStateToDataObject(t *testing.T) {
 	})
 
 	t.Run("PrometheusWebhook channel", func(t *testing.T) {
+		tagAttrTypes := map[string]attr.Type{
+			AlertingChannelFieldRbacTagID:          types.StringType,
+			AlertingChannelFieldRbacTagDisplayName: types.StringType,
+		}
+		emptyList, _ := types.ListValue(
+			types.ObjectType{AttrTypes: tagAttrTypes},
+			[]attr.Value{},
+		)
+
 		model := AlertingChannelModel{
-			ID:   types.StringValue("test-id"),
-			Name: types.StringValue("test-name"),
+			ID:       types.StringValue("test-id"),
+			Name:     types.StringValue("test-name"),
+			RbacTags: emptyList,
 			PrometheusWebhook: &shared.PrometheusWebhookModel{
 				WebhookURL: types.StringValue("https://prometheus.com/webhook"),
 			},
@@ -646,9 +767,19 @@ func TestMapStateToDataObject(t *testing.T) {
 	})
 
 	t.Run("WebexTeamsWebhook channel", func(t *testing.T) {
+		tagAttrTypes := map[string]attr.Type{
+			AlertingChannelFieldRbacTagID:          types.StringType,
+			AlertingChannelFieldRbacTagDisplayName: types.StringType,
+		}
+		emptyList, _ := types.ListValue(
+			types.ObjectType{AttrTypes: tagAttrTypes},
+			[]attr.Value{},
+		)
+
 		model := AlertingChannelModel{
-			ID:   types.StringValue("test-id"),
-			Name: types.StringValue("test-name"),
+			ID:       types.StringValue("test-id"),
+			Name:     types.StringValue("test-name"),
+			RbacTags: emptyList,
 			WebexTeamsWebhook: &shared.WebhookBasedModel{
 				WebhookURL: types.StringValue("https://webex.com/webhook"),
 			},
@@ -662,9 +793,19 @@ func TestMapStateToDataObject(t *testing.T) {
 	})
 
 	t.Run("WatsonAIOpsWebhook channel", func(t *testing.T) {
+		tagAttrTypes := map[string]attr.Type{
+			AlertingChannelFieldRbacTagID:          types.StringType,
+			AlertingChannelFieldRbacTagDisplayName: types.StringType,
+		}
+		emptyList, _ := types.ListValue(
+			types.ObjectType{AttrTypes: tagAttrTypes},
+			[]attr.Value{},
+		)
+
 		model := AlertingChannelModel{
-			ID:   types.StringValue("test-id"),
-			Name: types.StringValue("test-name"),
+			ID:       types.StringValue("test-id"),
+			Name:     types.StringValue("test-name"),
+			RbacTags: emptyList,
 			WatsonAIOpsWebhook: &shared.WatsonAIOpsWebhookModel{
 				WebhookURL:  types.StringValue("https://watson.com/webhook"),
 				HTTPHeaders: types.SetNull(types.StringType),
@@ -679,9 +820,19 @@ func TestMapStateToDataObject(t *testing.T) {
 	})
 
 	t.Run("No channel configured", func(t *testing.T) {
+		tagAttrTypes := map[string]attr.Type{
+			AlertingChannelFieldRbacTagID:          types.StringType,
+			AlertingChannelFieldRbacTagDisplayName: types.StringType,
+		}
+		emptyList, _ := types.ListValue(
+			types.ObjectType{AttrTypes: tagAttrTypes},
+			[]attr.Value{},
+		)
+
 		model := AlertingChannelModel{
-			ID:   types.StringValue("test-id"),
-			Name: types.StringValue("test-name"),
+			ID:       types.StringValue("test-id"),
+			Name:     types.StringValue("test-name"),
+			RbacTags: emptyList,
 		}
 
 		state := createMockState(t, ctx, model)

--- a/internal/resources/apdexconfig/apdex-config-model.go
+++ b/internal/resources/apdexconfig/apdex-config-model.go
@@ -9,7 +9,7 @@ type ApdexConfigModel struct {
 	ID          types.String      `tfsdk:"id"`
 	ApdexName   types.String      `tfsdk:"apdex_name"`
 	Tags        types.Set         `tfsdk:"tags"`
-	RbacTags    []RbacTagModel    `tfsdk:"rbac_tags"`
+	RbacTags    types.List        `tfsdk:"rbac_tags"`
 	ApdexEntity *ApdexEntityModel `tfsdk:"apdex_entity"`
 }
 

--- a/internal/resources/apdexconfig/resource-apdex-config.go
+++ b/internal/resources/apdexconfig/resource-apdex-config.go
@@ -99,6 +99,7 @@ func buildTagsAttribute() schema.SetAttribute {
 func buildRbacTagsAttribute() schema.ListNestedAttribute {
 	return schema.ListNestedAttribute{
 		Optional:    true,
+		Computed:    true,
 		Description: ApdexConfigDescRbacTags,
 		Validators: []validator.List{
 			listvalidator.SizeAtLeast(1),
@@ -257,14 +258,21 @@ func (r *apdexConfigResource) mapTagsFromState(tagsSet types.Set) []string {
 	return tags
 }
 
-// mapRbacTagsFromState maps RBAC tags from Terraform state to API model
-func (r *apdexConfigResource) mapRbacTagsFromState(rbacTagModels []RbacTagModel) []api.RbacTag {
-	if rbacTagModels == nil {
+// mapRbacTagsFromState maps RBAC tags from Terraform state List to API model
+func (r *apdexConfigResource) mapRbacTagsFromState(rbacTagsList types.List) []api.RbacTag {
+	if rbacTagsList.IsNull() || rbacTagsList.IsUnknown() {
 		return []api.RbacTag{}
 	}
 
-	rbacTags := make([]api.RbacTag, 0, len(rbacTagModels))
-	for _, model := range rbacTagModels {
+	var tagModels []RbacTagModel
+	rbacTagsList.ElementsAs(context.Background(), &tagModels, false)
+
+	if len(tagModels) == 0 {
+		return []api.RbacTag{}
+	}
+
+	rbacTags := make([]api.RbacTag, 0, len(tagModels))
+	for _, model := range tagModels {
 		rbacTags = append(rbacTags, api.RbacTag{
 			DisplayName: model.DisplayName.ValueString(),
 			ID:          model.ID.ValueString(),
@@ -462,20 +470,36 @@ func (r *apdexConfigResource) mapTagsToState(tags []string) types.Set {
 	return types.SetValueMust(types.StringType, elements)
 }
 
-// mapRbacTagsToState converts RBAC tags from API to state
-func (r *apdexConfigResource) mapRbacTagsToState(rbacTags []api.RbacTag) []RbacTagModel {
-	if rbacTags == nil {
-		return nil
+// mapRbacTagsToState converts RBAC tags from API to state List
+func (r *apdexConfigResource) mapRbacTagsToState(rbacTags []api.RbacTag) types.List {
+	tagAttrTypes := map[string]attr.Type{
+		SchemaFieldID:          types.StringType,
+		SchemaFieldDisplayName: types.StringType,
 	}
 
-	stateRbacTags := make([]RbacTagModel, 0, len(rbacTags))
-	for _, tag := range rbacTags {
-		stateRbacTags = append(stateRbacTags, RbacTagModel{
-			DisplayName: types.StringValue(tag.DisplayName),
-			ID:          types.StringValue(tag.ID),
-		})
+	// Always initialize with empty list, even if data is null or empty
+	if rbacTags == nil || len(rbacTags) == 0 {
+		emptyList, _ := types.ListValue(
+			types.ObjectType{AttrTypes: tagAttrTypes},
+			[]attr.Value{},
+		)
+		return emptyList
 	}
-	return stateRbacTags
+
+	tagValues := make([]attr.Value, len(rbacTags))
+	for i, tag := range rbacTags {
+		tagObj, _ := types.ObjectValue(
+			tagAttrTypes,
+			map[string]attr.Value{
+				SchemaFieldID:          types.StringValue(tag.ID),
+				SchemaFieldDisplayName: types.StringValue(tag.DisplayName),
+			},
+		)
+		tagValues[i] = tagObj
+	}
+
+	list, _ := types.ListValue(types.ObjectType{AttrTypes: tagAttrTypes}, tagValues)
+	return list
 }
 
 // mapEntityToState maps API entity to Terraform state

--- a/internal/resources/apdexconfig/resource-apdex-config_test.go
+++ b/internal/resources/apdexconfig/resource-apdex-config_test.go
@@ -364,30 +364,42 @@ func TestMapRbacTagsToState(t *testing.T) {
 				ID:          "team-b-id",
 			},
 		}
-	
+
 		result := resource.mapRbacTagsToState(rbacTags)
-	
+
 		assert.NotNil(t, result)
-		assert.Equal(t, 2, len(result))
-		assert.Equal(t, "Team A", result[0].DisplayName.ValueString())
-		assert.Equal(t, "team-a-id", result[0].ID.ValueString())
-		assert.Equal(t, "Team B", result[1].DisplayName.ValueString())
-		assert.Equal(t, "team-b-id", result[1].ID.ValueString())
+		assert.False(t, result.IsNull())
+		assert.False(t, result.IsUnknown())
+
+		var tagModels []RbacTagModel
+		result.ElementsAs(context.Background(), &tagModels, false)
+		assert.Equal(t, 2, len(tagModels))
+		assert.Equal(t, "Team A", tagModels[0].DisplayName.ValueString())
+		assert.Equal(t, "team-a-id", tagModels[0].ID.ValueString())
+		assert.Equal(t, "Team B", tagModels[1].DisplayName.ValueString())
+		assert.Equal(t, "team-b-id", tagModels[1].ID.ValueString())
 	})
-	
-	t.Run("should return nil for empty RBAC tags", func(t *testing.T) {
+
+	t.Run("should return empty list for empty RBAC tags", func(t *testing.T) {
 		rbacTags := []api.RbacTag{}
-	
+
 		result := resource.mapRbacTagsToState(rbacTags)
-	
+
 		assert.NotNil(t, result)
-		assert.Equal(t, 0, len(result))
+		assert.False(t, result.IsNull())
+		var tagModels []RbacTagModel
+		result.ElementsAs(context.Background(), &tagModels, false)
+		assert.Equal(t, 0, len(tagModels))
 	})
-	
-	t.Run("should return nil for nil RBAC tags", func(t *testing.T) {
+
+	t.Run("should return empty list for nil RBAC tags", func(t *testing.T) {
 		result := resource.mapRbacTagsToState(nil)
-	
-		assert.Nil(t, result)
+
+		assert.NotNil(t, result)
+		assert.False(t, result.IsNull())
+		var tagModels []RbacTagModel
+		result.ElementsAs(context.Background(), &tagModels, false)
+		assert.Equal(t, 0, len(tagModels))
 	})
 }
 
@@ -437,7 +449,7 @@ func TestMapEntityToState(t *testing.T) {
 		boundaryScope := "ALL"
 		includeInternal := true
 		includeSynthetic := false
-		
+
 		entity := api.ApdexEntity{
 			Type:             "application",
 			EntityID:         "app-123",
@@ -461,7 +473,7 @@ func TestMapEntityToState(t *testing.T) {
 
 	t.Run("should map website entity to state", func(t *testing.T) {
 		beaconType := "pageLoad"
-		
+
 		entity := api.ApdexEntity{
 			Type:       "website",
 			EntityID:   "website-456",

--- a/internal/resources/customdashboard/custom-dashboard-model.go
+++ b/internal/resources/customdashboard/custom-dashboard-model.go
@@ -10,6 +10,7 @@ type CustomDashboardModel struct {
 	ID          types.String         `tfsdk:"id"`
 	Title       types.String         `tfsdk:"title"`
 	AccessRules []AccessRuleModel    `tfsdk:"access_rule"`
+	RbacTags    []RbacTagModel       `tfsdk:"rbac_tags"`
 	Widgets     jsontypes.Normalized `tfsdk:"widgets"`
 }
 
@@ -18,4 +19,10 @@ type AccessRuleModel struct {
 	AccessType   types.String `tfsdk:"access_type"`
 	RelatedID    types.String `tfsdk:"related_id"`
 	RelationType types.String `tfsdk:"relation_type"`
+}
+
+// RbacTagModel represents an RBAC tag of the custom dashboard
+type RbacTagModel struct {
+	DisplayName types.String `tfsdk:"display_name"`
+	ID          types.String `tfsdk:"id"`
 }

--- a/internal/resources/customdashboard/custom-dashboard-model.go
+++ b/internal/resources/customdashboard/custom-dashboard-model.go
@@ -10,7 +10,7 @@ type CustomDashboardModel struct {
 	ID          types.String         `tfsdk:"id"`
 	Title       types.String         `tfsdk:"title"`
 	AccessRules []AccessRuleModel    `tfsdk:"access_rule"`
-	RbacTags    []RbacTagModel       `tfsdk:"rbac_tags"`
+	RbacTags    types.List           `tfsdk:"rbac_tags"`
 	Widgets     jsontypes.Normalized `tfsdk:"widgets"`
 }
 

--- a/internal/resources/customdashboard/resource-custom-dashboard-constants.go
+++ b/internal/resources/customdashboard/resource-custom-dashboard-constants.go
@@ -18,6 +18,12 @@ const (
 	CustomDashboardFieldAccessRuleRelationType = "relation_type"
 	//CustomDashboardFieldWidgets constant value for the schema field widgets
 	CustomDashboardFieldWidgets = "widgets"
+	//CustomDashboardFieldRbacTags constant value for the schema field rbac_tags
+	CustomDashboardFieldRbacTags = "rbac_tags"
+	//CustomDashboardFieldRbacTagDisplayName constant value for the schema field rbac_tags.display_name
+	CustomDashboardFieldRbacTagDisplayName = "display_name"
+	//CustomDashboardFieldRbacTagID constant value for the schema field rbac_tags.id
+	CustomDashboardFieldRbacTagID = "id"
 )
 
 // Resource description
@@ -35,6 +41,11 @@ const CustomDashboardDescAccessRule = "The access rules applied to the custom da
 const CustomDashboardDescAccessRuleAccessType = "The access type of the given access rule."
 const CustomDashboardDescAccessRuleRelatedID = "The id of the related entity (user, api_token, etc.) of the given access rule."
 const CustomDashboardDescAccessRuleRelationType = "The relation type of the given access rule."
+
+// Field descriptions - RBAC Tags
+const CustomDashboardDescRbacTags = "RBAC tags (teams) the custom dashboard is assigned to."
+const CustomDashboardDescRbacTagDisplayName = "Display name of the RBAC tag (team)."
+const CustomDashboardDescRbacTagID = "ID of the RBAC tag (team)."
 
 // Error messages
 const CustomDashboardErrMarshalWidgets = "Error marshaling widgets"

--- a/internal/resources/customdashboard/resource-custom-dashboard.go
+++ b/internal/resources/customdashboard/resource-custom-dashboard.go
@@ -81,6 +81,22 @@ func NewCustomDashboardResourceHandle() resourcehandle.ResourceHandle[*api.Custo
 							},
 						},
 					},
+					CustomDashboardFieldRbacTags: schema.ListNestedAttribute{
+						Description: CustomDashboardDescRbacTags,
+						Optional:    true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								CustomDashboardFieldRbacTagID: schema.StringAttribute{
+									Required:    true,
+									Description: CustomDashboardDescRbacTagID,
+								},
+								CustomDashboardFieldRbacTagDisplayName: schema.StringAttribute{
+									Required:    true,
+									Description: CustomDashboardDescRbacTagDisplayName,
+								},
+							},
+						},
+					},
 				},
 			},
 			SchemaVersion: 2,
@@ -154,6 +170,17 @@ func (r *customDashboardResource) UpdateState(ctx context.Context, state *tfsdk.
 	// Map access rules
 	model.AccessRules = r.mapAccessRulesToState(dashboard.AccessRules)
 
+	// Map RBAC tags (team assignments). The Instana create/update API does not
+	// echo rbacTags back in its response, so on Create/Update (plan != nil) we
+	// keep the configured value to avoid an "inconsistent result" error. On
+	// Read (plan == nil) we populate from the API. This mirrors the widgets
+	// handling above.
+	if plan != nil {
+		// keep model.RbacTags as provided by the plan
+	} else {
+		model.RbacTags = r.mapRbacTagsToState(dashboard.RbacTags)
+	}
+
 	// Set the entire model to state
 	diags.Append(state.Set(ctx, model)...)
 	return diags
@@ -177,9 +204,22 @@ func (r *customDashboardResource) mapAccessRulesToState(accessRules []model.Acce
 	return models
 }
 
-// ============================================================================
-// State to API Mapping
-// ============================================================================
+// mapRbacTagsToState converts RBAC tags from API format to state models
+func (r *customDashboardResource) mapRbacTagsToState(rbacTags []api.RbacTag) []RbacTagModel {
+	if len(rbacTags) == 0 {
+		return nil
+	}
+
+	models := make([]RbacTagModel, len(rbacTags))
+	for i, tag := range rbacTags {
+		models[i] = RbacTagModel{
+			DisplayName: types.StringValue(tag.DisplayName),
+			ID:          types.StringValue(tag.ID),
+		}
+	}
+
+	return models
+}
 
 // MapStateToDataObject converts Terraform state to API data object
 func (r *customDashboardResource) MapStateToDataObject(ctx context.Context, plan *tfsdk.Plan, state *tfsdk.State) (*api.CustomDashboard, diag.Diagnostics) {
@@ -217,6 +257,7 @@ func (r *customDashboardResource) MapStateToDataObject(ctx context.Context, plan
 		ID:          id,
 		Title:       model.Title.ValueString(),
 		AccessRules: accessRules,
+		RbacTags:    r.mapRbacTagsFromState(model.RbacTags),
 		Widgets:     widgets,
 	}, diags
 }
@@ -248,6 +289,23 @@ func (r *customDashboardResource) mapAccessRulesFromState(accessRuleModels []Acc
 	}
 
 	return accessRules
+}
+
+// mapRbacTagsFromState converts RBAC tag models from state to API format
+func (r *customDashboardResource) mapRbacTagsFromState(rbacTagModels []RbacTagModel) []api.RbacTag {
+	if len(rbacTagModels) == 0 {
+		return nil
+	}
+
+	rbacTags := make([]api.RbacTag, len(rbacTagModels))
+	for i, tagModel := range rbacTagModels {
+		rbacTags[i] = api.RbacTag{
+			DisplayName: tagModel.DisplayName.ValueString(),
+			ID:          tagModel.ID.ValueString(),
+		}
+	}
+
+	return rbacTags
 }
 
 // GetStateUpgraders returns the state upgraders for this resource

--- a/internal/resources/customdashboard/resource-custom-dashboard.go
+++ b/internal/resources/customdashboard/resource-custom-dashboard.go
@@ -145,11 +145,7 @@ func (r *customDashboardResource) UpdateState(ctx context.Context, state *tfsdk.
 	} else {
 		model = CustomDashboardModel{}
 	}
-	// Create a model and populate it with values from the dashboard
-	// model = CustomDashboardModel{
-	// 	ID:    types.StringValue(dashboard.ID),
-	// 	Title: types.StringValue(dashboard.Title),
-	// }
+
 	model.ID = types.StringValue(dashboard.ID)
 	model.Title = types.StringValue(dashboard.Title)
 
@@ -172,16 +168,7 @@ func (r *customDashboardResource) UpdateState(ctx context.Context, state *tfsdk.
 	// Map access rules
 	model.AccessRules = r.mapAccessRulesToState(dashboard.AccessRules)
 
-	// Map RBAC tags (team assignments). The Instana create/update API does not
-	// echo rbacTags back in its response, so on Create/Update (plan != nil) we
-	// keep the configured value to avoid an "inconsistent result" error. On
-	// Read (plan == nil) we populate from the API. This mirrors the widgets
-	// handling above.
-	if plan != nil {
-		// keep model.RbacTags as provided by the plan
-	} else {
-		model.RbacTags = r.mapRbacTagsToState(dashboard.RbacTags)
-	}
+	model.RbacTags = r.mapRbacTagsToState(dashboard.RbacTags)
 
 	// Set the entire model to state
 	diags.Append(state.Set(ctx, model)...)

--- a/internal/resources/customdashboard/resource-custom-dashboard.go
+++ b/internal/resources/customdashboard/resource-custom-dashboard.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -84,6 +85,7 @@ func NewCustomDashboardResourceHandle() resourcehandle.ResourceHandle[*api.Custo
 					CustomDashboardFieldRbacTags: schema.ListNestedAttribute{
 						Description: CustomDashboardDescRbacTags,
 						Optional:    true,
+						Computed:    true,
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								CustomDashboardFieldRbacTagID: schema.StringAttribute{
@@ -204,21 +206,36 @@ func (r *customDashboardResource) mapAccessRulesToState(accessRules []model.Acce
 	return models
 }
 
-// mapRbacTagsToState converts RBAC tags from API format to state models
-func (r *customDashboardResource) mapRbacTagsToState(rbacTags []api.RbacTag) []RbacTagModel {
+// mapRbacTagsToState converts RBAC tags from API format to state List
+func (r *customDashboardResource) mapRbacTagsToState(rbacTags []api.RbacTag) types.List {
+	tagAttrTypes := map[string]attr.Type{
+		CustomDashboardFieldRbacTagID:          types.StringType,
+		CustomDashboardFieldRbacTagDisplayName: types.StringType,
+	}
+
+	// Always initialize with empty list, even if data is null or empty
 	if len(rbacTags) == 0 {
-		return nil
+		emptyList, _ := types.ListValue(
+			types.ObjectType{AttrTypes: tagAttrTypes},
+			[]attr.Value{},
+		)
+		return emptyList
 	}
 
-	models := make([]RbacTagModel, len(rbacTags))
+	tagValues := make([]attr.Value, len(rbacTags))
 	for i, tag := range rbacTags {
-		models[i] = RbacTagModel{
-			DisplayName: types.StringValue(tag.DisplayName),
-			ID:          types.StringValue(tag.ID),
-		}
+		tagObj, _ := types.ObjectValue(
+			tagAttrTypes,
+			map[string]attr.Value{
+				CustomDashboardFieldRbacTagID:          types.StringValue(tag.ID),
+				CustomDashboardFieldRbacTagDisplayName: types.StringValue(tag.DisplayName),
+			},
+		)
+		tagValues[i] = tagObj
 	}
 
-	return models
+	list, _ := types.ListValue(types.ObjectType{AttrTypes: tagAttrTypes}, tagValues)
+	return list
 }
 
 // MapStateToDataObject converts Terraform state to API data object
@@ -291,14 +308,22 @@ func (r *customDashboardResource) mapAccessRulesFromState(accessRuleModels []Acc
 	return accessRules
 }
 
-// mapRbacTagsFromState converts RBAC tag models from state to API format
-func (r *customDashboardResource) mapRbacTagsFromState(rbacTagModels []RbacTagModel) []api.RbacTag {
-	if len(rbacTagModels) == 0 {
-		return nil
+// mapRbacTagsFromState converts RBAC tag models from state List to API format
+func (r *customDashboardResource) mapRbacTagsFromState(rbacTagsList types.List) []api.RbacTag {
+	// Always initialize with empty array, even if data is null or empty
+	if rbacTagsList.IsNull() || rbacTagsList.IsUnknown() {
+		return []api.RbacTag{}
 	}
 
-	rbacTags := make([]api.RbacTag, len(rbacTagModels))
-	for i, tagModel := range rbacTagModels {
+	var tagModels []RbacTagModel
+	rbacTagsList.ElementsAs(context.Background(), &tagModels, false)
+
+	if len(tagModels) == 0 {
+		return []api.RbacTag{}
+	}
+
+	rbacTags := make([]api.RbacTag, len(tagModels))
+	for i, tagModel := range tagModels {
 		rbacTags[i] = api.RbacTag{
 			DisplayName: tagModel.DisplayName.ValueString(),
 			ID:          tagModel.ID.ValueString(),

--- a/internal/resources/customdashboard/resource-custom-dashboard_test.go
+++ b/internal/resources/customdashboard/resource-custom-dashboard_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/instana/instana-go-client/api"
@@ -165,10 +166,20 @@ func TestUpdateState(t *testing.T) {
 		}
 
 		// Create plan with model
+		tagAttrTypes := map[string]attr.Type{
+			CustomDashboardFieldRbacTagID:          types.StringType,
+			CustomDashboardFieldRbacTagDisplayName: types.StringType,
+		}
+		emptyList, _ := types.ListValue(
+			types.ObjectType{AttrTypes: tagAttrTypes},
+			[]attr.Value{},
+		)
+
 		planModel := CustomDashboardModel{
-			ID:      types.StringValue("dashboard-123"),
-			Title:   types.StringValue("Test Dashboard"),
-			Widgets: jsontypes.NewNormalizedValue(`[{"type":"chart","data":"test"}]`),
+			ID:       types.StringValue("dashboard-123"),
+			Title:    types.StringValue("Test Dashboard"),
+			Widgets:  jsontypes.NewNormalizedValue(`[{"type":"chart","data":"test"}]`),
+			RbacTags: emptyList,
 			AccessRules: []AccessRuleModel{
 				{
 					AccessType:   types.StringValue("READ"),
@@ -315,10 +326,20 @@ func TestUpdateState(t *testing.T) {
 			},
 		}
 
+		tagAttrTypes := map[string]attr.Type{
+			CustomDashboardFieldRbacTagID:          types.StringType,
+			CustomDashboardFieldRbacTagDisplayName: types.StringType,
+		}
+		emptyList, _ := types.ListValue(
+			types.ObjectType{AttrTypes: tagAttrTypes},
+			[]attr.Value{},
+		)
+
 		planModel := CustomDashboardModel{
-			ID:      types.StringValue("dashboard-multi"),
-			Title:   types.StringValue("Multi Access Dashboard"),
-			Widgets: jsontypes.NewNormalizedValue(`[]`),
+			ID:       types.StringValue("dashboard-multi"),
+			Title:    types.StringValue("Multi Access Dashboard"),
+			Widgets:  jsontypes.NewNormalizedValue(`[]`),
+			RbacTags: emptyList,
 			AccessRules: []AccessRuleModel{
 				{
 					AccessType:   types.StringValue("READ"),
@@ -360,10 +381,20 @@ func TestMapStateToDataObject(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("from plan - complete dashboard", func(t *testing.T) {
+		tagAttrTypes := map[string]attr.Type{
+			CustomDashboardFieldRbacTagID:          types.StringType,
+			CustomDashboardFieldRbacTagDisplayName: types.StringType,
+		}
+		emptyList, _ := types.ListValue(
+			types.ObjectType{AttrTypes: tagAttrTypes},
+			[]attr.Value{},
+		)
+
 		model := CustomDashboardModel{
-			ID:      types.StringValue("dashboard-123"),
-			Title:   types.StringValue("Test Dashboard"),
-			Widgets: jsontypes.NewNormalizedValue(`[{"type":"chart","data":"test"}]`),
+			ID:       types.StringValue("dashboard-123"),
+			Title:    types.StringValue("Test Dashboard"),
+			Widgets:  jsontypes.NewNormalizedValue(`[{"type":"chart","data":"test"}]`),
+			RbacTags: emptyList,
 			AccessRules: []AccessRuleModel{
 				{
 					AccessType:   types.StringValue("READ"),
@@ -393,10 +424,20 @@ func TestMapStateToDataObject(t *testing.T) {
 	})
 
 	t.Run("from state - complete dashboard", func(t *testing.T) {
+		tagAttrTypes := map[string]attr.Type{
+			CustomDashboardFieldRbacTagID:          types.StringType,
+			CustomDashboardFieldRbacTagDisplayName: types.StringType,
+		}
+		emptyList, _ := types.ListValue(
+			types.ObjectType{AttrTypes: tagAttrTypes},
+			[]attr.Value{},
+		)
+
 		model := CustomDashboardModel{
-			ID:      types.StringValue("dashboard-456"),
-			Title:   types.StringValue("State Dashboard"),
-			Widgets: jsontypes.NewNormalizedValue(`{"widgets":[{"id":"w1"}]}`),
+			ID:       types.StringValue("dashboard-456"),
+			Title:    types.StringValue("State Dashboard"),
+			Widgets:  jsontypes.NewNormalizedValue(`{"widgets":[{"id":"w1"}]}`),
+			RbacTags: emptyList,
 			AccessRules: []AccessRuleModel{
 				{
 					AccessType:   types.StringValue("READ_WRITE"),
@@ -420,10 +461,20 @@ func TestMapStateToDataObject(t *testing.T) {
 	})
 
 	t.Run("with null ID", func(t *testing.T) {
+		tagAttrTypes := map[string]attr.Type{
+			CustomDashboardFieldRbacTagID:          types.StringType,
+			CustomDashboardFieldRbacTagDisplayName: types.StringType,
+		}
+		emptyList, _ := types.ListValue(
+			types.ObjectType{AttrTypes: tagAttrTypes},
+			[]attr.Value{},
+		)
+
 		model := CustomDashboardModel{
-			ID:      types.StringNull(),
-			Title:   types.StringValue("New Dashboard"),
-			Widgets: jsontypes.NewNormalizedValue(`[]`),
+			ID:       types.StringNull(),
+			Title:    types.StringValue("New Dashboard"),
+			Widgets:  jsontypes.NewNormalizedValue(`[]`),
+			RbacTags: emptyList,
 		}
 
 		plan := createMockPlan(t, ctx, model)
@@ -436,10 +487,20 @@ func TestMapStateToDataObject(t *testing.T) {
 	})
 
 	t.Run("with null widgets", func(t *testing.T) {
+		tagAttrTypes := map[string]attr.Type{
+			CustomDashboardFieldRbacTagID:          types.StringType,
+			CustomDashboardFieldRbacTagDisplayName: types.StringType,
+		}
+		emptyList, _ := types.ListValue(
+			types.ObjectType{AttrTypes: tagAttrTypes},
+			[]attr.Value{},
+		)
+
 		model := CustomDashboardModel{
-			ID:      types.StringValue("dashboard-789"),
-			Title:   types.StringValue("No Widgets Dashboard"),
-			Widgets: jsontypes.NewNormalizedNull(),
+			ID:       types.StringValue("dashboard-789"),
+			Title:    types.StringValue("No Widgets Dashboard"),
+			Widgets:  jsontypes.NewNormalizedNull(),
+			RbacTags: emptyList,
 		}
 
 		plan := createMockPlan(t, ctx, model)
@@ -451,10 +512,20 @@ func TestMapStateToDataObject(t *testing.T) {
 	})
 
 	t.Run("with empty access rules", func(t *testing.T) {
+		tagAttrTypes := map[string]attr.Type{
+			CustomDashboardFieldRbacTagID:          types.StringType,
+			CustomDashboardFieldRbacTagDisplayName: types.StringType,
+		}
+		emptyList, _ := types.ListValue(
+			types.ObjectType{AttrTypes: tagAttrTypes},
+			[]attr.Value{},
+		)
+
 		model := CustomDashboardModel{
 			ID:          types.StringValue("dashboard-empty"),
 			Title:       types.StringValue("Empty Rules Dashboard"),
 			Widgets:     jsontypes.NewNormalizedValue(`[]`),
+			RbacTags:    emptyList,
 			AccessRules: []AccessRuleModel{},
 		}
 
@@ -467,10 +538,20 @@ func TestMapStateToDataObject(t *testing.T) {
 	})
 
 	t.Run("with global access rule without related ID", func(t *testing.T) {
+		tagAttrTypes := map[string]attr.Type{
+			CustomDashboardFieldRbacTagID:          types.StringType,
+			CustomDashboardFieldRbacTagDisplayName: types.StringType,
+		}
+		emptyList, _ := types.ListValue(
+			types.ObjectType{AttrTypes: tagAttrTypes},
+			[]attr.Value{},
+		)
+
 		model := CustomDashboardModel{
-			ID:      types.StringValue("dashboard-global"),
-			Title:   types.StringValue("Global Dashboard"),
-			Widgets: jsontypes.NewNormalizedValue(`[]`),
+			ID:       types.StringValue("dashboard-global"),
+			Title:    types.StringValue("Global Dashboard"),
+			Widgets:  jsontypes.NewNormalizedValue(`[]`),
+			RbacTags: emptyList,
 			AccessRules: []AccessRuleModel{
 				{
 					AccessType:   types.StringValue("READ"),
@@ -511,10 +592,20 @@ func TestMapStateToDataObject(t *testing.T) {
 			]
 		}`
 
+		tagAttrTypes := map[string]attr.Type{
+			CustomDashboardFieldRbacTagID:          types.StringType,
+			CustomDashboardFieldRbacTagDisplayName: types.StringType,
+		}
+		emptyList, _ := types.ListValue(
+			types.ObjectType{AttrTypes: tagAttrTypes},
+			[]attr.Value{},
+		)
+
 		model := CustomDashboardModel{
-			ID:      types.StringValue("dashboard-complex"),
-			Title:   types.StringValue("Complex Dashboard"),
-			Widgets: jsontypes.NewNormalizedValue(complexWidgets),
+			ID:       types.StringValue("dashboard-complex"),
+			Title:    types.StringValue("Complex Dashboard"),
+			Widgets:  jsontypes.NewNormalizedValue(complexWidgets),
+			RbacTags: emptyList,
 		}
 
 		plan := createMockPlan(t, ctx, model)
@@ -530,10 +621,20 @@ func TestMapStateToDataObject(t *testing.T) {
 	})
 
 	t.Run("with all access types", func(t *testing.T) {
+		tagAttrTypes := map[string]attr.Type{
+			CustomDashboardFieldRbacTagID:          types.StringType,
+			CustomDashboardFieldRbacTagDisplayName: types.StringType,
+		}
+		emptyList, _ := types.ListValue(
+			types.ObjectType{AttrTypes: tagAttrTypes},
+			[]attr.Value{},
+		)
+
 		model := CustomDashboardModel{
-			ID:      types.StringValue("dashboard-all-types"),
-			Title:   types.StringValue("All Types Dashboard"),
-			Widgets: jsontypes.NewNormalizedValue(`[]`),
+			ID:       types.StringValue("dashboard-all-types"),
+			Title:    types.StringValue("All Types Dashboard"),
+			Widgets:  jsontypes.NewNormalizedValue(`[]`),
+			RbacTags: emptyList,
 			AccessRules: []AccessRuleModel{
 				{
 					AccessType:   types.StringValue("READ"),
@@ -727,10 +828,20 @@ func stringPtr(s string) *string {
 
 // initializeEmptyState initializes the state with an empty CustomDashboardModel
 func initializeEmptyState(t *testing.T, ctx context.Context, state *tfsdk.State) {
+	tagAttrTypes := map[string]attr.Type{
+		CustomDashboardFieldRbacTagID:          types.StringType,
+		CustomDashboardFieldRbacTagDisplayName: types.StringType,
+	}
+	emptyList, _ := types.ListValue(
+		types.ObjectType{AttrTypes: tagAttrTypes},
+		[]attr.Value{},
+	)
+
 	emptyModel := CustomDashboardModel{
 		ID:          types.StringNull(),
 		Title:       types.StringNull(),
 		AccessRules: []AccessRuleModel{},
+		RbacTags:    emptyList,
 		Widgets:     jsontypes.NewNormalizedNull(),
 	}
 	diags := state.Set(ctx, emptyModel)

--- a/internal/resources/infralertconfig/resource-infra-alert-config_test.go
+++ b/internal/resources/infralertconfig/resource-infra-alert-config_test.go
@@ -1560,8 +1560,9 @@ func TestUpdateState_WithEmptyCustomPayloadFields(t *testing.T) {
 	diags = state.Get(ctx, &model)
 	require.False(t, diags.HasError())
 
-	// Empty custom payload fields should result in null list
-	assert.True(t, model.CustomPayloadField.IsNull())
+	// Empty custom payload fields should result in empty list (not null)
+	assert.False(t, model.CustomPayloadField.IsNull())
+	assert.True(t, len(model.CustomPayloadField.Elements()) == 0)
 }
 
 func TestMapStateToDataObject_WithEmptyAlertChannelLists(t *testing.T) {

--- a/internal/resources/sloconfig/resource-slo-config.go
+++ b/internal/resources/sloconfig/resource-slo-config.go
@@ -118,6 +118,7 @@ func buildTagsAttribute() schema.SetAttribute {
 func buildRbacTagsAttribute() schema.ListNestedAttribute {
 	return schema.ListNestedAttribute{
 		Optional:    true,
+		Computed:    true,
 		Description: SloConfigDescRbacTags,
 		Validators: []validator.List{
 			listvalidator.SizeAtLeast(1),
@@ -590,16 +591,27 @@ func (r *sloConfigResource) mapTagsFromState(tags types.Set) []string {
 	return tagsList
 }
 
-// mapRbacTagsFromState converts RBAC tags from state to API model
-func (r *sloConfigResource) mapRbacTagsFromState(rbacTags []RbacTagModel) []api.RbacTag {
-	rbacTagsList := make([]api.RbacTag, 0, len(rbacTags))
-	for _, t := range rbacTags {
-		rbacTagsList = append(rbacTagsList, api.RbacTag{
+// mapRbacTagsFromState converts RBAC tags from state List to API model
+func (r *sloConfigResource) mapRbacTagsFromState(rbacTagsList types.List) []api.RbacTag {
+	if rbacTagsList.IsNull() || rbacTagsList.IsUnknown() {
+		return []api.RbacTag{}
+	}
+
+	var tagModels []RbacTagModel
+	rbacTagsList.ElementsAs(context.Background(), &tagModels, false)
+
+	if len(tagModels) == 0 {
+		return []api.RbacTag{}
+	}
+
+	rbacTags := make([]api.RbacTag, 0, len(tagModels))
+	for _, t := range tagModels {
+		rbacTags = append(rbacTags, api.RbacTag{
 			DisplayName: t.DisplayName.ValueString(),
 			ID:          t.ID.ValueString(),
 		})
 	}
-	return rbacTagsList
+	return rbacTags
 }
 
 func (r *sloConfigResource) mapEntityFromState(entityObj EntityModel) (api.SloEntity, diag.Diagnostics) {
@@ -1204,20 +1216,36 @@ func (r *sloConfigResource) mapTagsToState(tags []string) types.Set {
 	return types.SetValueMust(types.StringType, elements)
 }
 
-// mapRbacTagsToState converts RBAC tags from API to state
-func (r *sloConfigResource) mapRbacTagsToState(rbacTags []api.RbacTag) []RbacTagModel {
-	if rbacTags == nil {
-		return nil
+// mapRbacTagsToState converts RBAC tags from API to state List
+func (r *sloConfigResource) mapRbacTagsToState(rbacTags []api.RbacTag) types.List {
+	tagAttrTypes := map[string]attr.Type{
+		SchemaFieldID:          types.StringType,
+		SchemaFieldDisplayName: types.StringType,
 	}
 
-	stateRbacTags := make([]RbacTagModel, 0, len(rbacTags))
-	for _, tag := range rbacTags {
-		stateRbacTags = append(stateRbacTags, RbacTagModel{
-			DisplayName: types.StringValue(tag.DisplayName),
-			ID:          types.StringValue(tag.ID),
-		})
+	// Always initialize with empty list, even if data is null or empty
+	if rbacTags == nil || len(rbacTags) == 0 {
+		emptyList, _ := types.ListValue(
+			types.ObjectType{AttrTypes: tagAttrTypes},
+			[]attr.Value{},
+		)
+		return emptyList
 	}
-	return stateRbacTags
+
+	tagValues := make([]attr.Value, len(rbacTags))
+	for i, tag := range rbacTags {
+		tagObj, _ := types.ObjectValue(
+			tagAttrTypes,
+			map[string]attr.Value{
+				SchemaFieldID:          types.StringValue(tag.ID),
+				SchemaFieldDisplayName: types.StringValue(tag.DisplayName),
+			},
+		)
+		tagValues[i] = tagObj
+	}
+
+	list, _ := types.ListValue(types.ObjectType{AttrTypes: tagAttrTypes}, tagValues)
+	return list
 }
 
 func (r *sloConfigResource) mapEntityToState(apiObject *api.SloConfig, currentEntityModel *EntityModel) (EntityModel, diag.Diagnostics) {

--- a/internal/resources/sloconfig/resource-slo-config.go
+++ b/internal/resources/sloconfig/resource-slo-config.go
@@ -1174,9 +1174,7 @@ func (r *sloConfigResource) UpdateState(ctx context.Context, state *tfsdk.State,
 	if len(apiObject.Tags) > 0 {
 		model.Tags = r.mapTagsToState(apiObject.Tags)
 	}
-	if len(apiObject.RbacTags) > 0 {
-		model.RbacTags = r.mapRbacTagsToState(apiObject.RbacTags)
-	}
+	model.RbacTags = r.mapRbacTagsToState(apiObject.RbacTags)
 
 	entityData, entityDiags := r.mapEntityToState(apiObject, model.Entity)
 	diags.Append(entityDiags...)

--- a/internal/resources/sloconfig/resource-slo-config_test.go
+++ b/internal/resources/sloconfig/resource-slo-config_test.go
@@ -667,18 +667,31 @@ func TestMapRbacTags(t *testing.T) {
 	resource := &sloConfigResource{}
 
 	t.Run("should map RBAC tags successfully", func(t *testing.T) {
-		rbacTags := []RbacTagModel{
-			{
-				DisplayName: types.StringValue("Team A"),
-				ID:          types.StringValue("team-a-id"),
-			},
-			{
-				DisplayName: types.StringValue("Team B"),
-				ID:          types.StringValue("team-b-id"),
-			},
+		tagAttrTypes := map[string]attr.Type{
+			SchemaFieldID:          types.StringType,
+			SchemaFieldDisplayName: types.StringType,
 		}
 
-		result := resource.mapRbacTagsFromState(rbacTags)
+		tagValues := []attr.Value{
+			func() attr.Value {
+				obj, _ := types.ObjectValue(tagAttrTypes, map[string]attr.Value{
+					SchemaFieldID:          types.StringValue("team-a-id"),
+					SchemaFieldDisplayName: types.StringValue("Team A"),
+				})
+				return obj
+			}(),
+			func() attr.Value {
+				obj, _ := types.ObjectValue(tagAttrTypes, map[string]attr.Value{
+					SchemaFieldID:          types.StringValue("team-b-id"),
+					SchemaFieldDisplayName: types.StringValue("Team B"),
+				})
+				return obj
+			}(),
+		}
+
+		rbacTagsList, _ := types.ListValue(types.ObjectType{AttrTypes: tagAttrTypes}, tagValues)
+
+		result := resource.mapRbacTagsFromState(rbacTagsList)
 
 		assert.Len(t, result, 2)
 		assert.Equal(t, "Team A", result[0].DisplayName)
@@ -688,7 +701,13 @@ func TestMapRbacTags(t *testing.T) {
 	})
 
 	t.Run("should return empty slice for no RBAC tags", func(t *testing.T) {
-		result := resource.mapRbacTagsFromState([]RbacTagModel{})
+		tagAttrTypes := map[string]attr.Type{
+			SchemaFieldID:          types.StringType,
+			SchemaFieldDisplayName: types.StringType,
+		}
+		emptyList, _ := types.ListValue(types.ObjectType{AttrTypes: tagAttrTypes}, []attr.Value{})
+
+		result := resource.mapRbacTagsFromState(emptyList)
 
 		assert.Empty(t, result)
 	})
@@ -1377,12 +1396,18 @@ func TestMapStateToDataObjectWithFullModel(t *testing.T) {
 				types.StringValue("tag1"),
 				types.StringValue("tag2"),
 			}),
-			RbacTags: []RbacTagModel{
-				{
-					DisplayName: types.StringValue("Team A"),
-					ID:          types.StringValue("team-a-id"),
-				},
-			},
+			RbacTags: func() types.List {
+				tagAttrTypes := map[string]attr.Type{
+					SchemaFieldID:          types.StringType,
+					SchemaFieldDisplayName: types.StringType,
+				}
+				tagObj, _ := types.ObjectValue(tagAttrTypes, map[string]attr.Value{
+					SchemaFieldID:          types.StringValue("team-a-id"),
+					SchemaFieldDisplayName: types.StringValue("Team A"),
+				})
+				list, _ := types.ListValue(types.ObjectType{AttrTypes: tagAttrTypes}, []attr.Value{tagObj})
+				return list
+			}(),
 			Entity: &EntityModel{
 				ApplicationEntityModel: &ApplicationEntityModel{
 					ApplicationID:    types.StringValue("app-123"),
@@ -1667,14 +1692,45 @@ func TestMapRbacTagsWithMultipleTags(t *testing.T) {
 	resource := &sloConfigResource{}
 
 	t.Run("should map multiple RBAC tags", func(t *testing.T) {
-		rbacTags := []RbacTagModel{
-			{DisplayName: types.StringValue("Team A"), ID: types.StringValue("team-a")},
-			{DisplayName: types.StringValue("Team B"), ID: types.StringValue("team-b")},
-			{DisplayName: types.StringValue("Team C"), ID: types.StringValue("team-c")},
-			{DisplayName: types.StringValue("Team D"), ID: types.StringValue("team-d")},
+		tagAttrTypes := map[string]attr.Type{
+			SchemaFieldID:          types.StringType,
+			SchemaFieldDisplayName: types.StringType,
 		}
 
-		result := resource.mapRbacTagsFromState(rbacTags)
+		tagValues := []attr.Value{
+			func() attr.Value {
+				obj, _ := types.ObjectValue(tagAttrTypes, map[string]attr.Value{
+					SchemaFieldID:          types.StringValue("team-a"),
+					SchemaFieldDisplayName: types.StringValue("Team A"),
+				})
+				return obj
+			}(),
+			func() attr.Value {
+				obj, _ := types.ObjectValue(tagAttrTypes, map[string]attr.Value{
+					SchemaFieldID:          types.StringValue("team-b"),
+					SchemaFieldDisplayName: types.StringValue("Team B"),
+				})
+				return obj
+			}(),
+			func() attr.Value {
+				obj, _ := types.ObjectValue(tagAttrTypes, map[string]attr.Value{
+					SchemaFieldID:          types.StringValue("team-c"),
+					SchemaFieldDisplayName: types.StringValue("Team C"),
+				})
+				return obj
+			}(),
+			func() attr.Value {
+				obj, _ := types.ObjectValue(tagAttrTypes, map[string]attr.Value{
+					SchemaFieldID:          types.StringValue("team-d"),
+					SchemaFieldDisplayName: types.StringValue("Team D"),
+				})
+				return obj
+			}(),
+		}
+
+		rbacTagsList, _ := types.ListValue(types.ObjectType{AttrTypes: tagAttrTypes}, tagValues)
+
+		result := resource.mapRbacTagsFromState(rbacTagsList)
 
 		assert.Len(t, result, 4)
 		assert.Equal(t, "Team A", result[0].DisplayName)

--- a/internal/resources/sloconfig/resource-slo-config_test.go
+++ b/internal/resources/sloconfig/resource-slo-config_test.go
@@ -1651,11 +1651,21 @@ func TestUpdateStateWithEmptyTags(t *testing.T) {
 		}
 
 		// Initialize state with existing tags so UpdateState will process them
+		rbacTagAttrTypes := map[string]attr.Type{
+			"id":           types.StringType,
+			"display_name": types.StringType,
+		}
+		emptyRbacTags, _ := types.ListValue(
+			types.ObjectType{AttrTypes: rbacTagAttrTypes},
+			[]attr.Value{},
+		)
+
 		initialModel := SloConfigModel{
-			ID:     types.StringValue("test-id"),
-			Name:   types.StringValue("Old Name"),
-			Target: types.Float64Value(95.0),
-			Tags:   types.SetValueMust(types.StringType, []attr.Value{types.StringValue("existing-tag")}),
+			ID:       types.StringValue("test-id"),
+			Name:     types.StringValue("Old Name"),
+			Target:   types.Float64Value(95.0),
+			Tags:     types.SetValueMust(types.StringType, []attr.Value{types.StringValue("existing-tag")}),
+			RbacTags: emptyRbacTags,
 			Entity: &EntityModel{
 				ApplicationEntityModel: &ApplicationEntityModel{
 					ApplicationID: types.StringValue(appID),

--- a/internal/resources/sloconfig/slo-config-model.go
+++ b/internal/resources/sloconfig/slo-config-model.go
@@ -10,7 +10,7 @@ type SloConfigModel struct {
 	Name       types.String     `tfsdk:"name"`
 	Target     types.Float64    `tfsdk:"target"`
 	Tags       types.Set        `tfsdk:"tags"`
-	RbacTags   []RbacTagModel   `tfsdk:"rbac_tags"`
+	RbacTags   types.List       `tfsdk:"rbac_tags"`
 	Entity     *EntityModel     `tfsdk:"entity"`
 	Indicator  *IndicatorModel  `tfsdk:"indicator"`
 	TimeWindow *TimeWindowModel `tfsdk:"time_window"`
@@ -118,9 +118,9 @@ type TimeBasedSaturationIndicatorModel struct {
 
 // SaturationIndicatorModel represents a saturation indicator in the Terraform model
 type EventBasedSaturationIndicatorModel struct {
-	MetricName  types.String  `tfsdk:"metric_name"`
-	Threshold   types.Float64 `tfsdk:"threshold"`
-	Operator    types.String  `tfsdk:"operator"`
+	MetricName types.String  `tfsdk:"metric_name"`
+	Threshold  types.Float64 `tfsdk:"threshold"`
+	Operator   types.String  `tfsdk:"operator"`
 }
 
 // RollingTimeWindowModel represents a rolling time window in the Terraform model

--- a/internal/resources/syntheticalertconfig/resource-synthetic-alert-config.go
+++ b/internal/resources/syntheticalertconfig/resource-synthetic-alert-config.go
@@ -455,9 +455,9 @@ func (r *syntheticAlertConfigResource) mapTagFilterFromModel(model *SyntheticAle
 	return r.createDefaultTagFilter(), diags
 }
 
-// hasTagFilterValue checks if the model has a tag filter value
+// hasTagFilterValue checks if the model has a non-empty tag filter value
 func (r *syntheticAlertConfigResource) hasTagFilterValue(model *SyntheticAlertConfigModel) bool {
-	return !model.TagFilter.IsNull() && !model.TagFilter.IsUnknown()
+	return !model.TagFilter.IsNull() && !model.TagFilter.IsUnknown() && model.TagFilter.ValueString() != ""
 }
 
 // parseTagFilterExpression parses the tag filter expression string

--- a/internal/resources/synthetictest/resource-synthetic-test-constants.go
+++ b/internal/resources/synthetictest/resource-synthetic-test-constants.go
@@ -204,9 +204,15 @@ const (
 	SyntheticTestDescWebpageAction = "Webpage action test configuration"
 	SyntheticTestDescWebpageScript = "Webpage script test configuration"
 
+	// RBAC tag field names
+	SyntheticTestFieldRbacTagID          = "id"
+	SyntheticTestFieldRbacTagDisplayName = "display_name"
+
 	// RBAC tag descriptions
-	SyntheticTestDescTagName  = "Tag name"
-	SyntheticTestDescTagValue = "Tag value"
+	SyntheticTestDescRbacTagID          = "ID of the RBAC tag"
+	SyntheticTestDescRbacTagDisplayName = "Display name of the RBAC tag"
+	SyntheticTestDescTagName            = "Tag name"
+	SyntheticTestDescTagValue           = "Tag value"
 
 	// Error message constants
 	SyntheticTestErrConfigRequired       = "Configuration required"

--- a/internal/resources/synthetictest/resource-synthetic-test.go
+++ b/internal/resources/synthetictest/resource-synthetic-test.go
@@ -603,13 +603,13 @@ func buildBaseSchema() map[string]schema.Attribute {
 			Description: SyntheticTestDescRbacTags,
 			NestedObject: schema.NestedAttributeObject{
 				Attributes: map[string]schema.Attribute{
-					SyntheticTestFieldName: schema.StringAttribute{
+					"id": schema.StringAttribute{
 						Required:    true,
-						Description: SyntheticTestDescTagName,
+						Description: "ID of the RBAC tag",
 					},
-					SyntheticTestFieldValue: schema.StringAttribute{
+					"display_name": schema.StringAttribute{
 						Required:    true,
-						Description: SyntheticTestDescTagValue,
+						Description: "Display name of the RBAC tag",
 					},
 				},
 			},
@@ -794,17 +794,17 @@ func (r *syntheticTestResource) mapLocationsFromModel(ctx context.Context, model
 }
 
 // mapRbacTagsFromModel maps RBAC tags from model
-func (r *syntheticTestResource) mapRbacTagsFromModel(ctx context.Context, model SyntheticTestModel) ([]api.ApiTag, diag.Diagnostics) {
+func (r *syntheticTestResource) mapRbacTagsFromModel(ctx context.Context, model SyntheticTestModel) ([]api.RbacTag, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	var rbacTags []api.ApiTag
+	var rbacTags []api.RbacTag
 	if !model.RbacTags.IsNull() && !model.RbacTags.IsUnknown() {
 		var rbacTagModels []RbacTagModel
 		diags.Append(model.RbacTags.ElementsAs(ctx, &rbacTagModels, false)...)
 		if !diags.HasError() {
 			for _, tagModel := range rbacTagModels {
-				rbacTags = append(rbacTags, api.ApiTag{
-					Name:  tagModel.Name.ValueString(),
-					Value: tagModel.Value.ValueString(),
+				rbacTags = append(rbacTags, api.RbacTag{
+					DisplayName: tagModel.DisplayName.ValueString(),
+					ID:          tagModel.ID.ValueString(),
 				})
 			}
 		}
@@ -1289,7 +1289,8 @@ func (r *syntheticTestResource) mapCustomPropertiesToModel(apiObject *api.Synthe
 		}
 		return types.MapValueMust(types.StringType, customPropertiesMap)
 	}
-	return types.MapNull(types.StringType)
+	// Return empty map (not null) to stay consistent with plan when custom_properties = {}
+	return types.MapValueMust(types.StringType, map[string]attr.Value{})
 }
 
 // mapLocationsToModel maps locations array to model
@@ -1306,33 +1307,28 @@ func (r *syntheticTestResource) mapLocationsToModel(apiObject *api.SyntheticTest
 
 // mapRbacTagsToModel maps RBAC tags to model
 func (r *syntheticTestResource) mapRbacTagsToModel(apiObject *api.SyntheticTest) types.Set {
+	tagAttrTypes := map[string]attr.Type{
+		"display_name": types.StringType,
+		"id":           types.StringType,
+	}
 	if len(apiObject.RbacTags) > 0 {
 		rbacTagValues := make([]attr.Value, len(apiObject.RbacTags))
 		for i, tag := range apiObject.RbacTags {
 			tagObj, _ := types.ObjectValue(
-				map[string]attr.Type{
-					SyntheticTestFieldName:  types.StringType,
-					SyntheticTestFieldValue: types.StringType,
-				},
+				tagAttrTypes,
 				map[string]attr.Value{
-					SyntheticTestFieldName:  types.StringValue(tag.Name),
-					SyntheticTestFieldValue: types.StringValue(tag.Value),
+					"display_name": types.StringValue(tag.DisplayName),
+					"id":           types.StringValue(tag.ID),
 				},
 			)
 			rbacTagValues[i] = tagObj
 		}
 		return types.SetValueMust(
-			types.ObjectType{AttrTypes: map[string]attr.Type{
-				SyntheticTestFieldName:  types.StringType,
-				SyntheticTestFieldValue: types.StringType,
-			}},
+			types.ObjectType{AttrTypes: tagAttrTypes},
 			rbacTagValues,
 		)
 	}
-	return types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
-		SyntheticTestFieldName:  types.StringType,
-		SyntheticTestFieldValue: types.StringType,
-	}})
+	return types.SetNull(types.ObjectType{AttrTypes: tagAttrTypes})
 }
 
 // mapHttpActionConfigToModel maps HTTP Action configuration to model

--- a/internal/resources/synthetictest/resource-synthetic-test.go
+++ b/internal/resources/synthetictest/resource-synthetic-test.go
@@ -601,6 +601,7 @@ func buildBaseSchema() map[string]schema.Attribute {
 		},
 		SyntheticTestFieldRbacTags: schema.SetNestedAttribute{
 			Optional:    true,
+			Computed:    true,
 			Description: SyntheticTestDescRbacTags,
 			NestedObject: schema.NestedAttributeObject{
 				Attributes: map[string]schema.Attribute{
@@ -801,7 +802,8 @@ func (r *syntheticTestResource) mapLocationsFromModel(ctx context.Context, model
 // mapRbacTagsFromModel maps RBAC tags from model
 func (r *syntheticTestResource) mapRbacTagsFromModel(ctx context.Context, model SyntheticTestModel) ([]api.RbacTag, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	var rbacTags []api.RbacTag
+	// Always initialize with empty array, even if data is null or empty
+	rbacTags := []api.RbacTag{}
 	if !model.RbacTags.IsNull() && !model.RbacTags.IsUnknown() {
 		var rbacTagModels []RbacTagModel
 		diags.Append(model.RbacTags.ElementsAs(ctx, &rbacTagModels, false)...)
@@ -1316,24 +1318,31 @@ func (r *syntheticTestResource) mapRbacTagsToModel(apiObject *api.SyntheticTest)
 		SyntheticTestFieldRbacTagDisplayName: types.StringType,
 		SyntheticTestFieldRbacTagID:          types.StringType,
 	}
-	if len(apiObject.RbacTags) > 0 {
-		rbacTagValues := make([]attr.Value, len(apiObject.RbacTags))
-		for i, tag := range apiObject.RbacTags {
-			tagObj, _ := types.ObjectValue(
-				tagAttrTypes,
-				map[string]attr.Value{
-					SyntheticTestFieldRbacTagDisplayName: types.StringValue(tag.DisplayName),
-					SyntheticTestFieldRbacTagID:          types.StringValue(tag.ID),
-				},
-			)
-			rbacTagValues[i] = tagObj
-		}
-		return types.SetValueMust(
+
+	// Always initialize with empty set, even if data is null or empty
+	if len(apiObject.RbacTags) == 0 {
+		emptySet, _ := types.SetValue(
 			types.ObjectType{AttrTypes: tagAttrTypes},
-			rbacTagValues,
+			[]attr.Value{},
 		)
+		return emptySet
 	}
-	return types.SetNull(types.ObjectType{AttrTypes: tagAttrTypes})
+
+	rbacTagValues := make([]attr.Value, len(apiObject.RbacTags))
+	for i, tag := range apiObject.RbacTags {
+		tagObj, _ := types.ObjectValue(
+			tagAttrTypes,
+			map[string]attr.Value{
+				SyntheticTestFieldRbacTagDisplayName: types.StringValue(tag.DisplayName),
+				SyntheticTestFieldRbacTagID:          types.StringValue(tag.ID),
+			},
+		)
+		rbacTagValues[i] = tagObj
+	}
+	return types.SetValueMust(
+		types.ObjectType{AttrTypes: tagAttrTypes},
+		rbacTagValues,
+	)
 }
 
 // mapHttpActionConfigToModel maps HTTP Action configuration to model

--- a/internal/resources/synthetictest/resource-synthetic-test.go
+++ b/internal/resources/synthetictest/resource-synthetic-test.go
@@ -604,13 +604,13 @@ func buildBaseSchema() map[string]schema.Attribute {
 			Description: SyntheticTestDescRbacTags,
 			NestedObject: schema.NestedAttributeObject{
 				Attributes: map[string]schema.Attribute{
-					"id": schema.StringAttribute{
+					SyntheticTestFieldRbacTagID: schema.StringAttribute{
 						Required:    true,
-						Description: "ID of the RBAC tag",
+						Description: SyntheticTestDescRbacTagID,
 					},
-					"display_name": schema.StringAttribute{
+					SyntheticTestFieldRbacTagDisplayName: schema.StringAttribute{
 						Required:    true,
-						Description: "Display name of the RBAC tag",
+						Description: SyntheticTestDescRbacTagDisplayName,
 					},
 				},
 			},
@@ -1313,8 +1313,8 @@ func (r *syntheticTestResource) mapLocationsToModel(apiObject *api.SyntheticTest
 // mapRbacTagsToModel maps RBAC tags to model
 func (r *syntheticTestResource) mapRbacTagsToModel(apiObject *api.SyntheticTest) types.Set {
 	tagAttrTypes := map[string]attr.Type{
-		"display_name": types.StringType,
-		"id":           types.StringType,
+		SyntheticTestFieldRbacTagDisplayName: types.StringType,
+		SyntheticTestFieldRbacTagID:          types.StringType,
 	}
 	if len(apiObject.RbacTags) > 0 {
 		rbacTagValues := make([]attr.Value, len(apiObject.RbacTags))
@@ -1322,8 +1322,8 @@ func (r *syntheticTestResource) mapRbacTagsToModel(apiObject *api.SyntheticTest)
 			tagObj, _ := types.ObjectValue(
 				tagAttrTypes,
 				map[string]attr.Value{
-					"display_name": types.StringValue(tag.DisplayName),
-					"id":           types.StringValue(tag.ID),
+					SyntheticTestFieldRbacTagDisplayName: types.StringValue(tag.DisplayName),
+					SyntheticTestFieldRbacTagID:          types.StringValue(tag.ID),
 				},
 			)
 			rbacTagValues[i] = tagObj

--- a/internal/resources/synthetictest/resource-synthetic-test.go
+++ b/internal/resources/synthetictest/resource-synthetic-test.go
@@ -590,6 +590,7 @@ func buildBaseSchema() map[string]schema.Attribute {
 		},
 		SyntheticTestFieldCustomProperties: schema.MapAttribute{
 			Optional:    true,
+			Computed:    true,
 			Description: SyntheticTestDescCustomProperties,
 			ElementType: types.StringType,
 		},
@@ -777,9 +778,13 @@ func (r *syntheticTestResource) mapWebsitesFromModel(ctx context.Context, model 
 func (r *syntheticTestResource) mapCustomPropertiesFromModel(ctx context.Context, model SyntheticTestModel) (map[string]string, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	customProperties := make(map[string]string)
+
+	// Always initialize with empty map, even if null or unknown
+	// This ensures empty object {} is treated as empty map and sent to API
 	if !model.CustomProperties.IsNull() && !model.CustomProperties.IsUnknown() {
 		diags.Append(model.CustomProperties.ElementsAs(ctx, &customProperties, false)...)
 	}
+
 	return customProperties, diags
 }
 

--- a/internal/resources/synthetictest/resource-synthetic-test_test.go
+++ b/internal/resources/synthetictest/resource-synthetic-test_test.go
@@ -161,8 +161,8 @@ func TestMapStateToDataObject(t *testing.T) {
 			PlaybackMode:     types.StringValue("Simultaneous"),
 			TestFrequency:    types.Int64Null(),
 			RbacTags: types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
-				"name":  types.StringType,
-				"value": types.StringType,
+				"id":           types.StringType,
+				"display_name": types.StringType,
 			}}),
 			HttpAction: &HttpActionConfigModel{
 				MarkSyntheticCall: types.BoolValue(false),
@@ -224,8 +224,8 @@ func TestMapStateToDataObject(t *testing.T) {
 			PlaybackMode:     types.StringValue("Simultaneous"),
 			TestFrequency:    types.Int64Null(),
 			RbacTags: types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
-				"name":  types.StringType,
-				"value": types.StringType,
+				"id":           types.StringType,
+				"display_name": types.StringType,
 			}}),
 			HttpScript: &HttpScriptConfigModel{
 				MarkSyntheticCall: types.BoolValue(false),
@@ -270,8 +270,8 @@ func TestMapStateToDataObject(t *testing.T) {
 			PlaybackMode:     types.StringValue("Simultaneous"),
 			TestFrequency:    types.Int64Null(),
 			RbacTags: types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
-				"name":  types.StringType,
-				"value": types.StringType,
+				"id":           types.StringType,
+				"display_name": types.StringType,
 			}}),
 			BrowserScript: &BrowserScriptConfigModel{
 				MarkSyntheticCall: types.BoolValue(false),
@@ -318,8 +318,8 @@ func TestMapStateToDataObject(t *testing.T) {
 			PlaybackMode:     types.StringValue("Simultaneous"),
 			TestFrequency:    types.Int64Null(),
 			RbacTags: types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
-				"name":  types.StringType,
-				"value": types.StringType,
+				"id":           types.StringType,
+				"display_name": types.StringType,
 			}}),
 			DNS: &DNSConfigModel{
 				MarkSyntheticCall: types.BoolValue(false),
@@ -375,8 +375,8 @@ func TestMapStateToDataObject(t *testing.T) {
 			PlaybackMode:     types.StringValue("Simultaneous"),
 			TestFrequency:    types.Int64Null(),
 			RbacTags: types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
-				"name":  types.StringType,
-				"value": types.StringType,
+				"id":           types.StringType,
+				"display_name": types.StringType,
 			}}),
 			SSLCertificate: &SSLCertificateConfigModel{
 				MarkSyntheticCall:    types.BoolValue(false),
@@ -427,8 +427,8 @@ func TestMapStateToDataObject(t *testing.T) {
 			PlaybackMode:     types.StringValue("Simultaneous"),
 			TestFrequency:    types.Int64Null(),
 			RbacTags: types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
-				"name":  types.StringType,
-				"value": types.StringType,
+				"id":           types.StringType,
+				"display_name": types.StringType,
 			}}),
 			WebpageAction: &WebpageActionConfigModel{
 				MarkSyntheticCall: types.BoolValue(false),
@@ -473,8 +473,8 @@ func TestMapStateToDataObject(t *testing.T) {
 			PlaybackMode:     types.StringValue("Simultaneous"),
 			TestFrequency:    types.Int64Null(),
 			RbacTags: types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
-				"name":  types.StringType,
-				"value": types.StringType,
+				"id":           types.StringType,
+				"display_name": types.StringType,
 			}}),
 			WebpageScript: &WebpageScriptConfigModel{
 				MarkSyntheticCall: types.BoolValue(false),
@@ -520,8 +520,8 @@ func TestMapStateToDataObject(t *testing.T) {
 			PlaybackMode:     types.StringValue("Simultaneous"),
 			TestFrequency:    types.Int64Null(),
 			RbacTags: types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
-				"name":  types.StringType,
-				"value": types.StringType,
+				"id":           types.StringType,
+				"display_name": types.StringType,
 			}}),
 		}
 
@@ -556,8 +556,8 @@ func TestMapStateToDataObject(t *testing.T) {
 			PlaybackMode:     types.StringValue("Simultaneous"),
 			TestFrequency:    types.Int64Null(),
 			RbacTags: types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
-				"name":  types.StringType,
-				"value": types.StringType,
+				"id":           types.StringType,
+				"display_name": types.StringType,
 			}}),
 			HttpAction: &HttpActionConfigModel{
 				MarkSyntheticCall: types.BoolValue(false),
@@ -609,12 +609,12 @@ func TestMapStateToDataObject(t *testing.T) {
 		rbacTags := []attr.Value{
 			types.ObjectValueMust(
 				map[string]attr.Type{
-					"name":  types.StringType,
-					"value": types.StringType,
+					"id":           types.StringType,
+					"display_name": types.StringType,
 				},
 				map[string]attr.Value{
-					"name":  types.StringValue("dept"),
-					"value": types.StringValue("eng"),
+					"id":           types.StringValue("dept"),
+					"display_name": types.StringValue("eng"),
 				},
 			),
 		}
@@ -630,8 +630,8 @@ func TestMapStateToDataObject(t *testing.T) {
 			CustomProperties: types.MapNull(types.StringType),
 			RbacTags: types.SetValueMust(
 				types.ObjectType{AttrTypes: map[string]attr.Type{
-					"name":  types.StringType,
-					"value": types.StringType,
+					"id":           types.StringType,
+					"display_name": types.StringType,
 				}},
 				rbacTags,
 			),
@@ -708,8 +708,8 @@ func TestMapStateToDataObject(t *testing.T) {
 			PlaybackMode:     types.StringValue("Simultaneous"),
 			TestFrequency:    types.Int64Null(),
 			RbacTags: types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
-				"name":  types.StringType,
-				"value": types.StringType,
+				"id":           types.StringType,
+				"display_name": types.StringType,
 			}}),
 			HttpAction: &HttpActionConfigModel{
 				MarkSyntheticCall: types.BoolValue(false),
@@ -783,8 +783,8 @@ func TestMapStateToDataObject(t *testing.T) {
 			PlaybackMode:     types.StringValue("Simultaneous"),
 			TestFrequency:    types.Int64Null(),
 			RbacTags: types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
-				"name":  types.StringType,
-				"value": types.StringType,
+				"id":           types.StringType,
+				"display_name": types.StringType,
 			}}),
 			DNS: &DNSConfigModel{
 				MarkSyntheticCall: types.BoolValue(false),
@@ -850,8 +850,8 @@ func TestMapStateToDataObject(t *testing.T) {
 			PlaybackMode:     types.StringValue("Simultaneous"),
 			TestFrequency:    types.Int64Null(),
 			RbacTags: types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
-				"name":  types.StringType,
-				"value": types.StringType,
+				"id":           types.StringType,
+				"display_name": types.StringType,
 			}}),
 			HttpAction: &HttpActionConfigModel{
 				MarkSyntheticCall: types.BoolValue(false),
@@ -917,8 +917,8 @@ func TestMapStateToDataObject(t *testing.T) {
 			PlaybackMode:     types.StringValue("Simultaneous"),
 			TestFrequency:    types.Int64Null(),
 			RbacTags: types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
-				"name":  types.StringType,
-				"value": types.StringType,
+				"id":           types.StringType,
+				"display_name": types.StringType,
 			}}),
 			SSLCertificate: &SSLCertificateConfigModel{
 				MarkSyntheticCall:    types.BoolValue(false),
@@ -1559,7 +1559,7 @@ func TestUpdateState(t *testing.T) {
 			Applications: []string{},
 			MobileApps:   []string{},
 			Websites:     []string{},
-			RbacTags:     []api.ApiTag{},
+			RbacTags:     []api.RbacTag{},
 			Configuration: api.SyntheticTestConfig{
 				MarkSyntheticCall: false,
 				Retries:           0,
@@ -1654,7 +1654,8 @@ func TestUpdateState(t *testing.T) {
 		var model SyntheticTestModel
 		diags = state.Get(ctx, &model)
 		assert.False(t, diags.HasError())
-		assert.True(t, model.CustomProperties.IsNull())
+		assert.False(t, model.CustomProperties.IsNull())
+		assert.Equal(t, 0, len(model.CustomProperties.Elements()))
 	})
 
 	t.Run("should update state with HTTP Action empty Headers and ExpectJson", func(t *testing.T) {
@@ -1789,8 +1790,8 @@ func TestUpdateState(t *testing.T) {
 			CustomProperties: map[string]string{
 				"env": "prod",
 			},
-			RbacTags: []api.ApiTag{
-				{Name: "dept", Value: "eng"},
+			RbacTags: []api.RbacTag{
+				{ID: "dept", DisplayName: "eng"},
 			},
 			Configuration: api.SyntheticTestConfig{
 				MarkSyntheticCall: false,
@@ -1856,8 +1857,8 @@ func TestMapStateToDataObjectEdgeCases(t *testing.T) {
 			PlaybackMode:     types.StringValue("Simultaneous"),
 			TestFrequency:    types.Int64Null(),
 			RbacTags: types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
-				"name":  types.StringType,
-				"value": types.StringType,
+				"id":           types.StringType,
+				"display_name": types.StringType,
 			}}),
 			HttpAction: &HttpActionConfigModel{
 				MarkSyntheticCall: types.BoolValue(false),
@@ -2147,8 +2148,8 @@ func TestMapConfigurationOptionalFields(t *testing.T) {
 			PlaybackMode:     types.StringValue("Simultaneous"),
 			TestFrequency:    types.Int64Null(),
 			RbacTags: types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
-				"name":  types.StringType,
-				"value": types.StringType,
+				"id":           types.StringType,
+				"display_name": types.StringType,
 			}}),
 			HttpScript: &HttpScriptConfigModel{
 				MarkSyntheticCall: types.BoolValue(false),
@@ -2197,8 +2198,8 @@ func TestMapConfigurationOptionalFields(t *testing.T) {
 			PlaybackMode:     types.StringValue("Simultaneous"),
 			TestFrequency:    types.Int64Null(),
 			RbacTags: types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
-				"name":  types.StringType,
-				"value": types.StringType,
+				"id":           types.StringType,
+				"display_name": types.StringType,
 			}}),
 			BrowserScript: &BrowserScriptConfigModel{
 				MarkSyntheticCall: types.BoolValue(false),
@@ -2249,8 +2250,8 @@ func TestMapConfigurationOptionalFields(t *testing.T) {
 			PlaybackMode:     types.StringValue("Simultaneous"),
 			TestFrequency:    types.Int64Null(),
 			RbacTags: types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
-				"name":  types.StringType,
-				"value": types.StringType,
+				"id":           types.StringType,
+				"display_name": types.StringType,
 			}}),
 			DNS: &DNSConfigModel{
 				MarkSyntheticCall: types.BoolValue(false),
@@ -2308,8 +2309,8 @@ func TestMapConfigurationOptionalFields(t *testing.T) {
 			PlaybackMode:     types.StringValue("Simultaneous"),
 			TestFrequency:    types.Int64Null(),
 			RbacTags: types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{
-				"name":  types.StringType,
-				"value": types.StringType,
+				"id":           types.StringType,
+				"display_name": types.StringType,
 			}}),
 			SSLCertificate: &SSLCertificateConfigModel{
 				MarkSyntheticCall:    types.BoolValue(false),
@@ -2473,7 +2474,7 @@ func initializeEmptyState(t *testing.T, ctx context.Context, state *tfsdk.State)
 		Locations:        types.SetNull(types.StringType),
 		PlaybackMode:     types.StringNull(),
 		TestFrequency:    types.Int64Null(),
-		RbacTags:         types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{"name": types.StringType, "value": types.StringType}}),
+		RbacTags:         types.SetNull(types.ObjectType{AttrTypes: map[string]attr.Type{"id": types.StringType, "display_name": types.StringType}}),
 		HttpAction:       nil,
 		HttpScript:       nil,
 		BrowserScript:    nil,

--- a/internal/resources/synthetictest/synthetic-test-model.go
+++ b/internal/resources/synthetictest/synthetic-test-model.go
@@ -30,8 +30,8 @@ type SyntheticTestModel struct {
 
 // RbacTagModel represents an RBAC tag
 type RbacTagModel struct {
-	Name  types.String `tfsdk:"name"`
-	Value types.String `tfsdk:"value"`
+	DisplayName types.String `tfsdk:"display_name"`
+	ID          types.String `tfsdk:"id"`
 }
 
 // MultipleScriptsModel represents multiple scripts configuration

--- a/internal/shared/custom-payload-field.go
+++ b/internal/shared/custom-payload-field.go
@@ -118,9 +118,10 @@ func GetStaticOnlyCustomPayloadFieldsSchema() schema.ListNestedAttribute {
 func CustomPayloadFieldsToTerraform(ctx context.Context, fields []model.CustomPayloadField[any]) (types.List, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	// If no fields, return null list
+	// If no fields, return empty list (not null) to avoid "inconsistent result" errors
+	// when Terraform planned an empty list and the API returns no fields.
 	if len(fields) == 0 {
-		return types.ListNull(GetCustomPayloadFieldType()), diags
+		return types.ListValueMust(GetCustomPayloadFieldType(), []attr.Value{}), diags
 	}
 
 	// Convert API fields to a slice of maps that can be used with ObjectValueFrom

--- a/internal/shared/custom-payload-field.go
+++ b/internal/shared/custom-payload-field.go
@@ -63,6 +63,7 @@ func GetCustomPayloadFieldsSchema() schema.ListNestedAttribute {
 	return schema.ListNestedAttribute{
 		Description: "Custom payload fields for the configuration.",
 		Optional:    true,
+		Computed:    true,
 		NestedObject: schema.NestedAttributeObject{
 			Attributes: map[string]schema.Attribute{
 				CustomPayloadFieldsFieldKey: schema.StringAttribute{
@@ -121,6 +122,7 @@ func CustomPayloadFieldsToTerraform(ctx context.Context, fields []model.CustomPa
 	// If no fields, return empty list (not null) to avoid "inconsistent result" errors
 	// when Terraform planned an empty list and the API returns no fields.
 	if len(fields) == 0 {
+		// return types.ListNull(GetCustomPayloadFieldType()), diags
 		return types.ListValueMust(GetCustomPayloadFieldType(), []attr.Value{}), diags
 	}
 

--- a/internal/shared/custom-payload-field.go
+++ b/internal/shared/custom-payload-field.go
@@ -122,7 +122,6 @@ func CustomPayloadFieldsToTerraform(ctx context.Context, fields []model.CustomPa
 	// If no fields, return empty list (not null) to avoid "inconsistent result" errors
 	// when Terraform planned an empty list and the API returns no fields.
 	if len(fields) == 0 {
-		// return types.ListNull(GetCustomPayloadFieldType()), diags
 		return types.ListValueMust(GetCustomPayloadFieldType(), []attr.Value{}), diags
 	}
 


### PR DESCRIPTION
**Key Changes**

1. RBAC Tags Support Added

- Alerting Channels : Added rbac_tags field with id and display_name attributes
- Custom Dashboards : Added rbac_tags field for team assignments
- SLO Configs : Enhanced RBAC tags handling, converted from slice to types.List
- Synthetic Tests: Updated RBAC tags from generic ApiTag to proper RbacTag model with id/display_name fields

```
     rbac_tags = [
            {
              id           = "team-id-123"
              display_name = "Engineering Team"
            }
   ]
```

2. Empty Collection Handling Fixes

- Changed empty collections from null to empty arrays/lists/sets/maps across all resources
- Ensures consistency between Terraform plan and API responses
- Prevents "inconsistent result after apply" errors
- Affected fields:
1. custom_properties in Synthetic Tests
2. custom_payload_fields in Alert Configs
3. rbac_tags across all resources