### PR TITLE
Mobile slo suport

### DIFF
--- a/docs/resources/slo_config.md
+++ b/docs/resources/slo_config.md
@@ -853,7 +853,8 @@ The `metric` block is an optional sub-attribute available on several indicator t
 
 * `metric_name` - (Optional) The name of the metric (e.g., `crashAffectedSessionCount`, `httpLatency`, `http5xx`)
 * `scope` - (Optional) Scope of the entity metric
-  * `scope_type` - (Optional) The beacon/signal type for the metric scope (e.g., `httpRequest`, `crash`, `viewChange`)
+  * `scope_type` - (Required) The beacon/signal type for the metric scope (e.g., `httpRequest`, `crash`, `viewChange`)
+  * `filter_expression` - (Optional) Tag filter expression to further narrow the metric scope - [Details](#tag-filter-expression-syntax)
 
 ### Time Window Attribute
 

--- a/docs/resources/slo_config.md
+++ b/docs/resources/slo_config.md
@@ -486,6 +486,144 @@ resource "instana_slo_config" "custom_infrastructure_slo" {
   }
 }
 ```
+### Mobile App Entity SLOs
+
+#### Mobile APP SLO with Time-Based
+```hcl
+resource "instana_slo_config" "time_based_mobile_app_slo" {
+  name   = "timebased_mobile_app_slo"
+  target = 0.99
+  tags   = ["time-based", "mobile-app-slo"]
+
+  entity = {
+    mobile = {
+      mobile_ids = ["i1IsNS7FQAegEljBTkNBMQ"]
+    }
+  }
+
+  indicator = {
+    time_based_availability = {
+      threshold   = 15
+      aggregation = "SUM"
+      metric = {
+        metric_name = "crashAffectedSessionCount"
+        scope = {
+          scope_type = "crash"
+        }
+      }
+    }
+  }
+
+  time_window = {
+    fixed = {
+      duration        = 1
+      duration_unit   = "calendar_month"
+      start_timestamp = 1781564400000
+      timezone        = "Europe/Dublin"
+    }
+  }
+}
+```
+
+#### Mobile APP SLO with Event-Based
+```hcl
+resource "instana_slo_config" "event_based_mobile_app_slo" {
+  name   = "eventbased-mobile-app-slo"
+  target = 0.95
+  tags   = ["event-based", "mobile-app-slo"]
+
+  entity = {
+    mobile = {
+      mobile_ids        = []
+      filter_expression = "mobileBeacon.platform@na EQUALS 'Android'"
+    }
+  }
+
+  indicator = {
+    event_based_availability = {
+      threshold   = 0
+      aggregation = "MEAN"
+      metric = {
+        metric_name = "http5xx"
+        scope = {
+          scope_type = "httpRequest"
+        }
+      }
+    }
+  }
+
+  time_window = {
+    fixed = {
+      duration        = 1
+      duration_unit   = "week"
+      start_timestamp = 1781582400000
+      timezone        = "UTC"
+    }
+  }
+}
+```
+
+#### Custom Mobile APP SLO
+```hcl
+resource "instana_slo_config" "custom_mobile_app_slo" {
+  name   = "custom_based_mobile_app_slo"
+  target = 0.99
+  tags   = ["custom-based", "mobile-app-slo"]
+
+  entity = {
+    mobile = {
+      mobile_ids = [
+        "PwozCjutQEuJjQT01ktwOw",
+        "i1IsNS7FQAegEljBTkNBMQ"
+      ]
+    }
+  }
+
+  indicator = {
+    advanced_custom = {
+      type = "eventBased"
+
+      good_events = {
+        aggregation = "SUM"
+        threshold   = 500
+        operator    = "<"
+
+        metric = {
+          metric_name = "httpLatency"
+          scope = {
+            scope_type = "httpRequest"
+          }
+        }
+      }
+
+      bad_events = {
+        aggregation = "SUM"
+        threshold   = 300
+        operator    = ">"
+
+        metric = {
+          metric_name = "viewChangeDuration"
+          scope = {
+            scope_type = "viewChange"
+          }
+        }
+      }
+    }
+  }
+
+  time_window = {
+    fixed = {
+      duration        = 1
+      duration_unit   = "calendar_month"
+      start_timestamp = 1782082800000
+      timezone        = "UTC"
+    }
+  }
+}
+```
+
+
+
 ### SLOs with RBAC Tags
 
 #### SLO with RBAC Tags
@@ -596,6 +734,7 @@ The `entity` attribute must contain exactly one of the following:
 * `website` - Website-based SLO entity - [Details](#website-entity-attributes)
 * `synthetic` - Synthetic-based SLO entity - [Details](#synthetic-entity-attributes)
 * `infrastructure` - Infrastructure-based SLO entity - [Details](#infrastructure-entity-attributes)
+* `mobile` - Mobile-app-based SLO entity - [Details](#mobile-entity-attributes)
 
 #### Application Entity Attributes
 
@@ -615,13 +754,22 @@ The `entity` attribute must contain exactly one of the following:
 
 #### Synthetic Entity Attributes
 
-* `synthetic_test_ids` - (Required) A set of synthetic test IDs. Must contain at least one ID.
-* `filter_expression` - (Optional) Tag filter expression to match events/calls - [Details](#tag-filter-expression-syntax)
+Exactly one of `synthetic_test_ids` or `filter_expression` must be provided — they are mutually exclusive.
+
+* `synthetic_test_ids` - (Optional) A static set of synthetic test IDs used to explicitly select tests. Cannot be combined with `filter_expression`
+* `filter_expression` - (Optional) Tag filter expression to dynamically scope the entity — use this instead of `synthetic_test_ids` when you want dynamic selection - [Details](#tag-filter-expression-syntax)
 
 #### Infrastructure Entity Attributes
 
 * `infra_type` - (Required) Type of the infrastructure entity.
 * `filter_expression` - (Optional) Tag filter expression that allows additional scoping or matching of infrastructure entities - [Details](#tag-filter-expression-syntax)
+
+#### Mobile Entity Attributes
+
+Exactly one of `mobile_ids` or `filter_expression` must be provided — they are mutually exclusive.
+
+* `mobile_ids` - (Optional) A static set of mobile app IDs used to explicitly select apps. Cannot be combined with `filter_expression`
+* `filter_expression` - (Optional) Tag filter expression to dynamically scope the entity — use this instead of `mobile_ids` when you want dynamic selection - [Details](#tag-filter-expression-syntax)
 
 ### Indicator Attribute
 
@@ -635,30 +783,35 @@ The `indicator` attribute must contain exactly one of the following:
 * `custom` - Custom indicator - [Details](#custom-indicator-attributes)
 * `time_based_saturation` - Time-based saturation indicator - [Details](#time-based-saturation-indicator-attributes)
 * `event_based_saturation` - Event-based saturation indicator - [Details](#event-based-saturation-indicator-attributes)
+* `advanced_custom` - Advanced custom indicator for mobile/event-based scenarios - [Details](#advanced-custom-indicator-attributes)
 
 #### Time-Based Latency Indicator Attributes
 
 * `threshold` - (Required) The latency threshold in milliseconds. Must be greater than 0
 * `aggregation` - (Required) The aggregation type. Valid values: `MEAN`, `MAX`, `MIN`, `P25`, `P50`, `P75`, `P90`, `P95`, `P98`, `P99`
+* `metric` - (Optional) Entity metric configuration - [Details](#metric-attribute)
 
 #### Event-Based Latency Indicator Attributes
 
 * `threshold` - (Required) The latency threshold in milliseconds. Must be greater than 0
+* `metric` - (Optional) Entity metric configuration - [Details](#metric-attribute)
 
 #### Time-Based Availability Indicator Attributes
 
 * `threshold` - (Required) The error rate threshold. Typically `0.0` for availability
 * `aggregation` - (Required) The aggregation type. Valid value: `MEAN`
+* `metric` - (Optional) Entity metric configuration - [Details](#metric-attribute)
 
 #### Event-Based Availability Indicator Attributes
 
-No additional attributes required. This is an empty object: `event_based_availability = {}`
+* `metric` - (Optional) Entity metric configuration - [Details](#metric-attribute)
 
 #### Traffic Indicator Attributes
 
 * `traffic_type` - (Required) The type of traffic to measure. Valid values: `all`, `erroneous`
 * `threshold` - (Required) The traffic threshold. Must be greater than 0
 * `operator` - (Required) The comparison operator. Valid values: ``, `=`, `<`, `<=`
+* `metric` - (Optional) Entity metric configuration - [Details](#metric-attribute)
 
 #### Custom Indicator Attributes
 
@@ -671,12 +824,36 @@ No additional attributes required. This is an empty object: `event_based_availab
 * `threshold` - (Required) The saturation threshold. Must be greater than or equal to 0
 * `aggregation` - (Required) The aggregation type. Valid values: `MEAN`, `MAX`, `MIN`, `P25`, `P50`, `P75`, `P90`, `P95`, `P98`, `P99`
 * `operator` - (Optional) Comparison operator used to evaluate the metric. Valid values: `>`, `>=`, `<`, `<=`. Defaults to `>=` if not specified.
