### PR TITLE
Alert channel datasource - slack and teams app 

### DIFF
--- a/docs/data-sources/alerting_channel.md
+++ b/docs/data-sources/alerting_channel.md
@@ -22,6 +22,7 @@ Exactly one of the following items is provided depending on the type of the aler
 
 * `email` - configuration of a email alerting channel - [Details](#email)
 * `google_chat` - configuration of a Google Chat alerting channel - [Details](#google-chat)
+* `ms_teams_app` - configuration of a MS Teams App (bidirectional) alerting channel - [Details](#ms-teams-app)
 * `office_365` - configuration of a Office 365 alerting channel - [Details](#office-365)
 * `ops_genie` - configuration of a OpsGenie alerting channel - [Details](#opsgenie)
 * `pager_duty` - configuration of a PagerDuty alerting channel - [Details](#pagerduty)
@@ -29,6 +30,7 @@ Exactly one of the following items is provided depending on the type of the aler
 * `service_now` - configuration of a ServiceNow alerting channel - [Details](#servicenow)
 * `service_now_application` - configuration of a ServiceNow Application alerting channel - [Details](#servicenow-application)
 * `slack` - configuration of a Slack alerting channel - [Details](#slack)
+* `slack_app` - configuration of a Slack App (bidirectional) alerting channel - [Details](#slack-app)
 * `splunk` - configuration of a Splunk alerting channel - [Details](#splunk)
 * `victor_ops` - configuration of a VictorOps alerting channel - [Details](#victorops)
 * `watson_aiops_webhook` - configuration of a Watson AIOps Webhook alerting channel - [Details](#watson-aiops-webhook)
@@ -118,3 +120,24 @@ Exactly one of the following items is provided depending on the type of the aler
 
 * `webhook_urls` - the list of webhook URLs where the alert will be sent to
 * `http_headers` - key/value map of additional http headers which will be sent to the webhook
+
+### Slack App
+
+* `app_id` - the App ID of the Slack App
+* `team_id` - the Team ID where the Slack App is installed
+* `team_name` - the Team Name where the Slack App is installed
+* `channel_id` - the Channel ID where alerts will be sent
+* `channel_name` - the Channel Name where alerts will be sent
+* `emoji_rendering` - whether emoji rendering is enabled in alert messages
+
+### MS Teams App
+
+* `api_token_id` - the API Token ID for MS Teams App authentication
+* `team_id` - the Team ID where the MS Teams App is installed
+* `team_name` - the Team Name where the MS Teams App is installed
+* `channel_id` - the Channel ID where alerts will be sent
+* `channel_name` - the Channel Name where alerts will be sent
+* `instana_url` - the Instana URL for linking back from MS Teams
+* `service_url` - the MS Teams service URL
+* `tenant_id` - the Tenant ID for MS Teams
+* `tenant_name` - the Tenant Name for MS Teams

--- a/internal/datasources/data-source-alerting-channel-constants.go
+++ b/internal/datasources/data-source-alerting-channel-constants.go
@@ -171,4 +171,57 @@ const (
 
 	//AlertingChannelFieldChannelWatsonAIOpsWebhook const for schema field of the Watson AIOps Webhook channel
 	AlertingChannelFieldChannelWatsonAIOpsWebhook = "watson_aiops_webhook"
+
+	//AlertingChannelFieldChannelSlackApp const for schema field of the Slack App channel
+	AlertingChannelFieldChannelSlackApp = "slack_app"
+	//AlertingChannelSlackAppFieldAppID const for the appId field of the Slack App alerting channel
+	AlertingChannelSlackAppFieldAppID = "app_id"
+	//AlertingChannelSlackAppFieldTeamID const for the teamId field of the Slack App alerting channel
+	AlertingChannelSlackAppFieldTeamID = "team_id"
+	//AlertingChannelSlackAppFieldTeamName const for the teamName field of the Slack App alerting channel
+	AlertingChannelSlackAppFieldTeamName = "team_name"
+	//AlertingChannelSlackAppFieldChannelID const for the channelId field of the Slack App alerting channel
+	AlertingChannelSlackAppFieldChannelID = "channel_id"
+	//AlertingChannelSlackAppFieldChannelName const for the channelName field of the Slack App alerting channel
+	AlertingChannelSlackAppFieldChannelName = "channel_name"
+	//AlertingChannelSlackAppFieldEmojiRendering const for the emojiRendering field of the Slack App alerting channel
+	AlertingChannelSlackAppFieldEmojiRendering = "emoji_rendering"
+	AlertingChannelDescSlackApp                = "The configuration of the Slack App (bidirectional) channel"
+	AlertingChannelDescSlackAppAppID           = "The App ID of the Slack App alerting channel"
+	AlertingChannelDescSlackAppTeamID          = "The Team ID of the Slack App alerting channel"
+	AlertingChannelDescSlackAppTeamName        = "The Team Name of the Slack App alerting channel"
+	AlertingChannelDescSlackAppChannelID       = "The Channel ID of the Slack App alerting channel"
+	AlertingChannelDescSlackAppChannelName     = "The Channel Name of the Slack App alerting channel"
+	AlertingChannelDescSlackAppEmojiRendering  = "Whether to enable emoji rendering in the Slack App alerting channel"
+
+	//AlertingChannelFieldChannelMsTeamsApp const for schema field of the MS Teams App channel
+	AlertingChannelFieldChannelMsTeamsApp = "ms_teams_app"
+	//AlertingChannelMsTeamsAppFieldAPITokenID const for the apiTokenId field of the MS Teams App alerting channel
+	AlertingChannelMsTeamsAppFieldAPITokenID = "api_token_id"
+	//AlertingChannelMsTeamsAppFieldTeamID const for the teamId field of the MS Teams App alerting channel
+	AlertingChannelMsTeamsAppFieldTeamID = "team_id"
+	//AlertingChannelMsTeamsAppFieldTeamName const for the teamName field of the MS Teams App alerting channel
+	AlertingChannelMsTeamsAppFieldTeamName = "team_name"
+	//AlertingChannelMsTeamsAppFieldChannelID const for the channelId field of the MS Teams App alerting channel
+	AlertingChannelMsTeamsAppFieldChannelID = "channel_id"
+	//AlertingChannelMsTeamsAppFieldChannelName const for the channelName field of the MS Teams App alerting channel
+	AlertingChannelMsTeamsAppFieldChannelName = "channel_name"
+	//AlertingChannelMsTeamsAppFieldInstanaURL const for the instanaUrl field of the MS Teams App alerting channel
+	AlertingChannelMsTeamsAppFieldInstanaURL = "instana_url"
+	//AlertingChannelMsTeamsAppFieldServiceURL const for the serviceUrl field of the MS Teams App alerting channel
+	AlertingChannelMsTeamsAppFieldServiceURL = "service_url"
+	//AlertingChannelMsTeamsAppFieldTenantID const for the tenantId field of the MS Teams App alerting channel
+	AlertingChannelMsTeamsAppFieldTenantID = "tenant_id"
+	//AlertingChannelMsTeamsAppFieldTenantName const for the tenantName field of the MS Teams App alerting channel
+	AlertingChannelMsTeamsAppFieldTenantName     = "tenant_name"
+	AlertingChannelDescMsTeamsApp                = "The configuration of the MS Teams App (bidirectional) channel"
+	AlertingChannelDescMsTeamsAppAPITokenID      = "The API Token ID of the MS Teams App alerting channel"
+	AlertingChannelDescMsTeamsAppTeamID          = "The Team ID of the MS Teams App alerting channel"
+	AlertingChannelDescMsTeamsAppTeamName        = "The Team Name of the MS Teams App alerting channel"
+	AlertingChannelDescMsTeamsAppChannelID       = "The Channel ID of the MS Teams App alerting channel"
+	AlertingChannelDescMsTeamsAppChannelName     = "The Channel Name of the MS Teams App alerting channel"
+	AlertingChannelDescMsTeamsAppInstanaURL      = "The Instana URL for the MS Teams App alerting channel"
+	AlertingChannelDescMsTeamsAppServiceURL      = "The Service URL of the MS Teams App alerting channel"
+	AlertingChannelDescMsTeamsAppTenantID        = "The Tenant ID of the MS Teams App alerting channel"
+	AlertingChannelDescMsTeamsAppTenantName      = "The Tenant Name of the MS Teams App alerting channel"
 )

--- a/internal/datasources/data-source-alerting-channel.go
+++ b/internal/datasources/data-source-alerting-channel.go
@@ -33,6 +33,8 @@ type AlertingChannelDataSourceModel struct {
 	PrometheusWebhook     *shared.PrometheusWebhookModel     `tfsdk:"prometheus_webhook"`
 	WebexTeamsWebhook     *shared.WebhookBasedModel          `tfsdk:"webex_teams_webhook"`
 	WatsonAIOpsWebhook    *shared.WatsonAIOpsWebhookModel    `tfsdk:"watson_aiops_webhook"`
+	SlackApp              *shared.SlackAppModel              `tfsdk:"slack_app"`
+	MsTeamsApp            *shared.MsTeamsAppModel            `tfsdk:"ms_teams_app"`
 }
 
 // NewAlertingChannelDataSource creates a new data source for alerting channel
@@ -309,6 +311,78 @@ func (d *AlertingChannelDataSource) Schema(_ context.Context, _ datasource.Schem
 					},
 				},
 			},
+			AlertingChannelFieldChannelSlackApp: schema.SingleNestedAttribute{
+				Computed:    true,
+				Description: AlertingChannelDescSlackApp,
+				Attributes: map[string]schema.Attribute{
+					AlertingChannelSlackAppFieldAppID: schema.StringAttribute{
+						Description: AlertingChannelDescSlackAppAppID,
+						Computed:    true,
+					},
+					AlertingChannelSlackAppFieldTeamID: schema.StringAttribute{
+						Description: AlertingChannelDescSlackAppTeamID,
+						Computed:    true,
+					},
+					AlertingChannelSlackAppFieldTeamName: schema.StringAttribute{
+						Description: AlertingChannelDescSlackAppTeamName,
+						Computed:    true,
+					},
+					AlertingChannelSlackAppFieldChannelID: schema.StringAttribute{
+						Description: AlertingChannelDescSlackAppChannelID,
+						Computed:    true,
+					},
+					AlertingChannelSlackAppFieldChannelName: schema.StringAttribute{
+						Description: AlertingChannelDescSlackAppChannelName,
+						Computed:    true,
+					},
+					AlertingChannelSlackAppFieldEmojiRendering: schema.BoolAttribute{
+						Description: AlertingChannelDescSlackAppEmojiRendering,
+						Computed:    true,
+					},
+				},
+			},
+			AlertingChannelFieldChannelMsTeamsApp: schema.SingleNestedAttribute{
+				Computed:    true,
+				Description: AlertingChannelDescMsTeamsApp,
+				Attributes: map[string]schema.Attribute{
+					AlertingChannelMsTeamsAppFieldAPITokenID: schema.StringAttribute{
+						Description: AlertingChannelDescMsTeamsAppAPITokenID,
+						Computed:    true,
+					},
+					AlertingChannelMsTeamsAppFieldTeamID: schema.StringAttribute{
+						Description: AlertingChannelDescMsTeamsAppTeamID,
+						Computed:    true,
+					},
+					AlertingChannelMsTeamsAppFieldTeamName: schema.StringAttribute{
+						Description: AlertingChannelDescMsTeamsAppTeamName,
+						Computed:    true,
+					},
+					AlertingChannelMsTeamsAppFieldChannelID: schema.StringAttribute{
+						Description: AlertingChannelDescMsTeamsAppChannelID,
+						Computed:    true,
+					},
+					AlertingChannelMsTeamsAppFieldChannelName: schema.StringAttribute{
+						Description: AlertingChannelDescMsTeamsAppChannelName,
+						Computed:    true,
+					},
+					AlertingChannelMsTeamsAppFieldInstanaURL: schema.StringAttribute{
+						Description: AlertingChannelDescMsTeamsAppInstanaURL,
+						Computed:    true,
+					},
+					AlertingChannelMsTeamsAppFieldServiceURL: schema.StringAttribute{
+						Description: AlertingChannelDescMsTeamsAppServiceURL,
+						Computed:    true,
+					},
+					AlertingChannelMsTeamsAppFieldTenantID: schema.StringAttribute{
+						Description: AlertingChannelDescMsTeamsAppTenantID,
+						Computed:    true,
+					},
+					AlertingChannelMsTeamsAppFieldTenantName: schema.StringAttribute{
+						Description: AlertingChannelDescMsTeamsAppTenantName,
+						Computed:    true,
+					},
+				},
+			},
 		},
 	}
 }
@@ -476,6 +550,20 @@ func (d *AlertingChannelDataSource) Read(ctx context.Context, req datasource.Rea
 			return
 		}
 		data.WatsonAIOpsWebhook = watsonAIOpsWebhookChannel
+	case api.SlackAppChannelType:
+		slackAppChannel, slackAppDiags := shared.MapSlackAppChannelToState(ctx, matchingChannel)
+		if slackAppDiags.HasError() {
+			resp.Diagnostics.Append(slackAppDiags...)
+			return
+		}
+		data.SlackApp = slackAppChannel
+	case api.MsTeamsAppChannelType:
+		msTeamsAppChannel, msTeamsAppDiags := shared.MapMsTeamsAppChannelToState(ctx, matchingChannel)
+		if msTeamsAppDiags.HasError() {
+			resp.Diagnostics.Append(msTeamsAppDiags...)
+			return
+		}
+		data.MsTeamsApp = msTeamsAppChannel
 	default:
 		resp.Diagnostics.AddError(
 			AlertingChannelErrUnsupportedChannelType,


### PR DESCRIPTION
This PR brings the alert channel data source to parity with the resource by adding the below alert channel types
- `BIDIRECTIONAL_SLACK` (Slack App)
- `BIDIRECTIONAL_MS_TEAMS` (MS Teams App)