### PR TITLE
Rbac tags documentation and custom dashboard fix

### DIFF
--- a/docs/resources/alerting_channel.md
+++ b/docs/resources/alerting_channel.md
@@ -72,6 +72,13 @@ resource "instana_alerting_channel" "email_multiple" {
       "devops@example.com"
     ]
   }
+
+  rbac_tags = [
+    {
+      id           = "team-id-1234"  # replace with actual team id
+      display_name = "Platform Team" # replace with actual team display name
+    }
+  ]
 }
 ```
 
@@ -486,6 +493,7 @@ terraform apply
 
 * `id` - (Computed) The unique identifier of the alerting channel
 * `name` - (Required) The name of the alerting channel
+* `rbac_tags` - (Optional, Computed) List of RBAC tags (teams) this alerting channel is assigned to. [Details](#rbac-tags-attributes)
 
 **Exactly one of the following channel types must be configured:**
 
@@ -654,6 +662,11 @@ terraform apply
 * `tenant_name` - (Required) The Tenant Name for MS Teams.
 
 **Type:** `string` for all attributes
+
+### RBAC Tags Attributes
+
+* `id` - (Required) The ID of the RBAC tag (team).
+* `display_name` - (Required) The display name of the RBAC tag (team).
 
 ## Attribute Reference
 

--- a/docs/resources/custom_dashboard.md
+++ b/docs/resources/custom_dashboard.md
@@ -82,6 +82,12 @@ resource "instana_custom_dashboard" "custom_dashboard" {
     },
   ]
   title = "custom_dashboard"
+  rbac_tags = [
+    {
+      id           = "team-id-1234"           # replace with actual team id
+      display_name = "Platform Team"          # replace with actual team display name
+    },
+  ]
   widgets = jsonencode([{
     config = {
       comparisonDecreaseColor = "greenish"
@@ -169,12 +175,18 @@ terraform apply
 * `title` - Required - The name/title of the custom dashboard
 * `access_rule` - Required - Configuration of access rules (sharing/permissions) of the custom dashboard (list). [Details](#access-rule-argument-reference)
 * `widgets` - Required - JSON array of widget configurations. It is recommended to get this configuration via the `Edit as Json` feature of custom dashboards in Instana UI and to adopt the configuration afterwards
+* `rbac_tags` - Optional, Computed - List of RBAC tags (teams) this custom dashboard is assigned to. [Details](#rbac-tags-argument-reference)
 
 ### Access Rule Argument Reference
 
 * `access_type` - Required - Type of granted access. Allowed values: `READ`, `READ_WRITE`
 * `relation_type` - Required - Type of the entity for which the access is granted. Allowed values: `USER`, `API_TOKEN`, `ROLE`, `TEAM`, `GLOBAL`
 * `related_id` - Optional - The ID of the related entity for which access is granted. Required for all `relation_type` except `GLOBAL`
+
+### RBAC Tags Argument Reference
+
+* `id` - Required - The ID of the RBAC tag (team).
+* `display_name` - Required - The display name of the RBAC tag (team).
 
 ## Attributes Reference
 

--- a/docs/resources/synthetic_test.md
+++ b/docs/resources/synthetic_test.md
@@ -60,7 +60,7 @@ resource "instana_synthetic_test" "example" {
 
 1. **Test Configuration Blocks**: `http_action { }` → `http_action = { }`
 2. **Nested Objects**: `scripts { }` → `scripts = { }`
-3. **RBAC Tags**: `rbac_tags { }` (multiple) → `rbac_tags = [{ }]` (set)
+3. **RBAC Tags**: `rbac_tags { }` (multiple) → `rbac_tags = [{ }]` (set) with `id` and `display_name` fields
 4. **DNS Filters**: `target_values { }` (multiple) → `target_values = [{ }]` (set)
 5. **SSL Validation**: `validation_rules { }` (multiple) → `validation_rules = [{ }]` (set)
 
@@ -71,16 +71,15 @@ resource "instana_synthetic_test" "example" {
 Basic HTTP GET request test:
 
 ```hcl