+* `metric` - (Optional) Entity metric configuration - [Details](#metric-attribute)
 
 #### Event-Based Saturation Indicator Attributes
 
 * `metric_name` - (Required) The name of the metric which needs to be measured.
 * `threshold` - (Required) The saturation threshold. Must be greater than or equal to 0
 * `operator` - (Optional) Comparison operator used to evaluate the metric. Valid values: `>`, `>=`, `<`, `<=`. Defaults to `>=` if not specified.
+* `metric` - (Optional) Entity metric configuration - [Details](#metric-attribute)
+
+#### Advanced Custom Indicator Attributes
+
+Used for mobile app SLOs and other event-based advanced scenarios.
+
+* `type` - (Optional) The indicator measurement type. Valid value: `eventBased`
+* `good_events` - (Optional) Advanced filter defining the good-event threshold condition
+  * `threshold` - (Optional) The threshold value to compare against
+  * `operator` - (Optional) The comparison operator. Valid values: `>`, `>=`, `<`, `<=`
+  * `metric` - (Optional) Entity metric configuration - [Details](#metric-attribute)
+* `bad_events` - (Optional) Advanced filter defining the bad-event threshold condition
+  * `threshold` - (Optional) The threshold value to compare against
+  * `operator` - (Optional) The comparison operator. Valid values: `>`, `>=`, `<`, `<=`
+  * `metric` - (Optional) Entity metric configuration - [Details](#metric-attribute)
+
+#### Metric Attribute
+
+The `metric` block is an optional sub-attribute available on several indicator types. It is primarily used for mobile app SLOs.
+
+* `metric_name` - (Optional) The name of the metric (e.g., `crashAffectedSessionCount`, `httpLatency`, `http5xx`)
+* `scope` - (Optional) Scope of the entity metric
+  * `scope_type` - (Optional) The beacon/signal type for the metric scope (e.g., `httpRequest`, `crash`, `viewChange`)
 
 ### Time Window Attribute
 
@@ -694,7 +871,7 @@ The `time_window` attribute must contain exactly one of the following:
 #### Fixed Time Window Attributes
 
 * `duration` - (Required) The duration of the time window. Must be an integer
-* `duration_unit` - (Required) The unit of the duration. Valid values: `day`, `week`
+* `duration_unit` - (Required) The unit of the duration. Valid values: `day`, `week`, `calendar_month`
 * `timezone` - (Optional) The timezone for the time window. Defaults to `UTC`
 * `start_timestamp` - (Required) The starting timestamp for the fixed time window (Unix timestamp as float)
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.18.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.36.1
-	github.com/instana/instana-go-client v1.1.2
+	github.com/instana/instana-go-client v1.1.3
 	github.com/rs/xid v1.5.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,8 @@ github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8=
 github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
-github.com/instana/instana-go-client v1.1.2 h1:pS6gXc64xZpn4rg7N+E5zc5t2urB8RNn0oMmGIQGfY0=
-github.com/instana/instana-go-client v1.1.2/go.mod h1:aOe+HQWz3md7VSvKrdeT+aso7sxzobWuXvyaTwIos3Q=
+github.com/instana/instana-go-client v1.1.3 h1:HEgseLjIIwY2zPo8EplCWFkbwDMrFLyHEMYtWz2UQmQ=
+github.com/instana/instana-go-client v1.1.3/go.mod h1:aOe+HQWz3md7VSvKrdeT+aso7sxzobWuXvyaTwIos3Q=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=
 github.com/jhump/protoreflect v1.17.0/go.mod h1:h9+vUUL38jiBzck8ck+6G/aeMX8Z4QUY/NiJPwPNi+8=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/internal/resources/applicationconfig/resource-application-config.go
+++ b/internal/resources/applicationconfig/resource-application-config.go
@@ -68,11 +68,7 @@ func NewApplicationConfigResourceHandle() resourcehandle.ResourceHandle[*api.App
 						},
 					},
 					ApplicationConfigFieldTagFilter: schema.StringAttribute{
-						Optional: true,
-						Computed: true,
-						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.UseStateForUnknown(),
-						},
+						Required:    true,
 						Description: ApplicationConfigDescTagFilter,
 					},
 					ApplicationConfigFieldAccessRules: schema.ListNestedAttribute{

--- a/internal/resources/sloconfig/resource-slo-config-constants.go
+++ b/internal/resources/sloconfig/resource-slo-config-constants.go
@@ -46,6 +46,10 @@ const (
 	SloConfigDescWebsiteEntity = "Website entity of SLO"
 	// SloConfigDescWebsiteID is the description for the website_id field
 	SloConfigDescWebsiteID = "The website ID of the entity"
+	// SloConfigDescMobileEntity is the description for the mobile entity block
+	SloConfigDescMobileEntity = "Mobile App entity of SLO"
+	// SloConfigDescMobileIDs is the description for the mobile_ids field
+	SloConfigDescMobileIDs = "The ID(s) of the Mobile Apps"
 	// SloConfigDescBeaconType is the description for the beacon_type field
 	SloConfigDescBeaconType = "The beacon type for the entity configuration (pageLoad, resourceLoad, httpRequest, error, custom, pageChange)"
 	// SloConfigDescSyntheticEntity is the description for the synthetic entity block
@@ -78,6 +82,18 @@ const (
 	SloConfigDescEventBasedSaturation = "Event-based Saturation indicator"
 	// SloConfigDescMetricName is the description for the metric_name field
 	SloConfigDescMetricName = "The metric name for saturation indicator"
+	// SloConfigDescAdvancedCustomEntity is the description for the advanced_custom indicator block
+	SloConfigDescAdvancedCustom = "Advanced custom indicator (event-based, mobile)"
+	// SloConfigDescMetric is the description for the metric block
+	SloConfigDescMetric = "Entity metric configuration for mobile/advanced indicators"
+	// SloConfigDescMetricMetricName is the description for metric name inside the metric block
+	SloConfigDescMetricMetricName = "Name of the metric (e.g. duration, crashRate)"
+	// SloConfigDescMetricScope is the description for the scope block inside metric
+	SloConfigDescMetricScope = "Scope of the entity metric"
+	// SloConfigDescMetricScopeType is the description for the type field inside metric scope
+	SloConfigDescMetricScopeType = "Beacon/signal type for the metric scope (e.g. httpRequests, crashes)"
+	// SloConfigDescAdvancedFilter is the description for goodEvents/badEvents block
+	SloConfigDescAdvancedFilter = "Advanced filter defining a threshold condition on a metric"
 	// SloConfigDescThreshold is the description for the threshold field
 	SloConfigDescThreshold = "The threshold for the metric configuration"
 	// SloConfigDescAggregation is the description for the aggregation field
@@ -117,6 +133,8 @@ const (
 	SloConfigErrWebsiteIDRequired = "website_id and beacon_type are required for website entity"
 	// SloConfigErrSyntheticTestIDsRequired is the error message for missing synthetic_test_ids
 	SloConfigErrSyntheticTestIDsRequired = "synthetic_test_ids is required for synthetic entity"
+	// SloConfigErrMobileIDsRequired is the error message for missing mobile_ids
+	SloConfigErrMobileIDsRequired = "mobile_ids is required for mobile entity"
 	// SloConfigErrMissingEntity is the error title for missing entity configuration
 	SloConfigErrMissingEntity = "Missing entity configuration"
 	// SloConfigErrExactlyOneEntity is the error message for missing entity configuration
@@ -175,6 +193,10 @@ const (
 	SloConfigErrInfraTypeRequired = "Infrastructure type required"
 	// SloConfigErrInfraTypeRequiredMsg is the error message for missing infrastructure type
 	SloConfigErrInfraTypeRequiredMsg = "infra_type is required for infrastructure entity"
+	// SloConfigErrAdvancedCustomRequired is the error title for missing advanced_custom indicator fields
+	SloConfigErrAdvancedCustomRequired = "Advanced custom indicator fields required"
+	// SloConfigErrAdvancedCustomRequiredMsg is the error message for missing advanced_custom fields
+	SloConfigErrAdvancedCustomRequiredMsg = "good_events with metric, aggregation, threshold and operator are required for advanced_custom indicator"
 	// SloConfigErrSaturationRequired is the error title for missing saturation indicator fields
 	SloConfigErrTimeBasedSaturationRequired = "Time-based Saturation indicator fields required"
 	// SloConfigErrSaturationRequired is the error title for missing saturation indicator fields
@@ -199,6 +221,7 @@ const (
 	SloConfigFieldSyntheticTestIDs               = "synthetic_test_ids"
 	SloConfigFieldIncludeUnscheduledTestResults  = "include_unscheduled_test_results"
 	SloConfigFieldInfraType                      = "infra_type"
+	SloConfigFieldMobileIDs                      = "mobile_ids"
 	SloConfigFieldFilterExpression          = "filter_expression"
 	SloConfigFieldServiceID                 = "service_id"
 	SloConfigFieldEndpointID                = "endpoint_id"
@@ -222,6 +245,7 @@ const (
 	SloConfigWebsiteEntity        = "website"
 	SloConfigSyntheticEntity      = "synthetic"
 	SloConfigInfrastructureEntity = "infrastructure"
+	SloConfigMobileEntity         = "mobile"
 
 	// Slo time windows types
 	SloConfigRollingTimeWindow = "rolling"
@@ -248,11 +272,12 @@ const (
 
 	SloConfigAPIFieldFilter = "tagFilterExpression"
 
-	SloConfigAPIIndicatorBlueprintLatency      = "latency"
-	SloConfigAPIIndicatorBlueprintAvailability = "availability"
-	SloConfigAPIIndicatorBlueprintTraffic      = "traffic"
-	SloConfigAPIIndicatorBlueprintCustom       = "custom"
-	SloConfigAPIIndicatorBlueprintSaturation   = "saturation"
+	SloConfigAPIIndicatorBlueprintLatency       = "latency"
+	SloConfigAPIIndicatorBlueprintAvailability  = "availability"
+	SloConfigAPIIndicatorBlueprintTraffic       = "traffic"
+	SloConfigAPIIndicatorBlueprintCustom        = "custom"
+	SloConfigAPIIndicatorBlueprintSaturation    = "saturation"
+	SloConfigAPIIndicatorBlueprintAdvancedCustom = "advanced-custom"
 
 	SloConfigAPIFieldBlueprint = "blueprint"
 	SloConfigAPIFieldType      = "type"
@@ -287,8 +312,20 @@ const (
 	SchemaFieldTimeBasedSaturation = "time_based_saturation"
 	// SchemaFieldEventBasedSaturation represents the event-based saturation field identifier
 	SchemaFieldEventBasedSaturation = "event_based_saturation"
+	// SchemaFieldAdvancedCustom represents the advanced_custom field identifier
+	SchemaFieldAdvancedCustom = "advanced_custom"
 	// SchemaFieldOperator represents the operator field identifier
 	SchemaFieldOperator = "operator"
+	// SchemaFieldMetric represents the metric field identifier
+	SchemaFieldMetric = "metric"
+	// SchemaFieldMetricScope represents the scope field identifier inside metric
+	SchemaFieldMetricScope = "scope"
+	// SchemaFieldMetricScopeType represents the type field inside metric scope
+	SchemaFieldMetricScopeType = "scope_type"
+	// SchemaFieldGoodEvents represents the good_events field identifier
+	SchemaFieldGoodEvents = "good_events"
+	// SchemaFieldBadEvents represents the bad_events field identifier
+	SchemaFieldBadEvents = "bad_events"
 
 	// Operator constants
 

--- a/internal/resources/sloconfig/resource-slo-config.go
+++ b/internal/resources/sloconfig/resource-slo-config.go
@@ -148,6 +148,7 @@ func buildEntityAttribute() schema.SingleNestedAttribute {
 			SloConfigWebsiteEntity:        buildWebsiteEntityAttribute(),
 			SloConfigSyntheticEntity:      buildSyntheticEntityAttribute(),
 			SloConfigInfrastructureEntity: buildInfrastructureEntityAttribute(),
+			SloConfigMobileEntity:         buildMobileEntityAttribute(),
 		},
 	}
 }
@@ -256,6 +257,25 @@ func buildInfrastructureEntityAttribute() schema.SingleNestedAttribute {
 	}
 }
 
+// buildMobileEntityAttribute creates the mobile app entity nested attribute
+func buildMobileEntityAttribute() schema.SingleNestedAttribute {
+	return schema.SingleNestedAttribute{
+		Description: SloConfigDescMobileEntity,
+		Optional:    true,
+		Attributes: map[string]schema.Attribute{
+			SloConfigFieldMobileIDs: schema.SetAttribute{
+				ElementType: types.StringType,
+				Optional:    true,
+				Description: SloConfigDescMobileIDs,
+			},
+			SloConfigFieldFilterExpression: schema.StringAttribute{
+				Optional:    true,
+				Description: SloConfigDescEntityFilter,
+			},
+		},
+	}
+}
+
 // buildIndicatorAttribute creates the indicator nested attribute
 func buildIndicatorAttribute() schema.SingleNestedAttribute {
 	return schema.SingleNestedAttribute{
@@ -270,6 +290,77 @@ func buildIndicatorAttribute() schema.SingleNestedAttribute {
 			SchemaFieldCustom:                 buildCustomIndicatorAttribute(),
 			SchemaFieldTimeBasedSaturation:    buildTimeBasedSaturationIndicatorAttribute(),
 			SchemaFieldEventBasedSaturation:   buildEventBasedSaturationIndicatorAttribute(),
+			SchemaFieldAdvancedCustom:         buildAdvancedCustomIndicatorAttribute(),
+		},
+	}
+}
+
+// buildEntityMetricAttribute builds the nested metric attribute shared across threshold indicators
+func buildEntityMetricAttribute() schema.SingleNestedAttribute {
+	return schema.SingleNestedAttribute{
+		Description: SloConfigDescMetric,
+		Optional:    true,
+		Attributes: map[string]schema.Attribute{
+			"metric_name": schema.StringAttribute{
+				Optional:    true,
+				Description: SloConfigDescMetricMetricName,
+			},
+			SchemaFieldMetricScope: schema.SingleNestedAttribute{
+				Optional:    true,
+				Description: SloConfigDescMetricScope,
+				Attributes: map[string]schema.Attribute{
+					SchemaFieldMetricScopeType: schema.StringAttribute{
+						Optional:    true,
+						Description: SloConfigDescMetricScopeType,
+					},
+					SloConfigFieldFilterExpression: schema.StringAttribute{
+						Optional:    true,
+						Description: SloConfigDescEntityFilter,
+					},
+				},
+			},
+		},
+	}
+}
+
+// buildAdvancedFilterAttribute builds the nested good_events/bad_events attribute
+func buildAdvancedFilterAttribute() schema.SingleNestedAttribute {
+	return schema.SingleNestedAttribute{
+		Description: SloConfigDescAdvancedFilter,
+		Optional:    true,
+		Attributes: map[string]schema.Attribute{
+			SloConfigFieldAggregation: schema.StringAttribute{
+				Optional:    true,
+				Description: SloConfigDescAggregation,
+			},
+			SloConfigFieldThreshold: schema.Float64Attribute{
+				Optional:    true,
+				Description: SloConfigDescThreshold,
+			},
+			SchemaFieldOperator: schema.StringAttribute{
+				Optional:    true,
+				Description: SloConfigDescOperator,
+				Validators: []validator.String{
+					stringvalidator.OneOf(OperatorGreaterThan, OperatorGreaterThanOrEqual, OperatorLessThan, OperatorLessThanOrEqual),
+				},
+			},
+			SchemaFieldMetric: buildEntityMetricAttribute(),
+		},
+	}
+}
+
+// buildAdvancedCustomIndicatorAttribute creates the advanced-custom indicator attribute
+func buildAdvancedCustomIndicatorAttribute() schema.SingleNestedAttribute {
+	return schema.SingleNestedAttribute{
+		Description: SloConfigDescAdvancedCustom,
+		Optional:    true,
+		Attributes: map[string]schema.Attribute{
+			SloConfigAPIFieldType: schema.StringAttribute{
+				Optional:    true,
+				Description: "Indicator type (eventBased)",
+			},
+			SchemaFieldGoodEvents: buildAdvancedFilterAttribute(),
+			SchemaFieldBadEvents:  buildAdvancedFilterAttribute(),
 		},
 	}
 }
@@ -290,6 +381,7 @@ func buildTimeBasedLatencyIndicatorAttribute() schema.SingleNestedAttribute {
 				Computed:    true,
 				Description: SloConfigDescAggregation,
 			},
+			SchemaFieldMetric: buildEntityMetricAttribute(),
 		},
 	}
 }
@@ -304,6 +396,7 @@ func buildEventBasedLatencyIndicatorAttribute() schema.SingleNestedAttribute {
 				Optional:    true,
 				Description: SloConfigDescThreshold,
 			},
+			SchemaFieldMetric: buildEntityMetricAttribute(),
 		},
 	}
 }
@@ -322,6 +415,7 @@ func buildTimeBasedAvailabilityIndicatorAttribute() schema.SingleNestedAttribute
 				Optional:    true,
 				Description: SloConfigDescAggregation,
 			},
+			SchemaFieldMetric: buildEntityMetricAttribute(),
 		},
 	}
 }
