### PR TITLE
fix(rbac): resolve apply consistency errors for instana_rbac_team scope and instana_rbac_role member

### DIFF
--- a/internal/resources/roles/resource-roles.go
+++ b/internal/resources/roles/resource-roles.go
@@ -125,10 +125,14 @@ func (r *roleResource) buildRoleModelFromAPIResponse(role *api.Role, existingMem
 	return model
 }
 
-// mapMembersToModel converts API members to model members
+// mapMembersToModel converts API members to model members.
+// When the API returns no members, the return value mirrors the plan:
+//   - nil  → member was not configured at all (keep null in state)
+//   - non-nil empty slice → member = [] was configured (keep empty set in state)
+
 func (r *roleResource) mapMembersToModel(apiMembers []api.APIMember, existingMembers []RoleMemberModel) []RoleMemberModel {
 	if len(apiMembers) == 0 {
-		return make([]RoleMemberModel, 0)
+		return existingMembers
 	}
 
 	members := make([]RoleMemberModel, len(apiMembers))

--- a/internal/resources/roles/resource-roles_test.go
+++ b/internal/resources/roles/resource-roles_test.go
@@ -762,6 +762,22 @@ func TestMapMembersToModel(t *testing.T) {
 		assert.Equal(t, "user-1", result[0].UserID.ValueString())
 		assert.Equal(t, "user-2", result[1].UserID.ValueString())
 	})
+
+	// Regression test for GitHub issue #105:
+	// When member is not configured (existingMembers = nil) and the API
+	// returns no members, the result must be nil — not an empty slice.
+	// Returning []RoleMemberModel{} causes the framework to serialise
+	// the field as an empty set, which mismatches the plan's null value.
+	t.Run("should return nil when member not configured and API has no members", func(t *testing.T) {
+		result := resource.mapMembersToModel([]api.APIMember{}, nil)
+		assert.Nil(t, result)
+	})
+
+	t.Run("should return empty slice when member configured as empty and API has no members", func(t *testing.T) {
+		result := resource.mapMembersToModel([]api.APIMember{}, []RoleMemberModel{})
+		assert.NotNil(t, result)
+		assert.Empty(t, result)
+	})
 }
 
 func TestMapModelMembersToAPI(t *testing.T) {

--- a/internal/resources/roles/resource-roles_test.go
+++ b/internal/resources/roles/resource-roles_test.go
@@ -763,7 +763,6 @@ func TestMapMembersToModel(t *testing.T) {
 		assert.Equal(t, "user-2", result[1].UserID.ValueString())
 	})
 
-	// Regression test for GitHub issue #105:
 	// When member is not configured (existingMembers = nil) and the API
 	// returns no members, the result must be nil — not an empty slice.
 	// Returning []RoleMemberModel{} causes the framework to serialise

