### PR TITLE
fix(rbac): resolve apply consistency errors for instana_rbac_team scope and instana_rbac_role member

### DIFF
--- a/internal/datasources/data-source-rbac-team.go
+++ b/internal/datasources/data-source-rbac-team.go
@@ -281,35 +281,51 @@ func (d *RbacTeamDataSource) Read(ctx context.Context, req datasource.ReadReques
 
 	// Map scope
 	if teamData.Scope != nil {
-		data.Scope = &team.TeamScopeModel{
-			AccessPermissions:    teamData.Scope.AccessPermissions,
-			Applications:         teamData.Scope.Applications,
-			KubernetesClusters:   teamData.Scope.KubernetesClusters,
-			KubernetesNamespaces: teamData.Scope.KubernetesNamespaces,
-			MobileApps:           teamData.Scope.MobileApps,
-			Websites:             teamData.Scope.Websites,
-			InfraDFQFilter:       types.StringPointerValue(teamData.Scope.InfraDFQFilter),
-			ActionFilter:         types.StringPointerValue(teamData.Scope.ActionFilter),
-			LogFilter:            types.StringPointerValue(teamData.Scope.LogFilter),
-			BusinessPerspectives: teamData.Scope.BusinessPerspectives,
-			SloIDs:               teamData.Scope.SloIDs,
-			SyntheticTests:       teamData.Scope.SyntheticTests,
-			SyntheticCredentials: teamData.Scope.SyntheticCredentials,
-			TagIDs:               teamData.Scope.TagIDs,
+		scopeModel := &team.TeamScopeModel{
+			InfraDFQFilter: types.StringPointerValue(teamData.Scope.InfraDFQFilter),
+			ActionFilter:   types.StringPointerValue(teamData.Scope.ActionFilter),
+			LogFilter:      types.StringPointerValue(teamData.Scope.LogFilter),
+		}
+
+		// Convert each []string scope field to types.Set
+		type setField struct {
+			src    []string
+			target *types.Set
+		}
+		fields := []setField{
+			{teamData.Scope.AccessPermissions, &scopeModel.AccessPermissions},
+			{teamData.Scope.Applications, &scopeModel.Applications},
+			{teamData.Scope.KubernetesClusters, &scopeModel.KubernetesClusters},
+			{teamData.Scope.KubernetesNamespaces, &scopeModel.KubernetesNamespaces},
+			{teamData.Scope.MobileApps, &scopeModel.MobileApps},
+			{teamData.Scope.Websites, &scopeModel.Websites},
+			{teamData.Scope.BusinessPerspectives, &scopeModel.BusinessPerspectives},
+			{teamData.Scope.SloIDs, &scopeModel.SloIDs},
+			{teamData.Scope.SyntheticTests, &scopeModel.SyntheticTests},
+			{teamData.Scope.SyntheticCredentials, &scopeModel.SyntheticCredentials},
+			{teamData.Scope.TagIDs, &scopeModel.TagIDs},
+		}
+		for _, f := range fields {
+			s, d := types.SetValueFrom(ctx, types.StringType, f.src)
+			resp.Diagnostics.Append(d...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+			*f.target = s
 		}
 
 		// Map restricted application filter if present
 		if teamData.Scope.RestrictedApplicationFilter != nil {
-			data.Scope.RestrictedApplicationFilter = &team.TeamRestrictedApplicationFilterModel{
+			scopeModel.RestrictedApplicationFilter = &team.TeamRestrictedApplicationFilterModel{
 				Label: types.StringPointerValue(teamData.Scope.RestrictedApplicationFilter.Label),
 			}
 			if teamData.Scope.RestrictedApplicationFilter.Scope != nil {
-				data.Scope.RestrictedApplicationFilter.Scope = types.StringValue(string(*teamData.Scope.RestrictedApplicationFilter.Scope))
+				scopeModel.RestrictedApplicationFilter.Scope = types.StringValue(string(*teamData.Scope.RestrictedApplicationFilter.Scope))
 			}
-			// Note: TagFilterExpression mapping would require the tagfilter package
-			// For now, we'll leave it as null if not needed
-			data.Scope.RestrictedApplicationFilter.TagFilterExpression = types.StringNull()
+			scopeModel.RestrictedApplicationFilter.TagFilterExpression = types.StringNull()
 		}
+
+		data.Scope = scopeModel
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/resources/roles/resource-roles.go
+++ b/internal/resources/roles/resource-roles.go
@@ -5,10 +5,12 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -47,8 +49,15 @@ func buildRoleSchema() schema.Schema {
 				Description: RoleDescName,
 			},
 			RoleFieldMembers: schema.SetNestedAttribute{
-				Description:  RoleDescMembers,
-				Optional:     true,
+				Description: RoleDescMembers,
+				Optional:    true,
+				Computed:    true,
+				// UseStateForUnknown: when the user omits the member block, the plan would
+				// normally be "unknown". This modifier fills it with the current state value
+				// instead, so Terraform can detect drift on subsequent plans.
+				PlanModifiers: []planmodifier.Set{
+					setplanmodifier.UseStateForUnknown(),
+				},
 				NestedObject: buildMemberNestedObject(),
 			},
 			RoleFieldPermissions: schema.SetAttribute{
@@ -95,49 +104,47 @@ func (r *roleResource) SetComputedFields(_ context.Context, _ *tfsdk.Plan) diag.
 
 // UpdateState updates the Terraform state with data from the API response
 func (r *roleResource) UpdateState(ctx context.Context, state *tfsdk.State, plan *tfsdk.Plan, role *api.Role) diag.Diagnostics {
-	// Get existing state/plan to preserve optional fields
-	var existingModel RoleModel
 	var diags diag.Diagnostics
 
-	if plan != nil {
-		diags.Append(plan.Get(ctx, &existingModel)...)
-	} else if state != nil {
-		diags.Append(state.Get(ctx, &existingModel)...)
-	}
-
+	membersSet, membersDiags := r.mapMembersToSet(ctx, role.Members)
+	diags.Append(membersDiags...)
 	if diags.HasError() {
 		return diags
 	}
 
-	model := r.buildRoleModelFromAPIResponse(role, existingModel.Members)
-	return state.Set(ctx, model)
-}
-
-// buildRoleModelFromAPIResponse constructs a RoleModel from the API Role response
-func (r *roleResource) buildRoleModelFromAPIResponse(role *api.Role, existingMembers []RoleMemberModel) RoleModel {
 	model := RoleModel{
 		ID:          types.StringValue(role.ID),
 		Name:        types.StringValue(role.Name),
-		Members:     r.mapMembersToModel(role.Members, existingMembers),
+		Members:     membersSet,
 		Permissions: role.Permissions,
 	}
-
-	return model
+	return state.Set(ctx, model)
 }
 
-// mapMembersToModel converts API members to model members
-func (r *roleResource) mapMembersToModel(apiMembers []api.APIMember, existingMembers []RoleMemberModel) []RoleMemberModel {
+// mapMembersToSet converts API members to a types.Set.
+// The Roles API always returns "members": [] — using types.Set (instead of []RoleMemberModel)
+// lets Terraform hold the unknown/null/empty distinction correctly when the field is
+// Optional+Computed.
+func (r *roleResource) mapMembersToSet(ctx context.Context, apiMembers []api.APIMember) (types.Set, diag.Diagnostics) {
+	memberType := buildMemberNestedObject().Type()
+
 	if len(apiMembers) == 0 {
-		return make([]RoleMemberModel, 0)
+		return types.SetValueMust(memberType, []attr.Value{}), nil
 	}
 
-	members := make([]RoleMemberModel, len(apiMembers))
+	elems := make([]attr.Value, len(apiMembers))
 	for i, apiMember := range apiMembers {
-		members[i] = RoleMemberModel{
-			UserID: types.StringValue(apiMember.UserID),
+		obj, diags := types.ObjectValue(
+			map[string]attr.Type{RoleFieldMemberUserID: types.StringType},
+			map[string]attr.Value{RoleFieldMemberUserID: types.StringValue(apiMember.UserID)},
+		)
+		if diags.HasError() {
+			return types.SetNull(memberType), diags
 		}
+		elems[i] = obj
 	}
-	return members
+
+	return types.SetValue(memberType, elems)
 }
 
 // MapStateToDataObject maps Terraform state/plan to API Role object
@@ -150,10 +157,16 @@ func (r *roleResource) MapStateToDataObject(ctx context.Context, plan *tfsdk.Pla
 		return nil, diags
 	}
 
+	apiMembers, membersDiags := r.mapSetMembersToAPI(ctx, model.Members)
+	diags.Append(membersDiags...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
 	role := &api.Role{
 		ID:          r.extractRoleID(model),
 		Name:        model.Name.ValueString(),
-		Members:     r.mapModelMembersToAPI(model.Members),
+		Members:     apiMembers,
 		Permissions: model.Permissions,
 	}
 
@@ -182,20 +195,23 @@ func (r *roleResource) extractRoleID(model RoleModel) string {
 	return model.ID.ValueString()
 }
 
-// mapModelMembersToAPI converts model members to API members
-func (r *roleResource) mapModelMembersToAPI(modelMembers []RoleMemberModel) []api.APIMember {
-	if len(modelMembers) == 0 {
-		return make([]api.APIMember, 0)
+// mapSetMembersToAPI converts a types.Set of members to API members
+func (r *roleResource) mapSetMembersToAPI(ctx context.Context, membersSet types.Set) ([]api.APIMember, diag.Diagnostics) {
+	if membersSet.IsNull() || membersSet.IsUnknown() || len(membersSet.Elements()) == 0 {
+		return []api.APIMember{}, nil
 	}
 
-	apiMembers := make([]api.APIMember, 0, len(modelMembers))
-	for _, memberModel := range modelMembers {
-		apiMembers = append(apiMembers, api.APIMember{
-			UserID: memberModel.UserID.ValueString(),
-		})
+	var modelMembers []RoleMemberModel
+	diags := membersSet.ElementsAs(ctx, &modelMembers, false)
+	if diags.HasError() {
+		return nil, diags
 	}
 
-	return apiMembers
+	apiMembers := make([]api.APIMember, len(modelMembers))
+	for i, m := range modelMembers {
+		apiMembers[i] = api.APIMember{UserID: m.UserID.ValueString()}
+	}
+	return apiMembers, nil
 }
 
 // GetStateUpgraders returns the state upgraders for this resource

--- a/internal/resources/roles/resource-roles.go
+++ b/internal/resources/roles/resource-roles.go
@@ -123,8 +123,7 @@ func (r *roleResource) UpdateState(ctx context.Context, state *tfsdk.State, plan
 
 // mapMembersToSet converts API members to a types.Set.
 // The Roles API always returns "members": [] — using types.Set (instead of []RoleMemberModel)
-// lets Terraform hold the unknown/null/empty distinction correctly when the field is
-// Optional+Computed.
+// lets Terraform hold the unknown/null/empty distinction correctly when the field is Optional+Computed.
 func (r *roleResource) mapMembersToSet(ctx context.Context, apiMembers []api.APIMember) (types.Set, diag.Diagnostics) {
 	memberType := buildMemberNestedObject().Type()
 

--- a/internal/resources/roles/resource-roles_test.go
+++ b/internal/resources/roles/resource-roles_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/instana/instana-go-client/api"
@@ -13,6 +14,39 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// buildMembersSet builds a types.Set of RoleMemberModel from a list of user IDs.
+func buildMembersSet(t *testing.T, userIDs ...string) types.Set {
+	t.Helper()
+	memberType := buildMemberNestedObject().Type()
+	if len(userIDs) == 0 {
+		return types.SetValueMust(memberType, []attr.Value{})
+	}
+	elems := make([]attr.Value, len(userIDs))
+	for i, uid := range userIDs {
+		obj, diags := types.ObjectValue(
+			map[string]attr.Type{RoleFieldMemberUserID: types.StringType},
+			map[string]attr.Value{RoleFieldMemberUserID: types.StringValue(uid)},
+		)
+		require.False(t, diags.HasError())
+		elems[i] = obj
+	}
+	s, diags := types.SetValue(memberType, elems)
+	require.False(t, diags.HasError())
+	return s
+}
+
+// extractMembersFromSet extracts []RoleMemberModel from a types.Set for assertions.
+func extractMembersFromSet(t *testing.T, ctx context.Context, membersSet types.Set) []RoleMemberModel {
+	t.Helper()
+	if membersSet.IsNull() || membersSet.IsUnknown() {
+		return nil
+	}
+	var members []RoleMemberModel
+	diags := membersSet.ElementsAs(ctx, &members, false)
+	require.False(t, diags.HasError())
+	return members
+}
 
 func TestNewRoleResourceHandle(t *testing.T) {
 	t.Run("should create resource handle with correct metadata", func(t *testing.T) {
@@ -163,16 +197,9 @@ func TestMapStateToDataObject(t *testing.T) {
 
 	t.Run("should map complete model from state successfully", func(t *testing.T) {
 		model := RoleModel{
-			ID:   types.StringValue("role-id-123"),
-			Name: types.StringValue("Test Role"),
-			Members: []RoleMemberModel{
-				{
-					UserID: types.StringValue("user-1"),
-				},
-				{
-					UserID: types.StringValue("user-2"),
-				},
-			},
+			ID:      types.StringValue("role-id-123"),
+			Name:    types.StringValue("Test Role"),
+			Members: buildMembersSet(t, "user-1", "user-2"),
 			Permissions: []string{
 				string(api.PermissionCanConfigureApplications),
 				string(api.PermissionCanViewLogs),
@@ -192,24 +219,16 @@ func TestMapStateToDataObject(t *testing.T) {
 		assert.Equal(t, "role-id-123", result.ID)
 		assert.Equal(t, "Test Role", result.Name)
 		assert.Len(t, result.Members, 2)
-		assert.Equal(t, "user-1", result.Members[0].UserID)
-		assert.Equal(t, "user-2", result.Members[1].UserID)
 		assert.Len(t, result.Permissions, 2)
 		assert.Contains(t, result.Permissions, string(api.PermissionCanConfigureApplications))
 	})
 
 	t.Run("should map model from plan successfully", func(t *testing.T) {
 		model := RoleModel{
-			ID:   types.StringValue("plan-role-id"),
-			Name: types.StringValue("Plan Role"),
-			Members: []RoleMemberModel{
-				{
-					UserID: types.StringValue("user-3"),
-				},
-			},
-			Permissions: []string{
-				string(api.PermissionCanConfigureUsers),
-			},
+			ID:          types.StringValue("plan-role-id"),
+			Name:        types.StringValue("Plan Role"),
+			Members:     buildMembersSet(t, "user-3"),
+			Permissions: []string{string(api.PermissionCanConfigureUsers)},
 		}
 
 		plan := &tfsdk.Plan{
@@ -239,19 +258,10 @@ func TestMapStateToDataObject(t *testing.T) {
 
 	t.Run("should map members with optional fields", func(t *testing.T) {
 		model := RoleModel{
-			ID:   types.StringValue("role-id"),
-			Name: types.StringValue("Test Role"),
-			Members: []RoleMemberModel{
-				{
-					UserID: types.StringValue("user-1"),
-				},
-				{
-					UserID: types.StringValue("user-2"),
-				},
-			},
-			Permissions: []string{
-				string(api.PermissionCanConfigureApplications),
-			},
+			ID:          types.StringValue("role-id"),
+			Name:        types.StringValue("Test Role"),
+			Members:     buildMembersSet(t, "user-1", "user-2"),
+			Permissions: []string{string(api.PermissionCanConfigureApplications)},
 		}
 
 		state := &tfsdk.State{
@@ -265,15 +275,13 @@ func TestMapStateToDataObject(t *testing.T) {
 		assert.False(t, resultDiags.HasError())
 		assert.NotNil(t, result)
 		assert.Len(t, result.Members, 2)
-		assert.Equal(t, "user-1", result.Members[0].UserID)
-		assert.Equal(t, "user-2", result.Members[1].UserID)
 	})
 
 	t.Run("should handle empty members list", func(t *testing.T) {
 		model := RoleModel{
 			ID:          types.StringValue("role-id"),
 			Name:        types.StringValue("Test Role"),
-			Members:     []RoleMemberModel{},
+			Members:     buildMembersSet(t),
 			Permissions: []string{string(api.PermissionCanConfigureApplications)},
 		}
 
@@ -292,13 +300,9 @@ func TestMapStateToDataObject(t *testing.T) {
 
 	t.Run("should handle empty permissions list", func(t *testing.T) {
 		model := RoleModel{
-			ID:   types.StringValue("role-id"),
-			Name: types.StringValue("Test Role"),
-			Members: []RoleMemberModel{
-				{
-					UserID: types.StringValue("user-1"),
-				},
-			},
+			ID:          types.StringValue("role-id"),
+			Name:        types.StringValue("Test Role"),
+			Members:     buildMembersSet(t, "user-1"),
 			Permissions: []string{},
 		}
 
@@ -317,13 +321,9 @@ func TestMapStateToDataObject(t *testing.T) {
 
 	t.Run("should handle null ID for new resource", func(t *testing.T) {
 		model := RoleModel{
-			ID:   types.StringNull(),
-			Name: types.StringValue("New Role"),
-			Members: []RoleMemberModel{
-				{
-					UserID: types.StringValue("user-1"),
-				},
-			},
+			ID:          types.StringNull(),
+			Name:        types.StringValue("New Role"),
+			Members:     buildMembersSet(t, "user-1"),
 			Permissions: []string{string(api.PermissionCanConfigureApplications)},
 		}
 
@@ -342,13 +342,9 @@ func TestMapStateToDataObject(t *testing.T) {
 
 	t.Run("should handle multiple permissions", func(t *testing.T) {
 		model := RoleModel{
-			ID:   types.StringValue("role-id"),
-			Name: types.StringValue("Test Role"),
-			Members: []RoleMemberModel{
-				{
-					UserID: types.StringValue("user-1"),
-				},
-			},
+			ID:      types.StringValue("role-id"),
+			Name:    types.StringValue("Test Role"),
+			Members: buildMembersSet(t, "user-1"),
 			Permissions: []string{
 				string(api.PermissionCanConfigureApplications),
 				string(api.PermissionCanViewLogs),
@@ -418,8 +414,8 @@ func TestUpdateState(t *testing.T) {
 		assert.False(t, diags.HasError())
 
 		assert.Equal(t, "api-role-id-123", model.ID.ValueString())
-		assert.Len(t, model.Members, 2)
-		assert.Equal(t, "user-1", model.Members[0].UserID.ValueString())
+		members := extractMembersFromSet(t, ctx, model.Members)
+		assert.Len(t, members, 2)
 		assert.Len(t, model.Permissions, 2)
 	})
 
@@ -454,8 +450,9 @@ func TestUpdateState(t *testing.T) {
 		assert.False(t, diags.HasError())
 
 		assert.Equal(t, "api-role-id-456", model.ID.ValueString())
-		assert.Len(t, model.Members, 1)
-		assert.Equal(t, "user-3", model.Members[0].UserID.ValueString())
+		members := extractMembersFromSet(t, ctx, model.Members)
+		assert.Len(t, members, 1)
+		assert.Equal(t, "user-3", members[0].UserID.ValueString())
 	})
 
 	t.Run("should update state with empty members list", func(t *testing.T) {
@@ -481,19 +478,16 @@ func TestUpdateState(t *testing.T) {
 		diags = state.Get(ctx, &model)
 		assert.False(t, diags.HasError())
 
-		assert.Empty(t, model.Members)
+		members := extractMembersFromSet(t, ctx, model.Members)
+		assert.Empty(t, members)
 	})
 
 	t.Run("should preserve existing member data from plan", func(t *testing.T) {
 		// Set up existing plan with member data
 		existingModel := RoleModel{
-			ID:   types.StringValue("role-id"),
-			Name: types.StringValue("Test Role"),
-			Members: []RoleMemberModel{
-				{
-					UserID: types.StringValue("user-1"),
-				},
-			},
+			ID:          types.StringValue("role-id"),
+			Name:        types.StringValue("Test Role"),
+			Members:     buildMembersSet(t, "user-1"),
 			Permissions: []string{string(api.PermissionCanConfigureApplications)},
 		}
 
@@ -559,20 +553,17 @@ func TestUpdateState(t *testing.T) {
 		diags = state.Get(ctx, &model)
 		assert.False(t, diags.HasError())
 
-		assert.Len(t, model.Members, 1)
+		members := extractMembersFromSet(t, ctx, model.Members)
+		assert.Len(t, members, 1)
 	})
 
 	t.Run("should update state with API values when present", func(t *testing.T) {
 
 		// Set up existing plan with different data
 		existingModel := RoleModel{
-			ID:   types.StringValue("role-id"),
-			Name: types.StringValue("Test Role"),
-			Members: []RoleMemberModel{
-				{
-					UserID: types.StringValue("user-1"),
-				},
-			},
+			ID:          types.StringValue("role-id"),
+			Name:        types.StringValue("Test Role"),
+			Members:     buildMembersSet(t, "user-1"),
 			Permissions: []string{string(api.PermissionCanConfigureApplications)},
 		}
 
@@ -610,20 +601,17 @@ func TestUpdateState(t *testing.T) {
 		assert.False(t, diags.HasError())
 
 		// Should use API values when present
-		assert.Len(t, model.Members, 1)
+		members := extractMembersFromSet(t, ctx, model.Members)
+		assert.Len(t, members, 1)
 	})
 
 	t.Run("should handle new members not in existing state", func(t *testing.T) {
 
 		// Set up existing plan with one member
 		existingModel := RoleModel{
-			ID:   types.StringValue("role-id"),
-			Name: types.StringValue("Test Role"),
-			Members: []RoleMemberModel{
-				{
-					UserID: types.StringValue("user-1"),
-				},
-			},
+			ID:          types.StringValue("role-id"),
+			Name:        types.StringValue("Test Role"),
+			Members:     buildMembersSet(t, "user-1"),
 			Permissions: []string{string(api.PermissionCanConfigureApplications)},
 		}
 
@@ -660,203 +648,91 @@ func TestUpdateState(t *testing.T) {
 		diags = state.Get(ctx, &model)
 		assert.False(t, diags.HasError())
 
-		assert.Len(t, model.Members, 1)
-		assert.Equal(t, "user-2", model.Members[0].UserID.ValueString())
+		members := extractMembersFromSet(t, ctx, model.Members)
+		assert.Len(t, members, 1)
+		assert.Equal(t, "user-2", members[0].UserID.ValueString())
 	})
 }
 
-func TestMapMembersToModel(t *testing.T) {
+func TestMapMembersToSet(t *testing.T) {
 	resource := &roleResource{}
+	ctx := context.Background()
 
 	t.Run("should map empty members list", func(t *testing.T) {
-		result := resource.mapMembersToModel([]api.APIMember{}, []RoleMemberModel{})
+		result, diags := resource.mapMembersToSet(ctx, []api.APIMember{})
+		assert.False(t, diags.HasError())
+		assert.Empty(t, result.Elements())
+	})
+
+	t.Run("should map members with all fields", func(t *testing.T) {
+		apiMembers := []api.APIMember{
+			{
+				UserID: "user-1",
+			},
+		}
+
+		result, diags := resource.mapMembersToSet(ctx, apiMembers)
+		assert.False(t, diags.HasError())
+		assert.Len(t, result.Elements(), 1)
+
+		members := extractMembersFromSet(t, ctx, result)
+		assert.Equal(t, "user-1", members[0].UserID.ValueString())
+	})
+
+	t.Run("should map multiple members", func(t *testing.T) {
+		apiMembers := []api.APIMember{
+			{UserID: "user-1"},
+			{UserID: "user-2"},
+		}
+
+		result, diags := resource.mapMembersToSet(ctx, apiMembers)
+		assert.False(t, diags.HasError())
+		assert.Len(t, result.Elements(), 2)
+	})
+}
+
+func TestMapSetMembersToAPI(t *testing.T) {
+	resource := &roleResource{}
+	ctx := context.Background()
+
+	t.Run("should map empty members set", func(t *testing.T) {
+		result, diags := resource.mapSetMembersToAPI(ctx, buildMembersSet(t))
+		assert.False(t, diags.HasError())
 		assert.Empty(t, result)
 	})
 
 	t.Run("should map members with all fields", func(t *testing.T) {
+		membersSet := buildMembersSet(t, "user-1")
 
-		apiMembers := []api.APIMember{
-			{
-				UserID: "user-1",
-			},
-		}
-
-		result := resource.mapMembersToModel(apiMembers, []RoleMemberModel{})
-
+		result, diags := resource.mapSetMembersToAPI(ctx, membersSet)
+		assert.False(t, diags.HasError())
 		assert.Len(t, result, 1)
-		assert.Equal(t, "user-1", result[0].UserID.ValueString())
+		assert.Equal(t, "user-1", result[0].UserID)
+		assert.Nil(t, result[0].Email)
+		assert.Nil(t, result[0].Name)
 	})
 
-	t.Run("should preserve existing member data when API returns nil", func(t *testing.T) {
-		existingMembers := []RoleMemberModel{
-			{
-				UserID: types.StringValue("user-1"),
-			},
-		}
-
-		apiMembers := []api.APIMember{
-			{
-				UserID: "user-1",
-				Email:  nil,
-			},
-		}
-
-		result := resource.mapMembersToModel(apiMembers, existingMembers)
-
-		assert.Len(t, result, 1)
-	})
-
-	t.Run("should handle empty strings from API", func(t *testing.T) {
-
-		existingMembers := []RoleMemberModel{
-			{
-				UserID: types.StringValue("user-1"),
-			},
-		}
-
-		apiMembers := []api.APIMember{
-			{
-				UserID: "user-1",
-			},
-		}
-
-		result := resource.mapMembersToModel(apiMembers, existingMembers)
-
-		assert.Len(t, result, 1)
-		// Should preserve existing values when API returns empty strings
-	})
-
-	t.Run("should use API values when present and non-empty", func(t *testing.T) {
-
-		existingMembers := []RoleMemberModel{
-			{
-				UserID: types.StringValue("user-1"),
-			},
-		}
-
-		apiMembers := []api.APIMember{
-			{
-				UserID: "user-1",
-			},
-		}
-
-		result := resource.mapMembersToModel(apiMembers, existingMembers)
-
-		assert.Len(t, result, 1)
-	})
-
-	t.Run("should handle multiple members", func(t *testing.T) {
-
-		apiMembers := []api.APIMember{
-			{
-				UserID: "user-1",
-			},
-			{
-				UserID: "user-2",
-			},
-		}
-
-		result := resource.mapMembersToModel(apiMembers, []RoleMemberModel{})
-
-		assert.Len(t, result, 2)
-		assert.Equal(t, "user-1", result[0].UserID.ValueString())
-		assert.Equal(t, "user-2", result[1].UserID.ValueString())
-	})
-}
-
-func TestMapModelMembersToAPI(t *testing.T) {
-	resource := &roleResource{}
-
-	t.Run("should map empty members list", func(t *testing.T) {
-		result := resource.mapModelMembersToAPI([]RoleMemberModel{})
+	t.Run("should handle null members set", func(t *testing.T) {
+		memberType := buildMemberNestedObject().Type()
+		result, diags := resource.mapSetMembersToAPI(ctx, types.SetNull(memberType))
+		assert.False(t, diags.HasError())
 		assert.Empty(t, result)
 	})
 
-	t.Run("should map members with all fields", func(t *testing.T) {
-		modelMembers := []RoleMemberModel{
-			{
-				UserID: types.StringValue("user-1"),
-			},
-		}
+	t.Run("should map multiple members", func(t *testing.T) {
+		membersSet := buildMembersSet(t, "user-1", "user-2", "user-3")
 
-		result := resource.mapModelMembersToAPI(modelMembers)
-
-		assert.Len(t, result, 1)
-		assert.Equal(t, "user-1", result[0].UserID)
-		assert.Nil(t, result[0].Email)
-		assert.Nil(t, result[0].Name)
-	})
-
-	t.Run("should handle null email and name", func(t *testing.T) {
-		modelMembers := []RoleMemberModel{
-			{
-				UserID: types.StringValue("user-1"),
-			},
-		}
-
-		result := resource.mapModelMembersToAPI(modelMembers)
-
-		assert.Len(t, result, 1)
-		assert.Equal(t, "user-1", result[0].UserID)
-		assert.Nil(t, result[0].Email)
-		assert.Nil(t, result[0].Name)
-	})
-
-	t.Run("should handle unknown email and name", func(t *testing.T) {
-		modelMembers := []RoleMemberModel{
-			{
-				UserID: types.StringValue("user-1"),
-			},
-		}
-
-		result := resource.mapModelMembersToAPI(modelMembers)
-
-		assert.Len(t, result, 1)
-		assert.Equal(t, "user-1", result[0].UserID)
-		assert.Nil(t, result[0].Email)
-		assert.Nil(t, result[0].Name)
-	})
-
-	t.Run("should handle mixed null and non-null fields", func(t *testing.T) {
-		modelMembers := []RoleMemberModel{
-			{
-				UserID: types.StringValue("user-1"),
-			},
-			{
-				UserID: types.StringValue("user-2"),
-			},
-		}
-
-		result := resource.mapModelMembersToAPI(modelMembers)
-
-		assert.Len(t, result, 2)
-		assert.Equal(t, "user-1", result[0].UserID)
-		assert.Equal(t, "user-2", result[1].UserID)
-		assert.Nil(t, result[0].Email)
-		assert.Nil(t, result[0].Name)
-		assert.Nil(t, result[1].Email)
-		assert.Nil(t, result[1].Name)
-	})
-
-	t.Run("should handle multiple members", func(t *testing.T) {
-		modelMembers := []RoleMemberModel{
-			{
-				UserID: types.StringValue("user-1"),
-			},
-			{
-				UserID: types.StringValue("user-2"),
-			},
-			{
-				UserID: types.StringValue("user-3"),
-			},
-		}
-
-		result := resource.mapModelMembersToAPI(modelMembers)
-
+		result, diags := resource.mapSetMembersToAPI(ctx, membersSet)
+		assert.False(t, diags.HasError())
 		assert.Len(t, result, 3)
-		assert.Equal(t, "user-1", result[0].UserID)
-		assert.Equal(t, "user-2", result[1].UserID)
-		assert.Equal(t, "user-3", result[2].UserID)
+		// Collect user IDs for assertion (set order is not guaranteed)
+		userIDs := make([]string, len(result))
+		for i, m := range result {
+			userIDs[i] = m.UserID
+		}
+		assert.Contains(t, userIDs, "user-1")
+		assert.Contains(t, userIDs, "user-2")
+		assert.Contains(t, userIDs, "user-3")
 	})
 }
 
@@ -882,59 +758,6 @@ func TestExtractRoleID(t *testing.T) {
 	})
 }
 
-func TestBuildRoleModelFromAPIResponse(t *testing.T) {
-	resource := &roleResource{}
-
-	t.Run("should build model with all fields", func(t *testing.T) {
-
-		apiRole := &api.Role{
-			ID:   "role-123",
-			Name: "Test Role",
-			Members: []api.APIMember{
-				{
-					UserID: "user-1",
-				},
-			},
-			Permissions: []string{
-				string(api.PermissionCanConfigureApplications),
-			},
-		}
-
-		result := resource.buildRoleModelFromAPIResponse(apiRole, []RoleMemberModel{})
-
-		assert.Equal(t, "role-123", result.ID.ValueString())
-		assert.Len(t, result.Members, 1)
-		assert.Len(t, result.Permissions, 1)
-	})
-
-	t.Run("should preserve existing member data", func(t *testing.T) {
-		existingMembers := []RoleMemberModel{
-			{
-				UserID: types.StringValue("user-1"),
-			},
-		}
-
-		apiRole := &api.Role{
-			ID:   "role-123",
-			Name: "Test Role",
-			Members: []api.APIMember{
-				{
-					UserID: "user-1",
-					Email:  nil,
-				},
-			},
-			Permissions: []string{
-				string(api.PermissionCanConfigureApplications),
-			},
-		}
-
-		result := resource.buildRoleModelFromAPIResponse(apiRole, existingMembers)
-
-		assert.NotNil(t, result)
-		assert.Equal(t, "role-123", result.ID.ValueString())
-	})
-}
-
 func TestExtractModelFromPlanOrState(t *testing.T) {
 	resource := &roleResource{
 		metaData: resourcehandle.ResourceMetaData{
@@ -947,13 +770,9 @@ func TestExtractModelFromPlanOrState(t *testing.T) {
 
 	t.Run("should extract from plan when provided", func(t *testing.T) {
 		model := RoleModel{
-			ID:   types.StringValue("role-id"),
-			Name: types.StringValue("Test Role"),
-			Members: []RoleMemberModel{
-				{
-					UserID: types.StringValue("user-1"),
-				},
-			},
+			ID:          types.StringValue("role-id"),
+			Name:        types.StringValue("Test Role"),
+			Members:     buildMembersSet(t, "user-1"),
 			Permissions: []string{string(api.PermissionCanConfigureApplications)},
 		}
 
@@ -971,13 +790,9 @@ func TestExtractModelFromPlanOrState(t *testing.T) {
 
 	t.Run("should extract from state when plan is nil", func(t *testing.T) {
 		model := RoleModel{
-			ID:   types.StringValue("state-role-id"),
-			Name: types.StringValue("State Role"),
-			Members: []RoleMemberModel{
-				{
-					UserID: types.StringValue("user-2"),
-				},
-			},
+			ID:          types.StringValue("state-role-id"),
+			Name:        types.StringValue("State Role"),
+			Members:     buildMembersSet(t, "user-2"),
 			Permissions: []string{string(api.PermissionCanConfigureUsers)},
 		}
 
@@ -1003,10 +818,11 @@ func TestExtractModelFromPlanOrState(t *testing.T) {
 
 // initializeEmptyRoleState initializes the state with an empty model to ensure proper state initialization
 func initializeEmptyRoleState(t *testing.T, ctx context.Context, state *tfsdk.State) {
+	memberType := buildMemberNestedObject().Type()
 	emptyModel := RoleModel{
 		ID:          types.StringNull(),
 		Name:        types.StringNull(),
-		Members:     []RoleMemberModel{},
+		Members:     types.SetValueMust(memberType, []attr.Value{}),
 		Permissions: []string{},
 	}
 	diags := state.Set(ctx, emptyModel)

--- a/internal/resources/roles/roles-model.go
+++ b/internal/resources/roles/roles-model.go
@@ -4,10 +4,10 @@ import "github.com/hashicorp/terraform-plugin-framework/types"
 
 // RoleModel represents the data model for RBAC Role
 type RoleModel struct {
-	ID          types.String      `tfsdk:"id"`
-	Name        types.String      `tfsdk:"name"`
-	Members     []RoleMemberModel `tfsdk:"member"`
-	Permissions []string          `tfsdk:"permissions"`
+	ID          types.String `tfsdk:"id"`
+	Name        types.String `tfsdk:"name"`
+	Members     types.Set    `tfsdk:"member"`
+	Permissions []string     `tfsdk:"permissions"`
 }
 
 // RoleMemberModel represents a member in the role

--- a/internal/resources/team/resource-team.go
+++ b/internal/resources/team/resource-team.go
@@ -4,10 +4,12 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -19,6 +21,28 @@ import (
 	"github.com/instana/terraform-provider-instana/internal/shared/tagfilter"
 	"github.com/instana/terraform-provider-instana/internal/util"
 )
+
+// stringsToSet converts a []string to a types.Set of strings.
+// Both nil (JSON null) and [] (JSON []) are stored as an empty set — the Teams API
+// uses null and [] interchangeably to mean "not configured", and the schema fields are
+// Optional+Computed with UseStateForUnknown. Storing an empty set for both cases keeps
+// the plan value ([] from TF filling an unset nested attr) consistent with state after
+// apply, regardless of whether the API echoes back null or [].
+func stringsToSet(ctx context.Context, ss []string) (types.Set, diag.Diagnostics) {
+	if len(ss) == 0 {
+		return types.SetValueMust(types.StringType, []attr.Value{}), nil
+	}
+	return types.SetValueFrom(ctx, types.StringType, ss)
+}
+
+// setToStrings extracts a []string from a types.Set. Returns nil for null/unknown/empty.
+func setToStrings(ctx context.Context, s types.Set) ([]string, diag.Diagnostics) {
+	if s.IsNull() || s.IsUnknown() || len(s.Elements()) == 0 {
+		return nil, nil
+	}
+	var result []string
+	return result, s.ElementsAs(ctx, &result, false)
+}
 
 // NewTeamResourceHandle creates the resource handle for RBAC Teams
 func NewTeamResourceHandle() resourcehandle.ResourceHandle[*api.Team] {
@@ -110,33 +134,45 @@ func buildScopeAttributes() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		TeamFieldScopeAccessPermissions: schema.SetAttribute{
 			Optional:    true,
+			Computed:    true,
 			Description: TeamDescScopeAccessPermissions,
 			ElementType: types.StringType,
+			PlanModifiers: []planmodifier.Set{setplanmodifier.UseStateForUnknown()},
 		},
 		TeamFieldScopeApplications: schema.SetAttribute{
 			Optional:    true,
+			Computed:    true,
 			Description: TeamDescScopeApplications,
 			ElementType: types.StringType,
+			PlanModifiers: []planmodifier.Set{setplanmodifier.UseStateForUnknown()},
 		},
 		TeamFieldScopeKubernetesClusters: schema.SetAttribute{
 			Optional:    true,
+			Computed:    true,
 			Description: TeamDescScopeKubernetesClusters,
 			ElementType: types.StringType,
+			PlanModifiers: []planmodifier.Set{setplanmodifier.UseStateForUnknown()},
 		},
 		TeamFieldScopeKubernetesNamespaces: schema.SetAttribute{
 			Optional:    true,
+			Computed:    true,
 			Description: TeamDescScopeKubernetesNamespaces,
 			ElementType: types.StringType,
+			PlanModifiers: []planmodifier.Set{setplanmodifier.UseStateForUnknown()},
 		},
 		TeamFieldScopeMobileApps: schema.SetAttribute{
 			Optional:    true,
+			Computed:    true,
 			Description: TeamDescScopeMobileApps,
 			ElementType: types.StringType,
+			PlanModifiers: []planmodifier.Set{setplanmodifier.UseStateForUnknown()},
 		},
 		TeamFieldScopeWebsites: schema.SetAttribute{
 			Optional:    true,
+			Computed:    true,
 			Description: TeamDescScopeWebsites,
 			ElementType: types.StringType,
+			PlanModifiers: []planmodifier.Set{setplanmodifier.UseStateForUnknown()},
 		},
 		TeamFieldScopeInfraDFQFilter: schema.StringAttribute{
 			Optional:    true,
@@ -152,28 +188,38 @@ func buildScopeAttributes() map[string]schema.Attribute {
 		},
 		TeamFieldScopeBusinessPerspectives: schema.SetAttribute{
 			Optional:    true,
+			Computed:    true,
 			Description: TeamDescScopeBusinessPerspectives,
 			ElementType: types.StringType,
+			PlanModifiers: []planmodifier.Set{setplanmodifier.UseStateForUnknown()},
 		},
 		TeamFieldScopeSloIDs: schema.SetAttribute{
 			Optional:    true,
+			Computed:    true,
 			Description: TeamDescScopeSloIDs,
 			ElementType: types.StringType,
+			PlanModifiers: []planmodifier.Set{setplanmodifier.UseStateForUnknown()},
 		},
 		TeamFieldScopeSyntheticTests: schema.SetAttribute{
 			Optional:    true,
+			Computed:    true,
 			Description: TeamDescScopeSyntheticTests,
 			ElementType: types.StringType,
+			PlanModifiers: []planmodifier.Set{setplanmodifier.UseStateForUnknown()},
 		},
 		TeamFieldScopeSyntheticCredentials: schema.SetAttribute{
 			Optional:    true,
+			Computed:    true,
 			Description: TeamDescScopeSyntheticCredentials,
 			ElementType: types.StringType,
+			PlanModifiers: []planmodifier.Set{setplanmodifier.UseStateForUnknown()},
 		},
 		TeamFieldScopeTagIDs: schema.SetAttribute{
 			Optional:    true,
+			Computed:    true,
 			Description: TeamDescScopeTagIDs,
 			ElementType: types.StringType,
+			PlanModifiers: []planmodifier.Set{setplanmodifier.UseStateForUnknown()},
 		},
 		TeamFieldScopeRestrictedApplicationFilter: schema.SingleNestedAttribute{
 			Description: TeamDescScopeRestrictedApplicationFilter,
@@ -233,7 +279,7 @@ func (r *teamResource) UpdateState(ctx context.Context, state *tfsdk.State, plan
 	} else if state != nil {
 		diags.Append(state.Get(ctx, &model)...)
 	}
-	m, diags := r.buildTeamModelFromAPIResponse(team, model)
+	m, diags := r.buildTeamModelFromAPIResponse(ctx, team, model)
 	if diags.HasError() {
 		return diags
 	}
@@ -241,7 +287,7 @@ func (r *teamResource) UpdateState(ctx context.Context, state *tfsdk.State, plan
 }
 
 // buildTeamModelFromAPIResponse constructs a TeamModel from the API Team response
-func (r *teamResource) buildTeamModelFromAPIResponse(team *api.Team, planModel TeamModel) (TeamModel, diag.Diagnostics) {
+func (r *teamResource) buildTeamModelFromAPIResponse(ctx context.Context, team *api.Team, planModel TeamModel) (TeamModel, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	model := TeamModel{
@@ -258,7 +304,7 @@ func (r *teamResource) buildTeamModelFromAPIResponse(team *api.Team, planModel T
 	}
 
 	if team.Scope != nil {
-		scopeModel, scopeDiags := r.mapScopeToModel(team.Scope)
+		scopeModel, scopeDiags := r.mapScopeToModel(ctx, team.Scope)
 		diags.Append(scopeDiags...)
 		if !diags.HasError() {
 			model.Scope = scopeModel
@@ -302,25 +348,42 @@ func (r *teamResource) mapRolesToModel(apiRoles []api.TeamRole) []TeamMemberRole
 	return roles
 }
 
-// mapScopeToModel converts API scope to model scope
-func (r *teamResource) mapScopeToModel(apiScope *api.TeamScope) (*TeamScopeModel, diag.Diagnostics) {
+// mapScopeToModel converts API scope to model scope.
+// Each []string scope field from the API (null or a list) is stored as types.Set so that
+// the Optional+Computed schema attribute can correctly distinguish unknown/null/empty during plan.
+func (r *teamResource) mapScopeToModel(ctx context.Context, apiScope *api.TeamScope) (*TeamScopeModel, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	scopeModel := &TeamScopeModel{
-		AccessPermissions:    apiScope.AccessPermissions,
-		Applications:         apiScope.Applications,
-		KubernetesClusters:   apiScope.KubernetesClusters,
-		KubernetesNamespaces: apiScope.KubernetesNamespaces,
-		MobileApps:           apiScope.MobileApps,
-		Websites:             apiScope.Websites,
-		InfraDFQFilter:       util.SetStringPointerToState(apiScope.InfraDFQFilter),
-		ActionFilter:         util.SetStringPointerToState(apiScope.ActionFilter),
-		LogFilter:            util.SetStringPointerToState(apiScope.LogFilter),
-		BusinessPerspectives: apiScope.BusinessPerspectives,
-		SloIDs:               apiScope.SloIDs,
-		SyntheticTests:       apiScope.SyntheticTests,
-		SyntheticCredentials: apiScope.SyntheticCredentials,
-		TagIDs:               apiScope.TagIDs,
+		InfraDFQFilter: util.SetStringPointerToState(apiScope.InfraDFQFilter),
+		ActionFilter:   util.SetStringPointerToState(apiScope.ActionFilter),
+		LogFilter:      util.SetStringPointerToState(apiScope.LogFilter),
+	}
+
+	setFields := []struct {
+		apiVal []string
+		target *types.Set
+	}{
+		{apiScope.AccessPermissions, &scopeModel.AccessPermissions},
+		{apiScope.Applications, &scopeModel.Applications},
+		{apiScope.KubernetesClusters, &scopeModel.KubernetesClusters},
+		{apiScope.KubernetesNamespaces, &scopeModel.KubernetesNamespaces},
+		{apiScope.MobileApps, &scopeModel.MobileApps},
+		{apiScope.Websites, &scopeModel.Websites},
+		{apiScope.BusinessPerspectives, &scopeModel.BusinessPerspectives},
+		{apiScope.SloIDs, &scopeModel.SloIDs},
+		{apiScope.SyntheticTests, &scopeModel.SyntheticTests},
+		{apiScope.SyntheticCredentials, &scopeModel.SyntheticCredentials},
+		{apiScope.TagIDs, &scopeModel.TagIDs},
+	}
+
+	for _, f := range setFields {
+		s, d := stringsToSet(ctx, f.apiVal)
+		diags.Append(d...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		*f.target = s
 	}
 
 	if apiScope.RestrictedApplicationFilter != nil {
@@ -386,7 +449,7 @@ func (r *teamResource) MapStateToDataObject(ctx context.Context, plan *tfsdk.Pla
 	}
 
 	if model.Scope != nil {
-		scopeAPI, scopeDiags := r.mapModelScopeToAPI(model.Scope)
+		scopeAPI, scopeDiags := r.mapModelScopeToAPI(ctx, model.Scope)
 		diags.Append(scopeDiags...)
 		if !diags.HasError() {
 			team.Scope = scopeAPI
@@ -469,21 +532,36 @@ func (r *teamResource) mapModelRolesToAPI(modelRoles []TeamMemberRole) []api.Tea
 }
 
 // mapModelScopeToAPI converts model scope to API scope
-func (r *teamResource) mapModelScopeToAPI(modelScope *TeamScopeModel) (*api.TeamScope, diag.Diagnostics) {
+func (r *teamResource) mapModelScopeToAPI(ctx context.Context, modelScope *TeamScopeModel) (*api.TeamScope, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	apiScope := &api.TeamScope{
-		AccessPermissions:    modelScope.AccessPermissions,
-		Applications:         modelScope.Applications,
-		KubernetesClusters:   modelScope.KubernetesClusters,
-		KubernetesNamespaces: modelScope.KubernetesNamespaces,
-		MobileApps:           modelScope.MobileApps,
-		Websites:             modelScope.Websites,
-		BusinessPerspectives: modelScope.BusinessPerspectives,
-		SloIDs:               modelScope.SloIDs,
-		SyntheticTests:       modelScope.SyntheticTests,
-		SyntheticCredentials: modelScope.SyntheticCredentials,
-		TagIDs:               modelScope.TagIDs,
+	apiScope := &api.TeamScope{}
+
+	// Extract each types.Set field back to []string for the API call.
+	setFields := []struct {
+		src    types.Set
+		target *[]string
+	}{
+		{modelScope.AccessPermissions, &apiScope.AccessPermissions},
+		{modelScope.Applications, &apiScope.Applications},
+		{modelScope.KubernetesClusters, &apiScope.KubernetesClusters},
+		{modelScope.KubernetesNamespaces, &apiScope.KubernetesNamespaces},
+		{modelScope.MobileApps, &apiScope.MobileApps},
+		{modelScope.Websites, &apiScope.Websites},
+		{modelScope.BusinessPerspectives, &apiScope.BusinessPerspectives},
+		{modelScope.SloIDs, &apiScope.SloIDs},
+		{modelScope.SyntheticTests, &apiScope.SyntheticTests},
+		{modelScope.SyntheticCredentials, &apiScope.SyntheticCredentials},
+		{modelScope.TagIDs, &apiScope.TagIDs},
+	}
+
+	for _, f := range setFields {
+		ss, d := setToStrings(ctx, f.src)
+		diags.Append(d...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		*f.target = ss
 	}
 
 	if !modelScope.InfraDFQFilter.IsNull() && !modelScope.InfraDFQFilter.IsUnknown() {

--- a/internal/resources/team/resource-team.go
+++ b/internal/resources/team/resource-team.go
@@ -23,22 +23,18 @@ import (
 )
 
 // stringsToSet converts a []string to a types.Set of strings.
-// Both nil (JSON null) and [] (JSON []) are stored as an empty set — the Teams API
-// uses null and [] interchangeably to mean "not configured", and the schema fields are
-// Optional+Computed with UseStateForUnknown. Storing an empty set for both cases keeps
-// the plan value ([] from TF filling an unset nested attr) consistent with state after
-// apply, regardless of whether the API echoes back null or [].
+// A nil or empty slice is mapped to an empty set; a non-empty slice is converted element-by-element.
 func stringsToSet(ctx context.Context, ss []string) (types.Set, diag.Diagnostics) {
-	if len(ss) == 0 {
+	if (ss == nil || len(ss) == 0) {
 		return types.SetValueMust(types.StringType, []attr.Value{}), nil
 	}
 	return types.SetValueFrom(ctx, types.StringType, ss)
 }
 
-// setToStrings extracts a []string from a types.Set. Returns nil for null/unknown/empty.
+// setToStrings extracts a []string from a types.Set. Returns [] for null/unknown/empty.
 func setToStrings(ctx context.Context, s types.Set) ([]string, diag.Diagnostics) {
 	if s.IsNull() || s.IsUnknown() || len(s.Elements()) == 0 {
-		return nil, nil
+		return []string{}, nil
 	}
 	var result []string
 	return result, s.ElementsAs(ctx, &result, false)

--- a/internal/resources/team/resource-team_test.go
+++ b/internal/resources/team/resource-team_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/instana/instana-go-client/api"
@@ -14,6 +15,56 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// stringsToTypesSet converts a []string to a types.Set for use in test struct literals.
+func stringsToTypesSet(t *testing.T, ss ...string) types.Set {
+	t.Helper()
+	if len(ss) == 0 {
+		return types.SetValueMust(types.StringType, []attr.Value{})
+	}
+	elems := make([]attr.Value, len(ss))
+	for i, s := range ss {
+		elems[i] = types.StringValue(s)
+	}
+	result, diags := types.SetValue(types.StringType, elems)
+	require.False(t, diags.HasError())
+	return result
+}
+
+// extractStringsFromSet extracts a []string from a types.Set for assertions.
+func extractStringsFromSet(t *testing.T, ctx context.Context, s types.Set) []string {
+	t.Helper()
+	if s.IsNull() || s.IsUnknown() {
+		return nil
+	}
+	var result []string
+	diags := s.ElementsAs(ctx, &result, false)
+	require.False(t, diags.HasError())
+	return result
+}
+
+// emptyTeamScopeModel returns a TeamScopeModel with all types.Set fields initialised to
+// empty, properly-typed sets. Tests that only need to set a subset of scope fields should
+// start from this base to avoid the "MISSING TYPE" framework panic.
+func emptyTeamScopeModel(t *testing.T) TeamScopeModel {
+	t.Helper()
+	return TeamScopeModel{
+		AccessPermissions:    stringsToTypesSet(t),
+		Applications:         stringsToTypesSet(t),
+		KubernetesClusters:   stringsToTypesSet(t),
+		KubernetesNamespaces: stringsToTypesSet(t),
+		MobileApps:           stringsToTypesSet(t),
+		Websites:             stringsToTypesSet(t),
+		InfraDFQFilter:       types.StringNull(),
+		ActionFilter:         types.StringNull(),
+		LogFilter:            types.StringNull(),
+		BusinessPerspectives: stringsToTypesSet(t),
+		SloIDs:               stringsToTypesSet(t),
+		SyntheticTests:       stringsToTypesSet(t),
+		SyntheticCredentials: stringsToTypesSet(t),
+		TagIDs:               stringsToTypesSet(t),
+	}
+}
 
 func TestNewTeamResourceHandle(t *testing.T) {
 	handle := NewTeamResourceHandle()
@@ -270,9 +321,10 @@ func TestUpdateState(t *testing.T) {
 		require.False(t, diags.HasError())
 
 		require.NotNil(t, model.Scope)
-		assert.Len(t, model.Scope.AccessPermissions, 2)
-		assert.Equal(t, "perm-1", model.Scope.AccessPermissions[0])
-		assert.Equal(t, "perm-2", model.Scope.AccessPermissions[1])
+		perms := extractStringsFromSet(t, ctx, model.Scope.AccessPermissions)
+		assert.Len(t, perms, 2)
+		assert.Contains(t, perms, "perm-1")
+		assert.Contains(t, perms, "perm-2")
 	})
 
 	t.Run("team with scope - applications", func(t *testing.T) {
@@ -297,8 +349,9 @@ func TestUpdateState(t *testing.T) {
 		require.False(t, diags.HasError())
 
 		require.NotNil(t, model.Scope)
-		assert.Len(t, model.Scope.Applications, 2)
-		assert.Equal(t, "app-1", model.Scope.Applications[0])
+		apps := extractStringsFromSet(t, ctx, model.Scope.Applications)
+		assert.Len(t, apps, 2)
+		assert.Contains(t, apps, "app-1")
 	})
 
 	t.Run("team with scope - kubernetes clusters", func(t *testing.T) {
@@ -323,8 +376,9 @@ func TestUpdateState(t *testing.T) {
 		require.False(t, diags.HasError())
 
 		require.NotNil(t, model.Scope)
-		assert.Len(t, model.Scope.KubernetesClusters, 2)
-		assert.Equal(t, "k8s-1", model.Scope.KubernetesClusters[0])
+		clusters := extractStringsFromSet(t, ctx, model.Scope.KubernetesClusters)
+		assert.Len(t, clusters, 2)
+		assert.Contains(t, clusters, "k8s-1")
 	})
 
 	t.Run("team with scope - kubernetes namespaces", func(t *testing.T) {
@@ -349,8 +403,9 @@ func TestUpdateState(t *testing.T) {
 		require.False(t, diags.HasError())
 
 		require.NotNil(t, model.Scope)
-		assert.Len(t, model.Scope.KubernetesNamespaces, 2)
-		assert.Equal(t, "ns-1", model.Scope.KubernetesNamespaces[0])
+		namespaces := extractStringsFromSet(t, ctx, model.Scope.KubernetesNamespaces)
+		assert.Len(t, namespaces, 2)
+		assert.Contains(t, namespaces, "ns-1")
 	})
 
 	t.Run("team with scope - mobile apps", func(t *testing.T) {
@@ -375,8 +430,9 @@ func TestUpdateState(t *testing.T) {
 		require.False(t, diags.HasError())
 
 		require.NotNil(t, model.Scope)
-		assert.Len(t, model.Scope.MobileApps, 2)
-		assert.Equal(t, "mobile-1", model.Scope.MobileApps[0])
+		mobileApps := extractStringsFromSet(t, ctx, model.Scope.MobileApps)
+		assert.Len(t, mobileApps, 2)
+		assert.Contains(t, mobileApps, "mobile-1")
 	})
 
 	t.Run("team with scope - websites", func(t *testing.T) {
@@ -401,8 +457,9 @@ func TestUpdateState(t *testing.T) {
 		require.False(t, diags.HasError())
 
 		require.NotNil(t, model.Scope)
-		assert.Len(t, model.Scope.Websites, 2)
-		assert.Equal(t, "website-1", model.Scope.Websites[0])
+		websites := extractStringsFromSet(t, ctx, model.Scope.Websites)
+		assert.Len(t, websites, 2)
+		assert.Contains(t, websites, "website-1")
 	})
 
 	t.Run("team with scope - infra DFQ filter", func(t *testing.T) {
@@ -505,8 +562,9 @@ func TestUpdateState(t *testing.T) {
 		require.False(t, diags.HasError())
 
 		require.NotNil(t, model.Scope)
-		assert.Len(t, model.Scope.BusinessPerspectives, 2)
-		assert.Equal(t, "bp-1", model.Scope.BusinessPerspectives[0])
+		bp := extractStringsFromSet(t, ctx, model.Scope.BusinessPerspectives)
+		assert.Len(t, bp, 2)
+		assert.Contains(t, bp, "bp-1")
 	})
 
 	t.Run("team with scope - SLO IDs", func(t *testing.T) {
@@ -531,8 +589,9 @@ func TestUpdateState(t *testing.T) {
 		require.False(t, diags.HasError())
 
 		require.NotNil(t, model.Scope)
-		assert.Len(t, model.Scope.SloIDs, 2)
-		assert.Equal(t, "slo-1", model.Scope.SloIDs[0])
+		sloIDs := extractStringsFromSet(t, ctx, model.Scope.SloIDs)
+		assert.Len(t, sloIDs, 2)
+		assert.Contains(t, sloIDs, "slo-1")
 	})
 
 	t.Run("team with scope - synthetic tests", func(t *testing.T) {
@@ -557,8 +616,9 @@ func TestUpdateState(t *testing.T) {
 		require.False(t, diags.HasError())
 
 		require.NotNil(t, model.Scope)
-		assert.Len(t, model.Scope.SyntheticTests, 2)
-		assert.Equal(t, "test-1", model.Scope.SyntheticTests[0])
+		tests := extractStringsFromSet(t, ctx, model.Scope.SyntheticTests)
+		assert.Len(t, tests, 2)
+		assert.Contains(t, tests, "test-1")
 	})
 
 	t.Run("team with scope - synthetic credentials", func(t *testing.T) {
@@ -583,8 +643,9 @@ func TestUpdateState(t *testing.T) {
 		require.False(t, diags.HasError())
 
 		require.NotNil(t, model.Scope)
-		assert.Len(t, model.Scope.SyntheticCredentials, 2)
-		assert.Equal(t, "cred-1", model.Scope.SyntheticCredentials[0])
+		creds := extractStringsFromSet(t, ctx, model.Scope.SyntheticCredentials)
+		assert.Len(t, creds, 2)
+		assert.Contains(t, creds, "cred-1")
 	})
 
 	t.Run("team with scope - tag IDs", func(t *testing.T) {
@@ -609,8 +670,9 @@ func TestUpdateState(t *testing.T) {
 		require.False(t, diags.HasError())
 
 		require.NotNil(t, model.Scope)
-		assert.Len(t, model.Scope.TagIDs, 2)
-		assert.Equal(t, "tag-1", model.Scope.TagIDs[0])
+		tagIDs := extractStringsFromSet(t, ctx, model.Scope.TagIDs)
+		assert.Len(t, tagIDs, 2)
+		assert.Contains(t, tagIDs, "tag-1")
 	})
 
 	t.Run("team with scope - restricted application filter with label", func(t *testing.T) {
@@ -765,18 +827,18 @@ func TestUpdateState(t *testing.T) {
 				},
 			},
 			Scope: &TeamScopeModel{
-				AccessPermissions:    []string{"perm-1"},
-				Applications:         []string{"app-1"},
-				KubernetesClusters:   []string{"k8s-1"},
-				KubernetesNamespaces: []string{"ns-1"},
-				MobileApps:           []string{"mobile-1"},
-				Websites:             []string{"website-1"},
+				AccessPermissions:    stringsToTypesSet(t, "perm-1"),
+				Applications:         stringsToTypesSet(t, "app-1"),
+				KubernetesClusters:   stringsToTypesSet(t, "k8s-1"),
+				KubernetesNamespaces: stringsToTypesSet(t, "ns-1"),
+				MobileApps:           stringsToTypesSet(t, "mobile-1"),
+				Websites:             stringsToTypesSet(t, "website-1"),
 				InfraDFQFilter:       types.StringValue("entity.type:host"),
-				BusinessPerspectives: []string{"bp-1"},
-				SloIDs:               []string{"slo-1"},
-				SyntheticTests:       []string{"test-1"},
-				SyntheticCredentials: []string{"cred-1"},
-				TagIDs:               []string{"tag-1"},
+				BusinessPerspectives: stringsToTypesSet(t, "bp-1"),
+				SloIDs:               stringsToTypesSet(t, "slo-1"),
+				SyntheticTests:       stringsToTypesSet(t, "test-1"),
+				SyntheticCredentials: stringsToTypesSet(t, "cred-1"),
+				TagIDs:               stringsToTypesSet(t, "tag-1"),
 				RestrictedApplicationFilter: &TeamRestrictedApplicationFilterModel{
 					Label: types.StringValue("test-label"),
 					Scope: types.StringValue(string(api.RestrictedApplicationFilterScopeIncludeAllDownstream)),
@@ -798,8 +860,8 @@ func TestUpdateState(t *testing.T) {
 		assert.Equal(t, "Full team", model.Info.Description.ValueString())
 		assert.Len(t, model.Members, 1)
 		require.NotNil(t, model.Scope)
-		assert.Len(t, model.Scope.AccessPermissions, 1)
-		assert.Len(t, model.Scope.Applications, 1)
+		assert.Len(t, model.Scope.AccessPermissions.Elements(), 1)
+		assert.Len(t, model.Scope.Applications.Elements(), 1)
 		require.NotNil(t, model.Scope.RestrictedApplicationFilter)
 	})
 }
@@ -978,9 +1040,11 @@ func TestMapStateToDataObject(t *testing.T) {
 		model := TeamModel{
 			ID:  types.StringValue("test-id"),
 			Tag: types.StringValue("test-team"),
-			Scope: &TeamScopeModel{
-				AccessPermissions: []string{"perm-1", "perm-2"},
-			},
+			Scope: func() *TeamScopeModel {
+					s := emptyTeamScopeModel(t)
+					s.AccessPermissions = stringsToTypesSet(t, "perm-1", "perm-2")
+					return &s
+				}(),
 		}
 
 		state := createMockTeamState(t, ctx, model)
@@ -990,16 +1054,18 @@ func TestMapStateToDataObject(t *testing.T) {
 
 		require.NotNil(t, team.Scope)
 		assert.Len(t, team.Scope.AccessPermissions, 2)
-		assert.Equal(t, "perm-1", team.Scope.AccessPermissions[0])
+		assert.Contains(t, team.Scope.AccessPermissions, "perm-1")
 	})
 
 	t.Run("team with scope - applications", func(t *testing.T) {
 		model := TeamModel{
 			ID:  types.StringValue("test-id"),
 			Tag: types.StringValue("test-team"),
-			Scope: &TeamScopeModel{
-				Applications: []string{"app-1", "app-2"},
-			},
+			Scope: func() *TeamScopeModel {
+					s := emptyTeamScopeModel(t)
+					s.Applications = stringsToTypesSet(t, "app-1", "app-2")
+					return &s
+				}(),
 		}
 
 		state := createMockTeamState(t, ctx, model)
@@ -1009,16 +1075,18 @@ func TestMapStateToDataObject(t *testing.T) {
 
 		require.NotNil(t, team.Scope)
 		assert.Len(t, team.Scope.Applications, 2)
-		assert.Equal(t, "app-1", team.Scope.Applications[0])
+		assert.Contains(t, team.Scope.Applications, "app-1")
 	})
 
 	t.Run("team with scope - infra DFQ filter", func(t *testing.T) {
 		model := TeamModel{
 			ID:  types.StringValue("test-id"),
 			Tag: types.StringValue("test-team"),
-			Scope: &TeamScopeModel{
-				InfraDFQFilter: types.StringValue("entity.type:host"),
-			},
+			Scope: func() *TeamScopeModel {
+					s := emptyTeamScopeModel(t)
+					s.InfraDFQFilter = types.StringValue("entity.type:host")
+					return &s
+				}(),
 		}
 
 		state := createMockTeamState(t, ctx, model)
@@ -1035,9 +1103,11 @@ func TestMapStateToDataObject(t *testing.T) {
 		model := TeamModel{
 			ID:  types.StringValue("test-id"),
 			Tag: types.StringValue("test-team"),
-			Scope: &TeamScopeModel{
-				InfraDFQFilter: types.StringNull(),
-			},
+			Scope: func() *TeamScopeModel {
+					s := emptyTeamScopeModel(t)
+					s.InfraDFQFilter = types.StringNull()
+					return &s
+				}(),
 		}
 
 		state := createMockTeamState(t, ctx, model)
@@ -1053,9 +1123,11 @@ func TestMapStateToDataObject(t *testing.T) {
 		model := TeamModel{
 			ID:  types.StringValue("test-id"),
 			Tag: types.StringValue("test-team"),
-			Scope: &TeamScopeModel{
-				ActionFilter: types.StringValue("action.type:custom"),
-			},
+			Scope: func() *TeamScopeModel {
+					s := emptyTeamScopeModel(t)
+					s.ActionFilter = types.StringValue("action.type:custom")
+					return &s
+				}(),
 		}
 
 		state := createMockTeamState(t, ctx, model)
@@ -1072,9 +1144,11 @@ func TestMapStateToDataObject(t *testing.T) {
 		model := TeamModel{
 			ID:  types.StringValue("test-id"),
 			Tag: types.StringValue("test-team"),
-			Scope: &TeamScopeModel{
-				LogFilter: types.StringValue("log.level:error"),
-			},
+			Scope: func() *TeamScopeModel {
+					s := emptyTeamScopeModel(t)
+					s.LogFilter = types.StringValue("log.level:error")
+					return &s
+				}(),
 		}
 
 		state := createMockTeamState(t, ctx, model)
@@ -1088,20 +1162,20 @@ func TestMapStateToDataObject(t *testing.T) {
 	})
 
 	t.Run("team with scope - all array fields", func(t *testing.T) {
+		scope := emptyTeamScopeModel(t)
+		scope.KubernetesClusters = stringsToTypesSet(t, "k8s-1")
+		scope.KubernetesNamespaces = stringsToTypesSet(t, "ns-1")
+		scope.MobileApps = stringsToTypesSet(t, "mobile-1")
+		scope.Websites = stringsToTypesSet(t, "website-1")
+		scope.BusinessPerspectives = stringsToTypesSet(t, "bp-1")
+		scope.SloIDs = stringsToTypesSet(t, "slo-1")
+		scope.SyntheticTests = stringsToTypesSet(t, "test-1")
+		scope.SyntheticCredentials = stringsToTypesSet(t, "cred-1")
+		scope.TagIDs = stringsToTypesSet(t, "tag-1")
 		model := TeamModel{
-			ID:  types.StringValue("test-id"),
-			Tag: types.StringValue("test-team"),
-			Scope: &TeamScopeModel{
-				KubernetesClusters:   []string{"k8s-1"},
-				KubernetesNamespaces: []string{"ns-1"},
-				MobileApps:           []string{"mobile-1"},
-				Websites:             []string{"website-1"},
-				BusinessPerspectives: []string{"bp-1"},
-				SloIDs:               []string{"slo-1"},
-				SyntheticTests:       []string{"test-1"},
-				SyntheticCredentials: []string{"cred-1"},
-				TagIDs:               []string{"tag-1"},
-			},
+			ID:    types.StringValue("test-id"),
+			Tag:   types.StringValue("test-team"),
+			Scope: &scope,
 		}
 
 		state := createMockTeamState(t, ctx, model)
@@ -1125,11 +1199,13 @@ func TestMapStateToDataObject(t *testing.T) {
 		model := TeamModel{
 			ID:  types.StringValue("test-id"),
 			Tag: types.StringValue("test-team"),
-			Scope: &TeamScopeModel{
-				RestrictedApplicationFilter: &TeamRestrictedApplicationFilterModel{
+			Scope: func() *TeamScopeModel {
+				s := emptyTeamScopeModel(t)
+				s.RestrictedApplicationFilter = &TeamRestrictedApplicationFilterModel{
 					Label: types.StringValue("test-label"),
-				},
-			},
+				}
+				return &s
+			}(),
 		}
 
 		state := createMockTeamState(t, ctx, model)
@@ -1147,11 +1223,13 @@ func TestMapStateToDataObject(t *testing.T) {
 		model := TeamModel{
 			ID:  types.StringValue("test-id"),
 			Tag: types.StringValue("test-team"),
-			Scope: &TeamScopeModel{
-				RestrictedApplicationFilter: &TeamRestrictedApplicationFilterModel{
+			Scope: func() *TeamScopeModel {
+				s := emptyTeamScopeModel(t)
+				s.RestrictedApplicationFilter = &TeamRestrictedApplicationFilterModel{
 					Scope: types.StringValue(string(api.RestrictedApplicationFilterScopeIncludeNoDownstream)),
-				},
-			},
+				}
+				return &s
+			}(),
 		}
 
 		state := createMockTeamState(t, ctx, model)
@@ -1169,11 +1247,13 @@ func TestMapStateToDataObject(t *testing.T) {
 		model := TeamModel{
 			ID:  types.StringValue("test-id"),
 			Tag: types.StringValue("test-team"),
-			Scope: &TeamScopeModel{
-				RestrictedApplicationFilter: &TeamRestrictedApplicationFilterModel{
+			Scope: func() *TeamScopeModel {
+				s := emptyTeamScopeModel(t)
+				s.RestrictedApplicationFilter = &TeamRestrictedApplicationFilterModel{
 					TagFilterExpression: types.StringValue("entity.type EQUALS 'service'"),
-				},
-			},
+				}
+				return &s
+			}(),
 		}
 
 		state := createMockTeamState(t, ctx, model)
@@ -1190,13 +1270,15 @@ func TestMapStateToDataObject(t *testing.T) {
 		model := TeamModel{
 			ID:  types.StringValue("test-id"),
 			Tag: types.StringValue("test-team"),
-			Scope: &TeamScopeModel{
-				RestrictedApplicationFilter: &TeamRestrictedApplicationFilterModel{
+			Scope: func() *TeamScopeModel {
+				s := emptyTeamScopeModel(t)
+				s.RestrictedApplicationFilter = &TeamRestrictedApplicationFilterModel{
 					Label:               types.StringNull(),
 					Scope:               types.StringNull(),
 					TagFilterExpression: types.StringNull(),
-				},
-			},
+				}
+				return &s
+			}(),
 		}
 
 		state := createMockTeamState(t, ctx, model)
@@ -1227,20 +1309,20 @@ func TestMapStateToDataObject(t *testing.T) {
 				},
 			},
 			Scope: &TeamScopeModel{
-				AccessPermissions:    []string{"perm-1"},
-				Applications:         []string{"app-1"},
-				KubernetesClusters:   []string{"k8s-1"},
-				KubernetesNamespaces: []string{"ns-1"},
-				MobileApps:           []string{"mobile-1"},
-				Websites:             []string{"website-1"},
+				AccessPermissions:    stringsToTypesSet(t, "perm-1"),
+				Applications:         stringsToTypesSet(t, "app-1"),
+				KubernetesClusters:   stringsToTypesSet(t, "k8s-1"),
+				KubernetesNamespaces: stringsToTypesSet(t, "ns-1"),
+				MobileApps:           stringsToTypesSet(t, "mobile-1"),
+				Websites:             stringsToTypesSet(t, "website-1"),
 				InfraDFQFilter:       types.StringValue("entity.type:host"),
 				ActionFilter:         types.StringValue("action.type:custom"),
 				LogFilter:            types.StringValue("log.level:error"),
-				BusinessPerspectives: []string{"bp-1"},
-				SloIDs:               []string{"slo-1"},
-				SyntheticTests:       []string{"test-1"},
-				SyntheticCredentials: []string{"cred-1"},
-				TagIDs:               []string{"tag-1"},
+				BusinessPerspectives: stringsToTypesSet(t, "bp-1"),
+				SloIDs:               stringsToTypesSet(t, "slo-1"),
+				SyntheticTests:       stringsToTypesSet(t, "test-1"),
+				SyntheticCredentials: stringsToTypesSet(t, "cred-1"),
+				TagIDs:               stringsToTypesSet(t, "tag-1"),
 				RestrictedApplicationFilter: &TeamRestrictedApplicationFilterModel{
 					Label:               types.StringValue("test-label"),
 					Scope:               types.StringValue(string(api.RestrictedApplicationFilterScopeIncludeAllDownstream)),
@@ -1325,18 +1407,18 @@ func TestRoundTripConversion(t *testing.T) {
 				},
 			},
 			Scope: &TeamScopeModel{
-				AccessPermissions:    []string{"perm-1"},
-				Applications:         []string{"app-1"},
-				KubernetesClusters:   []string{"k8s-1"},
-				KubernetesNamespaces: []string{"ns-1"},
-				MobileApps:           []string{"mobile-1"},
-				Websites:             []string{"website-1"},
+				AccessPermissions:    stringsToTypesSet(t, "perm-1"),
+				Applications:         stringsToTypesSet(t, "app-1"),
+				KubernetesClusters:   stringsToTypesSet(t, "k8s-1"),
+				KubernetesNamespaces: stringsToTypesSet(t, "ns-1"),
+				MobileApps:           stringsToTypesSet(t, "mobile-1"),
+				Websites:             stringsToTypesSet(t, "website-1"),
 				InfraDFQFilter:       types.StringValue("entity.type:host"),
-				BusinessPerspectives: []string{"bp-1"},
-				SloIDs:               []string{"slo-1"},
-				SyntheticTests:       []string{"test-1"},
-				SyntheticCredentials: []string{"cred-1"},
-				TagIDs:               []string{"tag-1"},
+				BusinessPerspectives: stringsToTypesSet(t, "bp-1"),
+				SloIDs:               stringsToTypesSet(t, "slo-1"),
+				SyntheticTests:       stringsToTypesSet(t, "test-1"),
+				SyntheticCredentials: stringsToTypesSet(t, "cred-1"),
+				TagIDs:               stringsToTypesSet(t, "tag-1"),
 				RestrictedApplicationFilter: &TeamRestrictedApplicationFilterModel{
 					Label: types.StringValue("test-label"),
 					Scope: types.StringValue(string(api.RestrictedApplicationFilterScopeIncludeAllDownstream)),
@@ -1408,17 +1490,17 @@ func TestEdgeCases(t *testing.T) {
 			ID:  types.StringValue("test-id"),
 			Tag: types.StringValue("test-team"),
 			Scope: &TeamScopeModel{
-				AccessPermissions:    []string{},
-				Applications:         []string{},
-				KubernetesClusters:   []string{},
-				KubernetesNamespaces: []string{},
-				MobileApps:           []string{},
-				Websites:             []string{},
-				BusinessPerspectives: []string{},
-				SloIDs:               []string{},
-				SyntheticTests:       []string{},
-				SyntheticCredentials: []string{},
-				TagIDs:               []string{},
+				AccessPermissions:    stringsToTypesSet(t),
+				Applications:         stringsToTypesSet(t),
+				KubernetesClusters:   stringsToTypesSet(t),
+				KubernetesNamespaces: stringsToTypesSet(t),
+				MobileApps:           stringsToTypesSet(t),
+				Websites:             stringsToTypesSet(t),
+				BusinessPerspectives: stringsToTypesSet(t),
+				SloIDs:               stringsToTypesSet(t),
+				SyntheticTests:       stringsToTypesSet(t),
+				SyntheticCredentials: stringsToTypesSet(t),
+				TagIDs:               stringsToTypesSet(t),
 			},
 		}
 
@@ -1457,11 +1539,13 @@ func TestEdgeCases(t *testing.T) {
 		model := TeamModel{
 			ID:  types.StringValue("test-id"),
 			Tag: types.StringValue("test-team"),
-			Scope: &TeamScopeModel{
-				RestrictedApplicationFilter: &TeamRestrictedApplicationFilterModel{
+			Scope: func() *TeamScopeModel {
+				s := emptyTeamScopeModel(t)
+				s.RestrictedApplicationFilter = &TeamRestrictedApplicationFilterModel{
 					TagFilterExpression: types.StringValue("invalid expression"),
-				},
-			},
+				}
+				return &s
+			}(),
 		}
 
 		state := createMockTeamState(t, ctx, model)

--- a/internal/resources/team/team-model.go
+++ b/internal/resources/team/team-model.go
@@ -27,22 +27,25 @@ type TeamMemberRole struct {
 	RoleID types.String `tfsdk:"role_id"`
 }
 
-// TeamScopeModel represents the scope configuration for the team
+// TeamScopeModel represents the scope configuration for the team.
+// All set-typed scope fields use types.Set (not []string) because the schema marks them
+// Optional+Computed — the Terraform Framework requires types.Set to correctly carry the
+// unknown value during plan when a Computed field has not yet been resolved.
 type TeamScopeModel struct {
-	AccessPermissions           []string                              `tfsdk:"access_permissions"`
-	Applications                []string                              `tfsdk:"applications"`
-	KubernetesClusters          []string                              `tfsdk:"kubernetes_clusters"`
-	KubernetesNamespaces        []string                              `tfsdk:"kubernetes_namespaces"`
-	MobileApps                  []string                              `tfsdk:"mobile_apps"`
-	Websites                    []string                              `tfsdk:"websites"`
+	AccessPermissions           types.Set                             `tfsdk:"access_permissions"`
+	Applications                types.Set                             `tfsdk:"applications"`
+	KubernetesClusters          types.Set                             `tfsdk:"kubernetes_clusters"`
+	KubernetesNamespaces        types.Set                             `tfsdk:"kubernetes_namespaces"`
+	MobileApps                  types.Set                             `tfsdk:"mobile_apps"`
+	Websites                    types.Set                             `tfsdk:"websites"`
 	InfraDFQFilter              types.String                          `tfsdk:"infra_dfq_filter"`
 	ActionFilter                types.String                          `tfsdk:"action_filter"`
 	LogFilter                   types.String                          `tfsdk:"log_filter"`
-	BusinessPerspectives        []string                              `tfsdk:"business_perspectives"`
-	SloIDs                      []string                              `tfsdk:"slo_ids"`
-	SyntheticTests              []string                              `tfsdk:"synthetic_tests"`
-	SyntheticCredentials        []string                              `tfsdk:"synthetic_credentials"`
-	TagIDs                      []string                              `tfsdk:"tag_ids"`
+	BusinessPerspectives        types.Set                             `tfsdk:"business_perspectives"`
+	SloIDs                      types.Set                             `tfsdk:"slo_ids"`
+	SyntheticTests              types.Set                             `tfsdk:"synthetic_tests"`
+	SyntheticCredentials        types.Set                             `tfsdk:"synthetic_credentials"`
+	TagIDs                      types.Set                             `tfsdk:"tag_ids"`
 	RestrictedApplicationFilter *TeamRestrictedApplicationFilterModel `tfsdk:"restricted_application_filter"`
 }
 

--- a/internal/resources/team/team-model.go
+++ b/internal/resources/team/team-model.go
@@ -28,9 +28,6 @@ type TeamMemberRole struct {
 }
 
 // TeamScopeModel represents the scope configuration for the team.
-// All set-typed scope fields use types.Set (not []string) because the schema marks them
-// Optional+Computed — the Terraform Framework requires types.Set to correctly carry the
-// unknown value during plan when a Computed field has not yet been resolved.
 type TeamScopeModel struct {
 	AccessPermissions           types.Set                             `tfsdk:"access_permissions"`
 	Applications                types.Set                             `tfsdk:"applications"`


### PR DESCRIPTION
### Description
- Fixed perpetual diff after terraform apply in instana_rbac_role by changing the member field from []RoleMemberModel to types.Set and adding a UseStateForUnknown plan modifier
- Fixed perpetual diff after terraform apply in instana_rbac_team by changing all set-typed scope fields from []string to types.Set and adding UseStateForUnknown plan modifiers

Fixes #105  