@@ -331,7 +425,17 @@ func buildEventBasedAvailabilityIndicatorAttribute() schema.SingleNestedAttribut
 	return schema.SingleNestedAttribute{
 		Description: SloConfigDescEventBasedAvailability,
 		Optional:    true,
-		Attributes:  map[string]schema.Attribute{},
+		Attributes: map[string]schema.Attribute{
+			SloConfigFieldThreshold: schema.Float64Attribute{
+				Optional:    true,
+				Description: SloConfigDescThreshold,
+			},
+			SloConfigFieldAggregation: schema.StringAttribute{
+				Optional:    true,
+				Description: SloConfigDescAggregation,
+			},
+			SchemaFieldMetric: buildEntityMetricAttribute(),
+		},
 	}
 }
 
@@ -351,14 +455,13 @@ func buildTrafficIndicatorAttribute() schema.SingleNestedAttribute {
 			},
 			SchemaFieldOperator: schema.StringAttribute{
 				Optional:    true,
+				Computed:    true,
 				Description: SloConfigDescOperator,
 				Validators: []validator.String{
 					stringvalidator.OneOf(OperatorGreaterThan, OperatorGreaterThanOrEqual, OperatorLessThan, OperatorLessThanOrEqual),
 				},
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
 			},
+			SchemaFieldMetric: buildEntityMetricAttribute(),
 		},
 	}
 }
@@ -415,6 +518,7 @@ func buildTimeBasedSaturationIndicatorAttribute() schema.SingleNestedAttribute {
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
+			SchemaFieldMetric: buildEntityMetricAttribute(),
 		},
 	}
 }
@@ -449,6 +553,7 @@ func buildEventBasedSaturationIndicatorAttribute() schema.SingleNestedAttribute 
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
+			SchemaFieldMetric: buildEntityMetricAttribute(),
 		},
 	}
 }