-
 resource "instana_synthetic_test" "http_action_basic" {
   label          = "Basic HTTP Test"
   description    = "Monitor website availability"
   active         = true
-  applications = ["NQIAsj1tSJm2zxMQx78MSA"] # replace with actual application Ids
-  locations      = ["b8dsyQt4fDukWzR9RMXW"] # replace with actual location Ids
+  applications   = ["NQIAsj1tSJm2zxMQx78MSA"] # replace with actual application Ids
+  locations      = ["b8dsyQt4fDukWzR9RMXW"]    # replace with actual location Ids
   test_frequency = 15
   playback_mode  = "Simultaneous"
-  
+
   http_action = {
     mark_synthetic_call = true
     retries             = 2
@@ -92,7 +91,14 @@ resource "instana_synthetic_test" "http_action_basic" {
     allow_insecure      = false
     expect_status       = 200
   }
-  
+
+  rbac_tags = [
+    {
+      id           = "team-id-1234"  # replace with actual team id
+      display_name = "Platform Team" # replace with actual team display name
+    }
+  ]
+
   custom_properties = {
     "environment" = "production"
     "team"        = "platform"
@@ -274,8 +280,8 @@ terraform apply
 
 ### RBAC Tags Reference
 
-* `name` - Required - Tag name
-* `value` - Required - Tag value
+* `id` - Required - The ID of the RBAC tag (team).
+* `display_name` - Required - The display name of the RBAC tag (team).
 
 ### HTTP Action Reference
 

--- a/internal/provider/terraform-provider-instana-resource.go
+++ b/internal/provider/terraform-provider-instana-resource.go
@@ -138,19 +138,46 @@ func (r *terraformResourceImpl[T]) Create(ctx context.Context, req resource.Crea
 		return
 	}
 
+	// If the resource handle requires a post-create update (e.g. custom dashboard
+	// RBAC tags are silently dropped by the Create endpoint), call Update with the
+	// original payload — patched with the server-assigned ID — so those fields are
+	// persisted before we write the final state.
+	finalObject := createdObject
+	if updater, ok := any(r.resourceHandle).(resourcehandle.PostCreateUpdater[T]); ok && updater.NeedsPostCreateUpdate(createRequest) {
+		updatePayload := updater.ApplyCreatedID(createRequest, createdObject)
+		tflog.Debug(ctx, "Calling Instana API to apply post-create update (e.g. RBAC tags)", map[string]interface{}{
+			"resource_id":    updatePayload.GetIDForResourcePath(),
+			"correlation_id": correlationID,
+		})
+		updatedObject, updateErr := r.resourceHandle.GetRestResource(r.providerMeta.InstanaAPI).Update(updatePayload)
+		if updateErr != nil {
+			tflog.Error(ctx, "Failed to apply post-create update via API", map[string]interface{}{
+				"resource_id":    updatePayload.GetIDForResourcePath(),
+				"correlation_id": correlationID,
+				"error":          updateErr.Error(),
+			})
+			resp.Diagnostics.AddError(
+				"Error applying post-create update",
+				fmt.Sprintf("Resource was created but the follow-up update (needed to persist all fields) failed: %s", updateErr),
+			)
+			return
+		}
+		finalObject = updatedObject
+	}
+
 	// Update state with created object
-	diags = r.resourceHandle.UpdateState(ctx, &resp.State, &req.Plan, createdObject)
+	diags = r.resourceHandle.UpdateState(ctx, &resp.State, &req.Plan, finalObject)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		tflog.Error(ctx, "Failed to update state after creation", map[string]interface{}{
-			"resource_id":    createdObject.GetIDForResourcePath(),
+			"resource_id":    finalObject.GetIDForResourcePath(),
 			"correlation_id": correlationID,
 		})
 		return
 	}
 
 	tflog.Debug(ctx, "Successfully created resource", map[string]interface{}{
-		"resource_id":    createdObject.GetIDForResourcePath(),
+		"resource_id":    finalObject.GetIDForResourcePath(),
 		"correlation_id": correlationID,
 	})
 }

--- a/internal/resourcehandle/resource_handle.go
+++ b/internal/resourcehandle/resource_handle.go
@@ -44,3 +44,25 @@ type ResourceHandle[T client.InstanaDataObject] interface {
 	// Return nil or empty map if no state upgrades are needed
 	GetStateUpgraders(ctx context.Context) map[int64]resource.StateUpgrader
 }
+
+// PostCreateUpdater is an optional interface that a ResourceHandle can implement
+// to indicate that an additional Update API call should be made immediately after
+// the Create API call. This is required for resources (e.g. custom dashboards)
+// whose Create endpoint does not accept certain fields (e.g. RBAC tags) but whose
+// Update endpoint does.
+//
+// If the resource handle implements this interface and NeedsPostCreateUpdate
+// returns true for the just-created object, the generic Create operation will
+// call the Update API with the original request payload (with the ID from the
+// created object applied) and use the update response to set the final state.
+type PostCreateUpdater[T client.InstanaDataObject] interface {
+	// NeedsPostCreateUpdate returns true when the created object requires a
+	// follow-up Update call to persist fields that were silently dropped by the
+	// Create endpoint.
+	NeedsPostCreateUpdate(original T) bool
+
+	// ApplyCreatedID copies the server-assigned ID from the created object into
+	// the original request payload so the subsequent Update call targets the
+	// correct resource.
+	ApplyCreatedID(original T, created T) T
+}

--- a/internal/resources/customdashboard/resource-custom-dashboard.go
+++ b/internal/resources/customdashboard/resource-custom-dashboard.go
@@ -326,3 +326,17 @@ func (r *customDashboardResource) GetStateUpgraders(ctx context.Context) map[int
 		1: resourcehandle.CreateStateUpgraderForVersion(1),
 	}
 }
+
+// NeedsPostCreateUpdate returns true when the original Create request contains
+// RBAC tags, because the Custom Dashboard Create endpoint silently drops them.
+// A follow-up Update call is needed to persist the tags.
+func (r *customDashboardResource) NeedsPostCreateUpdate(original *api.CustomDashboard) bool {
+	return len(original.RbacTags) > 0
+}
+
+// ApplyCreatedID copies the server-assigned ID from the created object into the
+// original request payload so the follow-up Update call targets the right resource.
+func (r *customDashboardResource) ApplyCreatedID(original *api.CustomDashboard, created *api.CustomDashboard) *api.CustomDashboard {
+	original.ID = created.ID
+	return original
+}


### PR DESCRIPTION
**Summary**
This PR fixes custom dashboard creation when rbac_tags are provided and updates resource documentation to correctly describe RBAC tag usage.

**What changed**
Added a generic post-create update hook in [internal/provider/terraform-provider-instana-resource.go](vscode-webview://0gg383pits7bp6m5647hj79t9s709egcfofpp1g9qrvu1riuu03c/internal/provider/terraform-provider-instana-resource.go) so resources can issue an immediate follow-up Update after Create when the Instana create endpoint drops fields silently.

**Documentation updates**
Added rbac_tags examples to alerting channel and custom dashboard docs
Documented rbac_tags arguments for custom dashboard and alerting channel
Corrected synthetic test RBAC tag fields to use:
   ```
    id
    display_name
```