--- a/internal/resources/team/resource-team.go
+++ b/internal/resources/team/resource-team.go
@@ -258,7 +258,7 @@ func (r *teamResource) buildTeamModelFromAPIResponse(team *api.Team, planModel T
 	}
 
 	if team.Scope != nil {
-		scopeModel, scopeDiags := r.mapScopeToModel(team.Scope)
+		scopeModel, scopeDiags := r.mapScopeToModel(team.Scope, planModel.Scope)
 		diags.Append(scopeDiags...)
 		if !diags.HasError() {
 			model.Scope = scopeModel
@@ -302,25 +302,31 @@ func (r *teamResource) mapRolesToModel(apiRoles []api.TeamRole) []TeamMemberRole
 	return roles
 }
 
-// mapScopeToModel converts API scope to model scope
-func (r *teamResource) mapScopeToModel(apiScope *api.TeamScope) (*TeamScopeModel, diag.Diagnostics) {
+// mapScopeToModel converts API scope to model scope.
+// planScope is the scope from the prior plan/state and is used as the
+// fallback for each slice field when the API omits it (omitempty nil).
+// This preserves the null-vs-empty-set distinction the user expressed:
+//   - field not configured in HCL  → plan nil  → API nil  → state nil  (null)
+//   - field configured as empty set → plan []   → API nil  → state []   (empty set)
+//   - field configured with values  → plan [x]  → API [x]  → state [x]
+func (r *teamResource) mapScopeToModel(apiScope *api.TeamScope, planScope *TeamScopeModel) (*TeamScopeModel, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	scopeModel := &TeamScopeModel{
-		AccessPermissions:    apiScope.AccessPermissions,
-		Applications:         apiScope.Applications,
-		KubernetesClusters:   apiScope.KubernetesClusters,
-		KubernetesNamespaces: apiScope.KubernetesNamespaces,
-		MobileApps:           apiScope.MobileApps,
-		Websites:             apiScope.Websites,
+		AccessPermissions:    coalesceStringSlice(apiScope.AccessPermissions, planScopeField(planScope, func(s *TeamScopeModel) []string { return s.AccessPermissions })),
+		Applications:         coalesceStringSlice(apiScope.Applications, planScopeField(planScope, func(s *TeamScopeModel) []string { return s.Applications })),
+		KubernetesClusters:   coalesceStringSlice(apiScope.KubernetesClusters, planScopeField(planScope, func(s *TeamScopeModel) []string { return s.KubernetesClusters })),
+		KubernetesNamespaces: coalesceStringSlice(apiScope.KubernetesNamespaces, planScopeField(planScope, func(s *TeamScopeModel) []string { return s.KubernetesNamespaces })),
+		MobileApps:           coalesceStringSlice(apiScope.MobileApps, planScopeField(planScope, func(s *TeamScopeModel) []string { return s.MobileApps })),
+		Websites:             coalesceStringSlice(apiScope.Websites, planScopeField(planScope, func(s *TeamScopeModel) []string { return s.Websites })),
 		InfraDFQFilter:       util.SetStringPointerToState(apiScope.InfraDFQFilter),
 		ActionFilter:         util.SetStringPointerToState(apiScope.ActionFilter),
 		LogFilter:            util.SetStringPointerToState(apiScope.LogFilter),
-		BusinessPerspectives: apiScope.BusinessPerspectives,
-		SloIDs:               apiScope.SloIDs,
-		SyntheticTests:       apiScope.SyntheticTests,
-		SyntheticCredentials: apiScope.SyntheticCredentials,
-		TagIDs:               apiScope.TagIDs,
+		BusinessPerspectives: coalesceStringSlice(apiScope.BusinessPerspectives, planScopeField(planScope, func(s *TeamScopeModel) []string { return s.BusinessPerspectives })),
+		SloIDs:               coalesceStringSlice(apiScope.SloIDs, planScopeField(planScope, func(s *TeamScopeModel) []string { return s.SloIDs })),
+		SyntheticTests:       coalesceStringSlice(apiScope.SyntheticTests, planScopeField(planScope, func(s *TeamScopeModel) []string { return s.SyntheticTests })),
+		SyntheticCredentials: coalesceStringSlice(apiScope.SyntheticCredentials, planScopeField(planScope, func(s *TeamScopeModel) []string { return s.SyntheticCredentials })),
+		TagIDs:               coalesceStringSlice(apiScope.TagIDs, planScopeField(planScope, func(s *TeamScopeModel) []string { return s.TagIDs })),
 	}
 
 	if apiScope.RestrictedApplicationFilter != nil {
@@ -550,4 +556,21 @@ func (r *teamResource) GetStateUpgraders(ctx context.Context) map[int64]resource
 	return map[int64]resource.StateUpgrader{
 		0: resourcehandle.CreateStateUpgraderForVersion(0),
 	}
+}
+
+// planScopeField safely extracts a []string field from a *TeamScopeModel that may be nil 
+func planScopeField(plan *TeamScopeModel, field func(*TeamScopeModel) []string) []string {
+	if plan == nil {
+		return nil
+	}
+	return field(plan)
+}
+
+// coalesceStringSlice returns apiVal when it is non-nil (the API returned data for this field), 
+// otherwise falls back to planVal.
+func coalesceStringSlice(apiVal []string, planVal []string) []string {
+	if apiVal != nil {
+		return apiVal
+	}
+	return planVal
 }

--- a/internal/resources/team/resource-team_test.go
+++ b/internal/resources/team/resource-team_test.go
@@ -1567,6 +1567,129 @@ func TestHelperFunctions(t *testing.T) {
 	})
 }
 
+func TestCoalesceStringSlice(t *testing.T) {
+	t.Run("returns api value when non-nil", func(t *testing.T) {
+		result := coalesceStringSlice([]string{"a"}, []string{"b"})
+		assert.Equal(t, []string{"a"}, result)
+	})
+
+	t.Run("returns api empty slice over plan nil", func(t *testing.T) {
+		result := coalesceStringSlice([]string{}, nil)
+		assert.NotNil(t, result)
+		assert.Empty(t, result)
+	})
+
+	t.Run("returns plan value when api is nil", func(t *testing.T) {
+		result := coalesceStringSlice(nil, []string{"b"})
+		assert.Equal(t, []string{"b"}, result)
+	})
+
+	t.Run("returns nil when both are nil", func(t *testing.T) {
+		result := coalesceStringSlice(nil, nil)
+		assert.Nil(t, result)
+	})
+}
+
+func TestPlanScopeField(t *testing.T) {
+	t.Run("returns nil when plan scope is nil", func(t *testing.T) {
+		result := planScopeField(nil, func(s *TeamScopeModel) []string { return s.Applications })
+		assert.Nil(t, result)
+	})
+
+	t.Run("returns field value from plan scope", func(t *testing.T) {
+		scope := &TeamScopeModel{Applications: []string{"app-1"}}
+		result := planScopeField(scope, func(s *TeamScopeModel) []string { return s.Applications })
+		assert.Equal(t, []string{"app-1"}, result)
+	})
+
+	t.Run("returns nil field from plan scope", func(t *testing.T) {
+		scope := &TeamScopeModel{Applications: nil}
+		result := planScopeField(scope, func(s *TeamScopeModel) []string { return s.Applications })
+		assert.Nil(t, result)
+	})
+
+	t.Run("returns empty slice field from plan scope", func(t *testing.T) {
+		scope := &TeamScopeModel{Applications: []string{}}
+		result := planScopeField(scope, func(s *TeamScopeModel) []string { return s.Applications })
+		assert.NotNil(t, result)
+		assert.Empty(t, result)
+	})
+}
+
+// Regression tests for GitHub issue #105.
+// The error direction depends on which fields the user configured vs omitted:
+//
+//   Bug A: field configured (plan = [])  → API omits it → was SetValEmpty, but now null
+//   Bug B: field not configured (plan = null) → normalisation → was null, but now SetValEmpty
+//
+// coalesceStringSlice fixes both by using the plan value as the fallback
+// when the API returns nil, exactly preserving what Terraform planned.
+func TestUpdateState_Issue105_ScopeCoalescing(t *testing.T) {
+	resource := &teamResource{}
+	ctx := context.Background()
+
+	// API returns scope with only some fields populated; all others are nil.
+	apiTeam := &api.Team{
+		ID:  "team-id",
+		Tag: "issue-105",
+		Scope: &api.TeamScope{
+			Applications: []string{"app-1"},
+			MobileApps:   []string{"mob-1"},
+			// all other slice fields nil (omitempty)
+		},
+	}
+
+	handle := NewTeamResourceHandle()
+	state := &tfsdk.State{Schema: handle.MetaData().Schema}
+
+	// Plan reflects exactly what the user wrote in HCL:
+	//   - applications / mobile_apps  → configured with values
+	//   - access_permissions / websites → configured as empty sets
+	//   - slo_ids / tag_ids / etc.    → not configured at all (nil)
+	planModel := TeamModel{
+		ID:  types.StringValue("team-id"),
+		Tag: types.StringValue("issue-105"),
+		Scope: &TeamScopeModel{
+			Applications:      []string{"app-1"},
+			MobileApps:        []string{"mob-1"},
+			AccessPermissions: []string{},
+			Websites:          []string{},
+			// SloIDs, TagIDs, KubernetesClusters, etc. left nil (not configured)
+		},
+	}
+	plan := createMockTeamPlan(t, ctx, planModel)
+
+	diags := resource.UpdateState(ctx, state, plan, apiTeam)
+	require.False(t, diags.HasError())
+
+	var model TeamModel
+	diags = state.Get(ctx, &model)
+	require.False(t, diags.HasError())
+
+	require.NotNil(t, model.Scope)
+
+	// Fields the API returned: must use API value.
+	assert.Equal(t, []string{"app-1"}, model.Scope.Applications)
+	assert.Equal(t, []string{"mob-1"}, model.Scope.MobileApps)
+
+	// Fields configured as empty set in plan: must stay non-nil empty slice
+	// (empty set in state), not flip to null.
+	assert.NotNil(t, model.Scope.AccessPermissions)
+	assert.Empty(t, model.Scope.AccessPermissions)
+	assert.NotNil(t, model.Scope.Websites)
+	assert.Empty(t, model.Scope.Websites)
+
+	// Fields not configured in plan (nil): must remain nil (null in state),
+	// not flip to empty set.
+	assert.Nil(t, model.Scope.SloIDs)
+	assert.Nil(t, model.Scope.TagIDs)
+	assert.Nil(t, model.Scope.KubernetesClusters)
+	assert.Nil(t, model.Scope.KubernetesNamespaces)
+	assert.Nil(t, model.Scope.BusinessPerspectives)
+	assert.Nil(t, model.Scope.SyntheticTests)
+	assert.Nil(t, model.Scope.SyntheticCredentials)
+}
+
 // Helper functions
 
 func createMockTeamState(t *testing.T, ctx context.Context, model TeamModel) *tfsdk.State {

--- a/internal/resources/team/resource-team_test.go
+++ b/internal/resources/team/resource-team_test.go
@@ -1616,14 +1616,6 @@ func TestPlanScopeField(t *testing.T) {
 	})
 }
 