@@ -538,7 +643,7 @@ func (r *sloConfigResource) MapStateToDataObject(ctx context.Context, plan *tfsd
 	if diags.HasError() {
 		return nil, diags
 	}
-	return &api.SloConfig{
+	sloConfig := &api.SloConfig{
 		ID:         id,
 		Name:       model.Name.ValueString(),
 		Target:     model.Target.ValueFloat64(),
@@ -547,7 +652,8 @@ func (r *sloConfigResource) MapStateToDataObject(ctx context.Context, plan *tfsd
 		TimeWindow: timeWindowData,
 		Tags:       r.mapTagsFromState(model.Tags),
 		RbacTags:   r.mapRbacTagsFromState(model.RbacTags),
-	}, diags
+	}
+	return sloConfig, diags
 }
 
 // extractModelFromPlanOrState retrieves the model from plan or state
@@ -629,6 +735,10 @@ func (r *sloConfigResource) mapEntityFromState(entityObj EntityModel) (api.SloEn
 
 	if entityObj.InfrastructureEntityModel != nil {
 		return r.validateAndMapInfrastructureEntity(entityObj.InfrastructureEntityModel)
+	}
+
+	if entityObj.MobileEntityModel != nil {
+		return r.validateAndMapMobileEntity(entityObj.MobileEntityModel)
 	}
 
 	var diags diag.Diagnostics
@@ -786,6 +896,32 @@ func (r *sloConfigResource) buildSyntheticEntity(model *SyntheticEntityModel) ap
 	return entity
 }
 
+// validateAndMapMobileEntity validates and maps mobile entity from state
+func (r *sloConfigResource) validateAndMapMobileEntity(model *MobileEntityModel) (api.SloEntity, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	mobileIDs := make([]string, 0)
+	if !model.MobileIDs.IsNull() && !model.MobileIDs.IsUnknown() {
+		for _, elem := range model.MobileIDs.Elements() {
+			if strVal, ok := elem.(types.String); ok && !strVal.IsNull() && !strVal.IsUnknown() {
+				mobileIDs = append(mobileIDs, strVal.ValueString())
+			}
+		}
+	}
+
+	filterExpr, filterDiags := r.mapFilterExpressionToEntity(model.FilterExpression)
+	diags.Append(filterDiags...)
+	if diags.HasError() {
+		return api.SloEntity{}, diags
+	}
+
+	return api.SloEntity{
+		Type:             SloConfigMobileEntity,
+		MobileIds:        mobileIDs,
+		FilterExpression: filterExpr,
+	}, diags
+}
+
 // validateAndMapInfrastructureEntity validates and maps infrastructure entity from state
 func (r *sloConfigResource) validateAndMapInfrastructureEntity(model *InfrastructureEntityModel) (api.SloEntity, diag.Diagnostics) {
 	var diags diag.Diagnostics
@@ -868,7 +1004,7 @@ func (r *sloConfigResource) mapIndicatorFromState(indicatorModel IndicatorModel)
 	}
 
 	if indicatorModel.EventBasedAvailabilityIndicatorModel != nil {
-		return r.mapEventBasedAvailabilityIndicator()
+		return r.mapEventBasedAvailabilityIndicator(indicatorModel.EventBasedAvailabilityIndicatorModel)
 	}
 
 	if indicatorModel.TrafficIndicatorModel != nil {
@@ -885,6 +1021,10 @@ func (r *sloConfigResource) mapIndicatorFromState(indicatorModel IndicatorModel)
 
 	if indicatorModel.EventBasedSaturationIndicatorModel != nil {
 		return r.mapEventBasedSaturationIndicator(indicatorModel.EventBasedSaturationIndicatorModel)
+	}
+
+	if indicatorModel.AdvancedCustomIndicatorModel != nil {
+		return r.mapAdvancedCustomIndicator(indicatorModel.AdvancedCustomIndicatorModel)
 	}
 
 	var diags diag.Diagnostics
@@ -908,6 +1048,7 @@ func (r *sloConfigResource) mapTimeBasedLatencyIndicator(model *TimeBasedLatency
 		Type:        SloConfigAPIIndicatorMeasurementTypeTimeBased,
 		Threshold:   model.Threshold.ValueFloat64(),
 		Aggregation: &aggregation,
+		Metric:      r.mapEntityMetricFromModel(model.Metric),
 	}, diags
 }
 
@@ -926,6 +1067,7 @@ func (r *sloConfigResource) mapEventBasedLatencyIndicator(model *EventBasedLaten
 		Type:        SloConfigAPIIndicatorMeasurementTypeEventBased,
 		Threshold:   model.Threshold.ValueFloat64(),
 		Aggregation: defaultAgg,
+		Metric:      r.mapEntityMetricFromModel(model.Metric),
 	}, diags
 }
 
@@ -945,18 +1087,24 @@ func (r *sloConfigResource) mapTimeBasedAvailabilityIndicator(model *TimeBasedAv
 		Type:        SloConfigAPIIndicatorMeasurementTypeTimeBased,
 		Threshold:   model.Threshold.ValueFloat64(),
 		Aggregation: &aggregation,
+		Metric:      r.mapEntityMetricFromModel(model.Metric),
 	}, diags
 }
 
 // mapEventBasedAvailabilityIndicator maps event-based availability indicator from state
-func (r *sloConfigResource) mapEventBasedAvailabilityIndicator() (api.SloIndicator, diag.Diagnostics) {
+func (r *sloConfigResource) mapEventBasedAvailabilityIndicator(model *EventBasedAvailabilityIndicatorModel) (api.SloIndicator, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	defaultAgg := r.getDefaultAggregation()
 
+	aggregation := model.Aggregation.ValueString()
+	if aggregation == "" {
+		aggregation = DefaultAggregation
+	}
 	return api.SloIndicator{
 		Blueprint:   SloConfigAPIIndicatorBlueprintAvailability,
 		Type:        SloConfigAPIIndicatorMeasurementTypeEventBased,
-		Aggregation: defaultAgg,
+		Threshold:   model.Threshold.ValueFloat64(),
+		Aggregation: &aggregation,
+		Metric:      r.mapEntityMetricFromModel(model.Metric),
 	}, diags
 }
 
@@ -971,7 +1119,7 @@ func (r *sloConfigResource) mapTrafficIndicator(model *TrafficIndicatorModel) (a
 
 	trafficType := model.TrafficType.ValueString()
 	operator := model.Operator.ValueString()
-	defaultAgg := r.getDefaultAggregation()
+	trafficAgg := "SUM"
 
 	return api.SloIndicator{
 		Blueprint:   SloConfigAPIIndicatorBlueprintTraffic,
@@ -979,7 +1127,8 @@ func (r *sloConfigResource) mapTrafficIndicator(model *TrafficIndicatorModel) (a
 		TrafficType: &trafficType,
 		Threshold:   model.Threshold.ValueFloat64(),
 		Operator:    &operator,
-		Aggregation: defaultAgg,
+		Aggregation: &trafficAgg,
+		Metric:      r.mapEntityMetricFromModel(model.Metric),
 	}, diags
 }
 
@@ -1034,6 +1183,7 @@ func (r *sloConfigResource) mapTimeBasedSaturationIndicator(model *TimeBasedSatu
 		Aggregation: &aggregation,
 		Operator:    &operator,
 		MetricName:  &metricName,
+		Metric:      r.mapEntityMetricFromModel(model.Metric),
 	}, diags
 }
 
@@ -1057,8 +1207,110 @@ func (r *sloConfigResource) mapEventBasedSaturationIndicator(model *EventBasedSa
 		Aggregation: defaultAgg,
 		Operator:    &operator,
 		MetricName:  &metricName,
+		Metric:      r.mapEntityMetricFromModel(model.Metric),
 	}, diags
+}
 
