### PR TITLE
Fix concurrent map writes panic in addCorrelationIDToClient

### DIFF
--- a/internal/provider/terraform-provider-instana-resource.go
+++ b/internal/provider/terraform-provider-instana-resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -17,6 +18,14 @@ import (
 
 // CorrelationIDHeader is the HTTP header name for correlation ID
 const CorrelationIDHeader = "X-Correlation-ID"
+
+// correlationIDMu guards writes to providerMeta.ClientConfig.Headers.Custom in
+// addCorrelationIDToClient. ClientConfig is shared across every resource
+// instance/goroutine (Create/Read/Update/Delete run concurrently under
+// Terraform's default parallelism), and Headers.Custom is a plain map with no
+// synchronization of its own, so unguarded concurrent writes here panic with
+// "fatal error: concurrent map writes" (see #91).
+var correlationIDMu sync.Mutex
 
 // NewTerraformResource creates a new terraform resource for the given handle
 func NewTerraformResource[T client.InstanaDataObject](handle resourcehandle.ResourceHandle[T]) TerraformResource {
@@ -427,6 +436,9 @@ func (r *terraformResourceImpl[T]) UpgradeState(ctx context.Context) map[int64]r
 
 // addCorrelationIDToClient adds the correlation ID header to the client configuration
 func (r *terraformResourceImpl[T]) addCorrelationIDToClient(correlationID string) {
+	correlationIDMu.Lock()
+	defer correlationIDMu.Unlock()
+
 	if r.providerMeta != nil && r.providerMeta.ClientConfig != nil {
 		if r.providerMeta.ClientConfig.Headers.Custom == nil {
 			r.providerMeta.ClientConfig.Headers.Custom = make(map[string]string)

--- a/internal/provider/terraform-provider-instana-resource_correlation_id_test.go
+++ b/internal/provider/terraform-provider-instana-resource_correlation_id_test.go
@@ -1,0 +1,50 @@
+package provider
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/instana/instana-go-client/config"
+	"github.com/instana/terraform-provider-instana/internal/shared"
+)
+
+// TestAddCorrelationIDToClient_ConcurrentSafe reproduces the scenario in #91:
+// many resource instances (as created by NewTerraformResource per
+// Create/Read/Update/Delete call) sharing the same *shared.ProviderMeta and
+// calling addCorrelationIDToClient concurrently, as happens under
+// Terraform's default parallelism when a config fans out many resources of
+// the same type. Before the fix, `go test -race` (or enough iterations/CPUs)
+// reliably reports a `fatal error: concurrent map writes` panic or a data
+// race on Headers.Custom; with the mutex in place, it passes cleanly.
+func TestAddCorrelationIDToClient_ConcurrentSafe(t *testing.T) {
+	providerMeta := &shared.ProviderMeta{
+		ClientConfig: &config.ClientConfig{},
+	}
+
+	const goroutines = 200
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		go func(n int) {
+			defer wg.Done()
+			r := &terraformResourceImpl[fakeInstanaDataObject]{
+				providerMeta: providerMeta,
+			}
+			r.addCorrelationIDToClient("correlation-id")
+		}(i)
+	}
+
+	wg.Wait()
+
+	if providerMeta.ClientConfig.Headers.Custom[CorrelationIDHeader] != "correlation-id" {
+		t.Fatalf("expected correlation ID header to be set after concurrent writes")
+	}
+}
+
+// fakeInstanaDataObject is a minimal stand-in satisfying the
+// client.InstanaDataObject type parameter for terraformResourceImpl in this
+// test; none of its methods are exercised by addCorrelationIDToClient.
+type fakeInstanaDataObject struct{}
+
+func (fakeInstanaDataObject) GetIDForResourcePath() string { return "" }


### PR DESCRIPTION
r.providerMeta.ClientConfig is shared across every resource instance/goroutine, and Create/Read/Update/Delete all call addCorrelationIDToClient concurrently under Terraform's default parallelism. Headers.Custom is a plain map with no synchronization, so concurrent writes (including the racy nil-check-then-make lazy init) panic with 'fatal error: concurrent map writes', crashing the provider process and taking down every other in-flight resource operation with it (Plugin did not respond / Request cancelled).

Confirmed present from v7.0.1 through the latest release (v7.3.4) via source inspection across tags; see #91 for multiple real-world crash reports (v7.0.1, v7.1.2, v7.3.4).

Fix: guard the map read-check-write with a package-level sync.Mutex, since this is the only place in the codebase that writes to Headers.Custom (confirmed via repo-wide search).

Adds a regression test that reproduces the crash under -race/high goroutine count without the fix, and passes cleanly with it.

Fixes #91