-// Regression tests for GitHub issue #105.
-// The error direction depends on which fields the user configured vs omitted:
-//
-//   Bug A: field configured (plan = [])  → API omits it → was SetValEmpty, but now null
-//   Bug B: field not configured (plan = null) → normalisation → was null, but now SetValEmpty
-//
-// coalesceStringSlice fixes both by using the plan value as the fallback
-// when the API returns nil, exactly preserving what Terraform planned.
 func TestUpdateState_Issue105_ScopeCoalescing(t *testing.T) {
 	resource := &teamResource{}
 	ctx := context.Background()
@@ -1642,10 +1634,6 @@ func TestUpdateState_Issue105_ScopeCoalescing(t *testing.T) {
 	handle := NewTeamResourceHandle()
 	state := &tfsdk.State{Schema: handle.MetaData().Schema}
 
-	// Plan reflects exactly what the user wrote in HCL:
-	//   - applications / mobile_apps  → configured with values
-	//   - access_permissions / websites → configured as empty sets
-	//   - slo_ids / tag_ids / etc.    → not configured at all (nil)
 	planModel := TeamModel{
 		ID:  types.StringValue("team-id"),
 		Tag: types.StringValue("issue-105"),
@@ -1668,19 +1656,14 @@ func TestUpdateState_Issue105_ScopeCoalescing(t *testing.T) {
 
 	require.NotNil(t, model.Scope)
 
-	// Fields the API returned: must use API value.
 	assert.Equal(t, []string{"app-1"}, model.Scope.Applications)
 	assert.Equal(t, []string{"mob-1"}, model.Scope.MobileApps)
 
-	// Fields configured as empty set in plan: must stay non-nil empty slice
-	// (empty set in state), not flip to null.
 	assert.NotNil(t, model.Scope.AccessPermissions)
 	assert.Empty(t, model.Scope.AccessPermissions)
 	assert.NotNil(t, model.Scope.Websites)
 	assert.Empty(t, model.Scope.Websites)
 
-	// Fields not configured in plan (nil): must remain nil (null in state),
-	// not flip to empty set.
 	assert.Nil(t, model.Scope.SloIDs)
 	assert.Nil(t, model.Scope.TagIDs)
 	assert.Nil(t, model.Scope.KubernetesClusters)


### PR DESCRIPTION
### Description
**instana_rbac_team**

The scope mapping now uses the plan as a fallback for any field the API omits. 

**instana_rbac_role**

The member mapping now preserves the plan's intent when the API returns no members — null if member was not configured, empty set if member = [] was explicitly written.