+// mapAdvancedCustomIndicator maps advanced-custom indicator from state
+func (r *sloConfigResource) mapAdvancedCustomIndicator(model *AdvancedCustomIndicatorModel) (api.SloIndicator, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if model.GoodEvents == nil || model.GoodEvents.Metric == nil {
+		diags.AddError(SloConfigErrAdvancedCustomRequired, SloConfigErrAdvancedCustomRequiredMsg)
+		return api.SloIndicator{}, diags
+	}
+
+	indicatorType := model.Type.ValueString()
+	if indicatorType == EmptyString {
+		indicatorType = SloConfigAPIIndicatorMeasurementTypeEventBased
+	}
+
+	goodEvents := r.mapAdvancedFilterFromModel(model.GoodEvents)
+	var badEvents *api.SloAdvancedFilter
+	if model.BadEvents != nil {
+		bf := r.mapAdvancedFilterFromModel(model.BadEvents)
+		badEvents = &bf
+	}
+
+	return api.SloIndicator{
+		Blueprint:  SloConfigAPIIndicatorBlueprintAdvancedCustom,
+		Type:       indicatorType,
+		GoodEvents: &goodEvents,
+		BadEvents:  badEvents,
+	}, diags
+}
+
+// mapAdvancedFilterFromModel converts an AdvancedFilterModel to an api.SloAdvancedFilter
+func (r *sloConfigResource) mapAdvancedFilterFromModel(model *AdvancedFilterModel) api.SloAdvancedFilter {
+	filter := api.SloAdvancedFilter{
+		Aggregation: model.Aggregation.ValueString(),
+		Threshold:   model.Threshold.ValueFloat64(),
+		Operator:    model.Operator.ValueString(),
+	}
+	if model.Metric != nil {
+		filter.Metric = r.mapEntityMetricFromModel(model.Metric)
+	}
+	return filter
+}
+
+// mapEntityMetricFromModel converts an EntityMetricModel to an api.SloEntityMetric (nil-safe)
+func (r *sloConfigResource) mapEntityMetricFromModel(model *EntityMetricModel) *api.SloEntityMetric {
+	if model == nil {
+		return nil
+	}
+	m := &api.SloEntityMetric{
+		Name: model.MetricName.ValueString(),
+	}
+	if model.Scope != nil {
+		scopeFilter := r.createDefaultTagFilter()
+		if !model.Scope.FilterExpression.IsNull() && !model.Scope.FilterExpression.IsUnknown() {
+			parser := tagfilter.NewParser()
+			expr, err := parser.Parse(model.Scope.FilterExpression.ValueString())
+			if err == nil {
+				mapper := tagfilter.NewMapper()
+				scopeFilter = mapper.ToAPIModel(expr)
+			}
+		}
+		m.Scope = &api.SloEntityMetricScope{
+			Type:             model.Scope.ScopeType.ValueString(),
+			FilterExpression: scopeFilter,
+		}
+	}
+	return m
+}
+
+// mapEntityMetricToModel converts an api.SloEntityMetric to an EntityMetricModel
+func (r *sloConfigResource) mapEntityMetricToModel(metric *api.SloEntityMetric) *EntityMetricModel {
+	if metric == nil {
+		return nil
+	}
+	m := &EntityMetricModel{
+		MetricName: types.StringValue(metric.Name),
+	}
+	if metric.Scope != nil {
+		scopeModel := &EntityMetricScopeModel{
+			ScopeType: types.StringValue(metric.Scope.Type),
+		}
+		if metric.Scope.FilterExpression != nil {
+			mapper := tagfilter.NewMapper()
+			expr, err := mapper.FromAPIModel(metric.Scope.FilterExpression)
+			if err == nil && expr != nil {
+				rendered := expr.Render()
+				// only store if it's a non-empty expression
+				if rendered != "" {
+					scopeModel.FilterExpression = types.StringValue(rendered)
+				} else {
+					scopeModel.FilterExpression = types.StringNull()
+				}
+			} else {
+				scopeModel.FilterExpression = types.StringNull()
+			}
+		} else {
+			scopeModel.FilterExpression = types.StringNull()
+		}
+		m.Scope = scopeModel
+	}
+	return m
 }
 
 // getDefaultAggregation returns the default aggregation value
@@ -1288,6 +1540,15 @@ func (r *sloConfigResource) mapEntityToState(apiObject *api.SloConfig, currentEn
 		if !diags.HasError() {
 			entityModel.InfrastructureEntityModel = &infraModel
 		}
+	case SloConfigMobileEntity:
+		mobileModel, mobileDiags := r.mapMobileEntityToState(apiObject.Entity)
+		if currentEntityModel != nil && currentEntityModel.MobileEntityModel != nil {
+			mobileModel.FilterExpression = currentEntityModel.MobileEntityModel.FilterExpression
+		}
+		diags.Append(mobileDiags...)
+		if !diags.HasError() {
+			entityModel.MobileEntityModel = &mobileModel
+		}
 	default:
 		diags.AddError(SloConfigErrMappingEntityToState, fmt.Sprintf(SloConfigErrUnsupportedEntityType, apiObject.Entity.Type))
 	}
@@ -1386,6 +1647,26 @@ func (r *sloConfigResource) mapInfrastructureEntityToState(entity api.SloEntity)
 	return model, diags
 }
 
+// mapMobileEntityToState converts mobile entity from API to state
+func (r *sloConfigResource) mapMobileEntityToState(entity api.SloEntity) (MobileEntityModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	mobileIDsSet, setDiags := types.SetValueFrom(context.Background(), types.StringType, entity.MobileIds)
+	diags.Append(setDiags...)
+
+	model := MobileEntityModel{
+		MobileIDs: mobileIDsSet,
+	}
+
+	filterExpr, filterDiags := r.mapFilterExpressionToState(entity.FilterExpression)
+	diags.Append(filterDiags...)
+	if !diags.HasError() {
+		model.FilterExpression = filterExpr
+	}
+
+	return model, diags
+}
+
 // mapFilterExpressionToState converts filter expression from API to state
 func (r *sloConfigResource) mapFilterExpressionToState(filterExpression *tag.TagFilter) (types.String, diag.Diagnostics) {
 	var diags diag.Diagnostics
@@ -1424,7 +1705,7 @@ func (r *sloConfigResource) mapIndicatorToState(apiObject *api.SloConfig, sloCon
 		indicatorModel.TimeBasedAvailabilityIndicatorModel = r.createTimeBasedAvailabilityModel(indicator)
 
 	case indicator.Type == SloConfigAPIIndicatorMeasurementTypeEventBased && indicator.Blueprint == SloConfigAPIIndicatorBlueprintAvailability:
-		indicatorModel.EventBasedAvailabilityIndicatorModel = r.createEventBasedAvailabilityModel()
+		indicatorModel.EventBasedAvailabilityIndicatorModel = r.createEventBasedAvailabilityModel(indicator)
 
 	case indicator.Blueprint == SloConfigAPIIndicatorBlueprintTraffic:
 		indicatorModel.TrafficIndicatorModel = r.createTrafficModel(indicator, existingVal)
@@ -1446,6 +1727,15 @@ func (r *sloConfigResource) mapIndicatorToState(apiObject *api.SloConfig, sloCon
 	case indicator.Type == SloConfigAPIIndicatorMeasurementTypeEventBased && indicator.Blueprint == SloConfigAPIIndicatorBlueprintSaturation:
 		indicatorModel.EventBasedSaturationIndicatorModel = r.createEventBasedSaturationModel(indicator)
 
+	case indicator.Blueprint == SloConfigAPIIndicatorBlueprintAdvancedCustom:
+		model := r.createAdvancedCustomModel(indicator)
+		// If bad_events was null in the plan, keep it null to avoid plan/apply inconsistency
+		if existingVal != nil && existingVal.AdvancedCustomIndicatorModel != nil &&
+			existingVal.AdvancedCustomIndicatorModel.BadEvents == nil {
+			model.BadEvents = nil
+		}
+		indicatorModel.AdvancedCustomIndicatorModel = model
+
 	default:
 		diags.AddError(SloConfigErrMappingIndicatorToState, fmt.Sprintf(SloConfigErrUnsupportedIndicatorType, indicator.Type, indicator.Blueprint))
 	}
@@ -1462,6 +1752,7 @@ func (r *sloConfigResource) createTimeBasedLatencyModel(indicator api.SloIndicat
 	return &TimeBasedLatencyIndicatorModel{
 		Threshold:   types.Float64Value(parsed),
 		Aggregation: util.SetStringPointerToState(indicator.Aggregation),
+		Metric:      r.mapEntityMetricToModel(indicator.Metric),
 	}
 }
 
@@ -1473,6 +1764,7 @@ func (r *sloConfigResource) createEventBasedLatencyModel(indicator api.SloIndica
 
 	return &EventBasedLatencyIndicatorModel{
 		Threshold: types.Float64Value(parsed),
+		Metric:    r.mapEntityMetricToModel(indicator.Metric),
 	}
 }
 
@@ -1485,12 +1777,19 @@ func (r *sloConfigResource) createTimeBasedAvailabilityModel(indicator api.SloIn
 	return &TimeBasedAvailabilityIndicatorModel{
 		Threshold:   types.Float64Value(parsed),
 		Aggregation: util.SetStringPointerToState(indicator.Aggregation),
+		Metric:      r.mapEntityMetricToModel(indicator.Metric),
 	}
 }
 
 // createEventBasedAvailabilityModel creates event-based availability indicator model
-func (r *sloConfigResource) createEventBasedAvailabilityModel() *EventBasedAvailabilityIndicatorModel {
-	return &EventBasedAvailabilityIndicatorModel{}
+func (r *sloConfigResource) createEventBasedAvailabilityModel(indicator api.SloIndicator) *EventBasedAvailabilityIndicatorModel {
+	formatted := strconv.FormatFloat(indicator.Threshold, 'f', 2, 64)
+	parsed, _ := strconv.ParseFloat(formatted, 64)
+	return &EventBasedAvailabilityIndicatorModel{
+		Threshold:   types.Float64Value(parsed),
+		Aggregation: util.SetStringPointerToState(indicator.Aggregation),
+		Metric:      r.mapEntityMetricToModel(indicator.Metric),
+	}
 }
 
 // createTrafficModel creates traffic indicator model
@@ -1502,9 +1801,13 @@ func (r *sloConfigResource) createTrafficModel(indicator api.SloIndicator, exist
 	trafficIndicatorModel := &TrafficIndicatorModel{
 		TrafficType: util.SetStringPointerToState(indicator.TrafficType),
 		Threshold:   types.Float64Value(parsed),
+		Metric:      r.mapEntityMetricToModel(indicator.Metric),
 	}
-	if existingVal == nil {
+	// Always prefer the API-returned operator; fall back to existing state value
+	if indicator.Operator != nil {
 		trafficIndicatorModel.Operator = util.SetStringPointerToState(indicator.Operator)
+	} else if existingVal != nil && existingVal.TrafficIndicatorModel != nil {
+		trafficIndicatorModel.Operator = existingVal.TrafficIndicatorModel.Operator
 	}
 	return trafficIndicatorModel
 }
@@ -1540,6 +1843,7 @@ func (r *sloConfigResource) createTimeBasedSaturationModel(indicator api.SloIndi
 		Threshold:   types.Float64Value(parsed),
 		Aggregation: util.SetStringPointerToState(indicator.Aggregation),
 		Operator:    util.SetStringPointerToState(indicator.Operator),
+		Metric:      r.mapEntityMetricToModel(indicator.Metric),
 	}
 }
 
@@ -1553,7 +1857,35 @@ func (r *sloConfigResource) createEventBasedSaturationModel(indicator api.SloInd
 		MetricName: util.SetStringPointerToState(indicator.MetricName),
 		Threshold:  types.Float64Value(parsed),
 		Operator:   util.SetStringPointerToState(indicator.Operator),
+		Metric:     r.mapEntityMetricToModel(indicator.Metric),
 	}
+}
+
+// createAdvancedCustomModel creates advanced-custom indicator model from API indicator
+func (r *sloConfigResource) createAdvancedCustomModel(indicator api.SloIndicator) *AdvancedCustomIndicatorModel {
+	model := &AdvancedCustomIndicatorModel{
+		Type: types.StringValue(indicator.Type),
+	}
+	if indicator.GoodEvents != nil {
+		gm := r.createAdvancedFilterModel(indicator.GoodEvents)
+		model.GoodEvents = &gm
+	}
+	if indicator.BadEvents != nil {
+		bm := r.createAdvancedFilterModel(indicator.BadEvents)
+		model.BadEvents = &bm
+	}
+	return model
+}
+
+// createAdvancedFilterModel creates an AdvancedFilterModel from an api.SloAdvancedFilter
+func (r *sloConfigResource) createAdvancedFilterModel(filter *api.SloAdvancedFilter) AdvancedFilterModel {
+	fm := AdvancedFilterModel{
+		Aggregation: types.StringValue(filter.Aggregation),
+		Threshold:   types.Float64Value(filter.Threshold),
+		Operator:    types.StringValue(filter.Operator),
+		Metric:      r.mapEntityMetricToModel(filter.Metric),
+	}
+	return fm
 }
 
 func (r *sloConfigResource) mapTimeWindowToState(apiObject *api.SloConfig) (TimeWindowModel, diag.Diagnostics) {

--- a/internal/resources/sloconfig/resource-slo-config_test.go
+++ b/internal/resources/sloconfig/resource-slo-config_test.go
@@ -379,7 +379,10 @@ func TestMapIndicatorFromState_EventBasedAvailability(t *testing.T) {
 
 	t.Run("should map event-based availability indicator successfully", func(t *testing.T) {
 		model := IndicatorModel{
-			EventBasedAvailabilityIndicatorModel: &EventBasedAvailabilityIndicatorModel{},
+			EventBasedAvailabilityIndicatorModel: &EventBasedAvailabilityIndicatorModel{
+				Threshold:   types.Float64Value(0),
+				Aggregation: types.StringValue("MEAN"),
+			},
 		}
 
 		result, diags := resource.mapIndicatorFromState(model)
@@ -387,6 +390,9 @@ func TestMapIndicatorFromState_EventBasedAvailability(t *testing.T) {
 		assert.False(t, diags.HasError())
 		assert.Equal(t, SloConfigAPIIndicatorBlueprintAvailability, result.Blueprint)
 		assert.Equal(t, SloConfigAPIIndicatorMeasurementTypeEventBased, result.Type)
+		assert.Equal(t, 0.0, result.Threshold)
+		assert.NotNil(t, result.Aggregation)
+		assert.Equal(t, "MEAN", *result.Aggregation)
 	})
 }
 
@@ -971,10 +977,13 @@ func TestMapIndicatorToState(t *testing.T) {
 	})
 
 	t.Run("should map event-based availability indicator to state", func(t *testing.T) {
+		aggregation := "MEAN"
 		apiObject := &api.SloConfig{
 			Indicator: api.SloIndicator{
-				Blueprint: SloConfigAPIIndicatorBlueprintAvailability,
-				Type:      SloConfigAPIIndicatorMeasurementTypeEventBased,
+				Blueprint:   SloConfigAPIIndicatorBlueprintAvailability,
+				Type:        SloConfigAPIIndicatorMeasurementTypeEventBased,
+				Threshold:   0.0,
+				Aggregation: &aggregation,
 			},
 		}
 
@@ -982,6 +991,8 @@ func TestMapIndicatorToState(t *testing.T) {
 
 		assert.False(t, diags.HasError())
 		assert.NotNil(t, result.EventBasedAvailabilityIndicatorModel)
+		assert.Equal(t, 0.0, result.EventBasedAvailabilityIndicatorModel.Threshold.ValueFloat64())
+		assert.Equal(t, "MEAN", result.EventBasedAvailabilityIndicatorModel.Aggregation.ValueString())
 	})
 
 	t.Run("should map traffic indicator to state", func(t *testing.T) {
@@ -1854,5 +1865,388 @@ func TestUpdateStateWithMappingErrors(t *testing.T) {
 		diags := resource.UpdateState(ctx, state, nil, apiObject)
 
 		assert.True(t, diags.HasError())
+	})
+}
+
+// ---- Mobile Entity tests ----
+
+func TestMapEntityFromState_MobileEntity(t *testing.T) {
+	resource := &sloConfigResource{}
+
+	t.Run("should map mobile entity successfully", func(t *testing.T) {
+		mobileIDs, _ := types.SetValueFrom(context.Background(), types.StringType, []string{"app-1", "app-2"})
+		entityModel := EntityModel{
+			MobileEntityModel: &MobileEntityModel{
+				MobileIDs:        mobileIDs,
+				FilterExpression: types.StringNull(),
+			},
+		}
+
+		result, diags := resource.mapEntityFromState(entityModel)
+
+		assert.False(t, diags.HasError())
+		assert.Equal(t, SloConfigMobileEntity, result.Type)
+		assert.ElementsMatch(t, []string{"app-1", "app-2"}, result.MobileIds)
+		assert.NotNil(t, result.FilterExpression)
+	})
+
+	t.Run("should succeed when mobile_ids is null (all mobile apps)", func(t *testing.T) {
+		entityModel := EntityModel{
+			MobileEntityModel: &MobileEntityModel{
+				MobileIDs:        types.SetNull(types.StringType),
+				FilterExpression: types.StringNull(),
+			},
+		}
+
+		result, diags := resource.mapEntityFromState(entityModel)
+
+		assert.False(t, diags.HasError())
+		assert.Equal(t, SloConfigMobileEntity, result.Type)
+		assert.Empty(t, result.MobileIds)
+	})
+
+	t.Run("should succeed when mobile_ids is empty (all mobile apps)", func(t *testing.T) {
+		emptySet, _ := types.SetValueFrom(context.Background(), types.StringType, []string{})
+		entityModel := EntityModel{
+			MobileEntityModel: &MobileEntityModel{
+				MobileIDs:        emptySet,
+				FilterExpression: types.StringNull(),
+			},
+		}
+
+		result, diags := resource.mapEntityFromState(entityModel)
+
+		assert.False(t, diags.HasError())
+		assert.Equal(t, SloConfigMobileEntity, result.Type)
+		assert.Empty(t, result.MobileIds)
+	})
+}
+
+func TestMapMobileEntityToState(t *testing.T) {
+	resource := &sloConfigResource{}
+
+	t.Run("should map mobile entity from API to Terraform state", func(t *testing.T) {
+		entity := api.SloEntity{
+			Type:      SloConfigMobileEntity,
+			MobileIds: []string{"app-1", "app-2"},
+		}
+
+		result, diags := resource.mapMobileEntityToState(entity)
+
+		assert.False(t, diags.HasError(), fmt.Sprintf("unexpected errors: %v", diags))
+		assert.Equal(t, 2, len(result.MobileIDs.Elements()))
+	})
+
+	t.Run("should map mobile entity type in full entity switch", func(t *testing.T) {
+		apiObject := &api.SloConfig{
+			Entity: api.SloEntity{
+				Type:      SloConfigMobileEntity,
+				MobileIds: []string{"app-1"},
+			},
+		}
+
+		result, diags := resource.mapEntityToState(apiObject, nil)
+
+		assert.False(t, diags.HasError())
+		require.NotNil(t, result.MobileEntityModel)
+		assert.Nil(t, result.ApplicationEntityModel)
+		assert.Equal(t, 1, len(result.MobileEntityModel.MobileIDs.Elements()))
+	})
+}
+
+// ---- EntityMetric (ThresholdIndicatorSupport metric field) tests ----
+
+func TestMapIndicatorFromState_WithEntityMetric(t *testing.T) {
+	resource := &sloConfigResource{}
+
+	t.Run("should map time-based latency indicator with metric field", func(t *testing.T) {
+		model := IndicatorModel{
+			TimeBasedLatencyIndicatorModel: &TimeBasedLatencyIndicatorModel{
+				Threshold:   types.Float64Value(500.0),
+				Aggregation: types.StringValue("MEAN"),
+				Metric: &EntityMetricModel{
+					MetricName: types.StringValue("duration"),
+					Scope: &EntityMetricScopeModel{
+						ScopeType: types.StringValue("httpRequests"),
+					},
+				},
+			},
+		}
+
+		result, diags := resource.mapIndicatorFromState(model)
+
+		assert.False(t, diags.HasError())
+		assert.Equal(t, SloConfigAPIIndicatorBlueprintLatency, result.Blueprint)
+		require.NotNil(t, result.Metric)
+		assert.Equal(t, "duration", result.Metric.Name)
+		require.NotNil(t, result.Metric.Scope)
+		assert.Equal(t, "httpRequests", result.Metric.Scope.Type)
+	})
+
+	t.Run("should map time-based availability indicator with metric field", func(t *testing.T) {
+		model := IndicatorModel{
+			TimeBasedAvailabilityIndicatorModel: &TimeBasedAvailabilityIndicatorModel{
+				Threshold:   types.Float64Value(0.99),
+				Aggregation: types.StringValue("MEAN"),
+				Metric: &EntityMetricModel{
+					MetricName: types.StringValue("crashRate"),
+					Scope: &EntityMetricScopeModel{
+						ScopeType: types.StringValue("crashes"),
+					},
+				},
+			},
+		}
+
+		result, diags := resource.mapIndicatorFromState(model)
+
+		assert.False(t, diags.HasError())
+		assert.Equal(t, SloConfigAPIIndicatorBlueprintAvailability, result.Blueprint)
+		require.NotNil(t, result.Metric)
+		assert.Equal(t, "crashRate", result.Metric.Name)
+	})
+
+	t.Run("should map traffic indicator with metric field", func(t *testing.T) {
+		model := IndicatorModel{
+			TrafficIndicatorModel: &TrafficIndicatorModel{
+				TrafficType: types.StringValue("CALLS_TOTAL"),
+				Threshold:   types.Float64Value(1000.0),
+				Operator:    types.StringValue(">="),
+				Metric: &EntityMetricModel{
+					MetricName: types.StringValue("requestCount"),
+					Scope: &EntityMetricScopeModel{
+						ScopeType: types.StringValue("httpRequests"),
+					},
+				},
+			},
+		}
+
+		result, diags := resource.mapIndicatorFromState(model)
+
+		assert.False(t, diags.HasError())
+		assert.Equal(t, SloConfigAPIIndicatorBlueprintTraffic, result.Blueprint)
+		require.NotNil(t, result.Metric)
+		assert.Equal(t, "requestCount", result.Metric.Name)
+	})
+}
+
+func TestMapIndicatorToState_WithEntityMetric(t *testing.T) {
+	resource := &sloConfigResource{}
+
+	t.Run("should map time-based latency indicator with metric to state", func(t *testing.T) {
+		aggregation := "MEAN"
+		apiObject := &api.SloConfig{
+			Indicator: api.SloIndicator{
+				Blueprint:   SloConfigAPIIndicatorBlueprintLatency,
+				Type:        SloConfigAPIIndicatorMeasurementTypeTimeBased,
+				Threshold:   500.0,
+				Aggregation: &aggregation,
+				Metric: &api.SloEntityMetric{
+					Name: "duration",
+					Scope: &api.SloEntityMetricScope{
+						Type: "httpRequests",
+					},
+				},
+			},
+		}
+
+		result, diags := resource.mapIndicatorToState(apiObject, &SloConfigModel{})
+
+		assert.False(t, diags.HasError())
+		require.NotNil(t, result.TimeBasedLatencyIndicatorModel)
+		require.NotNil(t, result.TimeBasedLatencyIndicatorModel.Metric)
+		assert.Equal(t, "duration", result.TimeBasedLatencyIndicatorModel.Metric.MetricName.ValueString())
+		require.NotNil(t, result.TimeBasedLatencyIndicatorModel.Metric.Scope)
+		assert.Equal(t, "httpRequests", result.TimeBasedLatencyIndicatorModel.Metric.Scope.ScopeType.ValueString())
+	})
+
+	t.Run("should map indicator with nil metric to state with nil Metric field", func(t *testing.T) {
+		aggregation := "MEAN"
+		apiObject := &api.SloConfig{
+			Indicator: api.SloIndicator{
+				Blueprint:   SloConfigAPIIndicatorBlueprintLatency,
+				Type:        SloConfigAPIIndicatorMeasurementTypeTimeBased,
+				Threshold:   500.0,
+				Aggregation: &aggregation,
+				Metric:      nil,
+			},
+		}
+
+		result, diags := resource.mapIndicatorToState(apiObject, &SloConfigModel{})
+
+		assert.False(t, diags.HasError())
+		require.NotNil(t, result.TimeBasedLatencyIndicatorModel)
+		assert.Nil(t, result.TimeBasedLatencyIndicatorModel.Metric)
+	})
+}
+
+// ---- AdvancedCustom indicator tests ----
+
+func TestMapIndicatorFromState_AdvancedCustom(t *testing.T) {
+	resource := &sloConfigResource{}
+
+	t.Run("should map advanced-custom indicator successfully", func(t *testing.T) {
+		model := IndicatorModel{
+			AdvancedCustomIndicatorModel: &AdvancedCustomIndicatorModel{
+				Type: types.StringValue("eventBased"),
+				GoodEvents: &AdvancedFilterModel{
+					Aggregation: types.StringValue("MEAN"),
+					Threshold:   types.Float64Value(500.0),
+					Operator:    types.StringValue("<"),
+					Metric: &EntityMetricModel{
+						MetricName: types.StringValue("duration"),
+						Scope: &EntityMetricScopeModel{
+							ScopeType: types.StringValue("httpRequests"),
+						},
+					},
+				},
+				BadEvents: &AdvancedFilterModel{
+					Aggregation: types.StringValue("MEAN"),
+					Threshold:   types.Float64Value(500.0),
+					Operator:    types.StringValue(">="),
+					Metric: &EntityMetricModel{
+						MetricName: types.StringValue("duration"),
+						Scope: &EntityMetricScopeModel{
+							ScopeType: types.StringValue("httpRequests"),
+						},
+					},
+				},
+			},
+		}
+
+		result, diags := resource.mapIndicatorFromState(model)
+
+		assert.False(t, diags.HasError())
+		assert.Equal(t, SloConfigAPIIndicatorBlueprintAdvancedCustom, result.Blueprint)
+		assert.Equal(t, "eventBased", result.Type)
+		require.NotNil(t, result.GoodEvents)
+		assert.Equal(t, "<", result.GoodEvents.Operator)
+		assert.Equal(t, "duration", result.GoodEvents.Metric.Name)
+		assert.Equal(t, "httpRequests", result.GoodEvents.Metric.Scope.Type)
+		require.NotNil(t, result.BadEvents)
+		assert.Equal(t, ">=", result.BadEvents.Operator)
+	})
+
+	t.Run("should default type to eventBased when not set", func(t *testing.T) {
+		model := IndicatorModel{
+			AdvancedCustomIndicatorModel: &AdvancedCustomIndicatorModel{
+				Type: types.StringNull(),
+				GoodEvents: &AdvancedFilterModel{
+					Aggregation: types.StringValue("MEAN"),
+					Threshold:   types.Float64Value(500.0),
+					Operator:    types.StringValue("<"),
+					Metric: &EntityMetricModel{
+						MetricName: types.StringValue("duration"),
+					},
+				},
+			},
+		}
+
+		result, diags := resource.mapIndicatorFromState(model)
+
+		assert.False(t, diags.HasError())
+		assert.Equal(t, SloConfigAPIIndicatorMeasurementTypeEventBased, result.Type)
+	})
+
+	t.Run("should return error when good_events metric is missing", func(t *testing.T) {
+		model := IndicatorModel{
+			AdvancedCustomIndicatorModel: &AdvancedCustomIndicatorModel{
+				Type: types.StringValue("eventBased"),
+				GoodEvents: &AdvancedFilterModel{
+					Aggregation: types.StringValue("MEAN"),
+					Threshold:   types.Float64Value(500.0),
+					Operator:    types.StringValue("<"),
+					Metric:      nil, // missing
+				},
+			},
+		}
+
+		_, diags := resource.mapIndicatorFromState(model)
+
+		assert.True(t, diags.HasError())
+		assert.Contains(t, diags[0].Summary(), SloConfigErrAdvancedCustomRequired)
+	})
+
+	t.Run("should return error when good_events is nil", func(t *testing.T) {
+		model := IndicatorModel{
+			AdvancedCustomIndicatorModel: &AdvancedCustomIndicatorModel{
+				Type:       types.StringValue("eventBased"),
+				GoodEvents: nil,
+			},
+		}
+
+		_, diags := resource.mapIndicatorFromState(model)
+
+		assert.True(t, diags.HasError())
+		assert.Contains(t, diags[0].Summary(), SloConfigErrAdvancedCustomRequired)
+	})
+}
+
+func TestMapIndicatorToState_AdvancedCustom(t *testing.T) {
+	resource := &sloConfigResource{}
+
+	t.Run("should map advanced-custom indicator from API to state", func(t *testing.T) {
+		apiObject := &api.SloConfig{
+			Indicator: api.SloIndicator{
+				Blueprint: SloConfigAPIIndicatorBlueprintAdvancedCustom,
+				Type:      "eventBased",
+				GoodEvents: &api.SloAdvancedFilter{
+					Aggregation: "MEAN",
+					Threshold:   500.0,
+					Operator:    "<",
+					Metric: &api.SloEntityMetric{
+						Name: "duration",
+						Scope: &api.SloEntityMetricScope{
+							Type: "httpRequests",
+						},
+					},
+				},
+				BadEvents: &api.SloAdvancedFilter{
+					Aggregation: "MEAN",
+					Threshold:   500.0,
+					Operator:    ">=",
+					Metric: &api.SloEntityMetric{
+						Name: "duration",
+						Scope: &api.SloEntityMetricScope{
+							Type: "httpRequests",
+						},
+					},
+				},
+			},
+		}
+
+		result, diags := resource.mapIndicatorToState(apiObject, &SloConfigModel{})
+
+		assert.False(t, diags.HasError())
+		require.NotNil(t, result.AdvancedCustomIndicatorModel)
+		assert.Equal(t, "eventBased", result.AdvancedCustomIndicatorModel.Type.ValueString())
+		require.NotNil(t, result.AdvancedCustomIndicatorModel.GoodEvents)
+		assert.Equal(t, "<", result.AdvancedCustomIndicatorModel.GoodEvents.Operator.ValueString())
+		assert.Equal(t, "duration", result.AdvancedCustomIndicatorModel.GoodEvents.Metric.MetricName.ValueString())
+		assert.Equal(t, "httpRequests", result.AdvancedCustomIndicatorModel.GoodEvents.Metric.Scope.ScopeType.ValueString())
+		require.NotNil(t, result.AdvancedCustomIndicatorModel.BadEvents)
+		assert.Equal(t, ">=", result.AdvancedCustomIndicatorModel.BadEvents.Operator.ValueString())
+		assert.Nil(t, result.TimeBasedLatencyIndicatorModel)
+	})
+
+	t.Run("should map advanced-custom with nil bad_events from API", func(t *testing.T) {
+		apiObject := &api.SloConfig{
+			Indicator: api.SloIndicator{
+				Blueprint: SloConfigAPIIndicatorBlueprintAdvancedCustom,
+				Type:      "eventBased",
+				GoodEvents: &api.SloAdvancedFilter{
+					Aggregation: "MEAN",
+					Threshold:   500.0,
+					Operator:    "<",
+					Metric:      &api.SloEntityMetric{Name: "duration"},
+				},
+				BadEvents: nil,
+			},
+		}
+
+		result, diags := resource.mapIndicatorToState(apiObject, &SloConfigModel{})
+
+		assert.False(t, diags.HasError())
+		require.NotNil(t, result.AdvancedCustomIndicatorModel)
+		assert.Nil(t, result.AdvancedCustomIndicatorModel.BadEvents)
 	})
 }

--- a/internal/resources/sloconfig/slo-config-model.go
+++ b/internal/resources/sloconfig/slo-config-model.go
@@ -30,6 +30,7 @@ type EntityModel struct {
 	WebsiteEntityModel        *WebsiteEntityModel        `tfsdk:"website"`
 	SyntheticEntityModel      *SyntheticEntityModel      `tfsdk:"synthetic"`
 	InfrastructureEntityModel *InfrastructureEntityModel `tfsdk:"infrastructure"`
+	MobileEntityModel         *MobileEntityModel         `tfsdk:"mobile"`
 }
 type IndicatorModel struct {
 	TimeBasedLatencyIndicatorModel       *TimeBasedLatencyIndicatorModel       `tfsdk:"time_based_latency"`
@@ -40,6 +41,7 @@ type IndicatorModel struct {
 	CustomIndicatorModel                 *CustomIndicatorModel                 `tfsdk:"custom"`
 	TimeBasedSaturationIndicatorModel    *TimeBasedSaturationIndicatorModel    `tfsdk:"time_based_saturation"`
 	EventBasedSaturationIndicatorModel   *EventBasedSaturationIndicatorModel   `tfsdk:"event_based_saturation"`
+	AdvancedCustomIndicatorModel         *AdvancedCustomIndicatorModel         `tfsdk:"advanced_custom"`
 }
 
 // ApplicationEntityModel represents an application entity in the Terraform model
@@ -73,33 +75,72 @@ type InfrastructureEntityModel struct {
 	FilterExpression types.String `tfsdk:"filter_expression"`
 }
 
+// MobileEntityModel represents a mobile app entity in the Terraform model
+type MobileEntityModel struct {
+	MobileIDs        types.Set    `tfsdk:"mobile_ids"`
+	FilterExpression types.String `tfsdk:"filter_expression"`
+}
+
+// EntityMetricScopeModel represents the scope nested inside a metric block
+type EntityMetricScopeModel struct {
+	ScopeType        types.String `tfsdk:"scope_type"`
+	FilterExpression types.String `tfsdk:"filter_expression"`
+}
+
+// EntityMetricModel represents the metric nested block for threshold-based mobile indicators
+type EntityMetricModel struct {
+	MetricName types.String            `tfsdk:"metric_name"`
+	Scope      *EntityMetricScopeModel `tfsdk:"scope"`
+}
+
+// AdvancedFilterModel represents one side (good or bad) of an advanced-custom indicator
+type AdvancedFilterModel struct {
+	Aggregation types.String       `tfsdk:"aggregation"`
+	Threshold   types.Float64      `tfsdk:"threshold"`
+	Operator    types.String       `tfsdk:"operator"`
+	Metric      *EntityMetricModel `tfsdk:"metric"`
+}
+
+// AdvancedCustomIndicatorModel represents the advanced-custom blueprint indicator
+type AdvancedCustomIndicatorModel struct {
+	Type       types.String         `tfsdk:"type"`
+	GoodEvents *AdvancedFilterModel `tfsdk:"good_events"`
+	BadEvents  *AdvancedFilterModel `tfsdk:"bad_events"`
+}
+
 // TimeBasedLatencyIndicatorModel represents a time-based latency indicator in the Terraform model
 type TimeBasedLatencyIndicatorModel struct {
-	Threshold   types.Float64 `tfsdk:"threshold"`
-	Aggregation types.String  `tfsdk:"aggregation"`
+	Threshold   types.Float64      `tfsdk:"threshold"`
+	Aggregation types.String       `tfsdk:"aggregation"`
+	Metric      *EntityMetricModel `tfsdk:"metric"`
 }
 
 // EventBasedLatencyIndicatorModel represents an event-based latency indicator in the Terraform model
 type EventBasedLatencyIndicatorModel struct {
-	Threshold types.Float64 `tfsdk:"threshold"`
+	Threshold types.Float64      `tfsdk:"threshold"`
+	Metric    *EntityMetricModel `tfsdk:"metric"`
 }
 
 // TimeBasedAvailabilityIndicatorModel represents a time-based availability indicator in the Terraform model
 type TimeBasedAvailabilityIndicatorModel struct {
-	Threshold   types.Float64 `tfsdk:"threshold"`
-	Aggregation types.String  `tfsdk:"aggregation"`
+	Threshold   types.Float64      `tfsdk:"threshold"`
+	Aggregation types.String       `tfsdk:"aggregation"`
+	Metric      *EntityMetricModel `tfsdk:"metric"`
 }
 
 // EventBasedAvailabilityIndicatorModel represents an event-based availability indicator in the Terraform model
 type EventBasedAvailabilityIndicatorModel struct {
-	// No fields needed for this indicator type
+	Threshold   types.Float64      `tfsdk:"threshold"`
+	Aggregation types.String       `tfsdk:"aggregation"`
+	Metric      *EntityMetricModel `tfsdk:"metric"`
 }
 
 // TrafficIndicatorModel represents a traffic indicator in the Terraform model
 type TrafficIndicatorModel struct {
-	TrafficType types.String  `tfsdk:"traffic_type"`
-	Threshold   types.Float64 `tfsdk:"threshold"`
-	Operator    types.String  `tfsdk:"operator"`
+	TrafficType types.String       `tfsdk:"traffic_type"`
+	Threshold   types.Float64      `tfsdk:"threshold"`
+	Operator    types.String       `tfsdk:"operator"`
+	Metric      *EntityMetricModel `tfsdk:"metric"`
 }
 
 // CustomIndicatorModel represents a custom indicator in the Terraform model
@@ -108,19 +149,21 @@ type CustomIndicatorModel struct {
 	BadEventFilterExpression  types.String `tfsdk:"bad_event_filter_expression"`
 }
 
-// SaturationIndicatorModel represents a saturation indicator in the Terraform model
+// TimeBasedSaturationIndicatorModel represents a saturation indicator in the Terraform model
 type TimeBasedSaturationIndicatorModel struct {
-	MetricName  types.String  `tfsdk:"metric_name"`
-	Threshold   types.Float64 `tfsdk:"threshold"`
-	Aggregation types.String  `tfsdk:"aggregation"`
-	Operator    types.String  `tfsdk:"operator"`
+	MetricName  types.String       `tfsdk:"metric_name"`
+	Threshold   types.Float64      `tfsdk:"threshold"`
+	Aggregation types.String       `tfsdk:"aggregation"`
+	Operator    types.String       `tfsdk:"operator"`
+	Metric      *EntityMetricModel `tfsdk:"metric"`
 }
 
-// SaturationIndicatorModel represents a saturation indicator in the Terraform model
+// EventBasedSaturationIndicatorModel represents a saturation indicator in the Terraform model
 type EventBasedSaturationIndicatorModel struct {
-	MetricName types.String  `tfsdk:"metric_name"`
-	Threshold  types.Float64 `tfsdk:"threshold"`
-	Operator   types.String  `tfsdk:"operator"`
+	MetricName types.String       `tfsdk:"metric_name"`
+	Threshold  types.Float64      `tfsdk:"threshold"`
+	Operator   types.String       `tfsdk:"operator"`
+	Metric     *EntityMetricModel `tfsdk:"metric"`
 }
 
 // RollingTimeWindowModel represents a rolling time window in the Terraform model


### PR DESCRIPTION
This PR extends the `instana_slo_config` resource to support **Mobile App SLOs**

## Changes
- Adds a new `mobile` entity block to the `entity` attribute.
- Supports `mobile_ids` (static list of app IDs) and `filter_expression` (dynamic tag-filter scoping) 
- Added application config mandatory validation for tag filter

## Dependency

- Bumps `instana-go-client` from `v1.1.2` → `v1.1.3` to include the new `MobileIds`, `SloAdvancedFilter`, and `SloEntityMetric` API model fields.

## Documentation
  - Mobile App entity examples (time-based, event-based, custom)
