### PR TITLE
CorrelationID map issue fix

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/instana/instana-go-client/config"
 	"github.com/instana/terraform-provider-instana/internal/datasources"
+	"github.com/instana/terraform-provider-instana/internal/util"
 	"github.com/instana/terraform-provider-instana/internal/resourcehandle"
 	"github.com/instana/terraform-provider-instana/internal/resources/alertingchannel"
 	"github.com/instana/terraform-provider-instana/internal/resources/alertingconfig"
@@ -73,6 +74,9 @@ const SchemaFieldEndpoint = "endpoint"
 
 // SchemaFieldTlsSkipVerify flag to deactivate skip tls verification
 const SchemaFieldTlsSkipVerify = "tls_skip_verify"
+
+// CorrelationIDHeader is the HTTP header name for correlation ID
+const CorrelationIDHeader = "X-Correlation-ID"
 
 // InstanaProviderModel describes the provider data model
 type InstanaProviderModel struct {
@@ -179,6 +183,10 @@ func (p *InstanaProvider) Configure(ctx context.Context, req provider.ConfigureR
 	clientConfig.BaseURL = "https://" + endpoint
 	clientConfig.UserAgent = userAgent
 	clientConfig.Logger = newTerraformLogger(ctx)
+	if clientConfig.Headers.Custom == nil {
+		clientConfig.Headers.Custom = make(map[string]string)
+	}
+	clientConfig.Headers.Custom[CorrelationIDHeader] = util.GenerateCorrelationID()
 
 	// Handle TLS skip verify by creating a custom HTTP client with appropriate transport
 	if !providerConfig.TLSSkipVerify.IsNull() && providerConfig.TLSSkipVerify.ValueBool() {

--- a/internal/provider/terraform-provider-instana-resource.go
+++ b/internal/provider/terraform-provider-instana-resource.go
@@ -15,9 +15,6 @@ import (
 	"github.com/instana/terraform-provider-instana/internal/util"
 )
 
-// CorrelationIDHeader is the HTTP header name for correlation ID
-const CorrelationIDHeader = "X-Correlation-ID"
-
 // NewTerraformResource creates a new terraform resource for the given handle
 func NewTerraformResource[T client.InstanaDataObject](handle resourcehandle.ResourceHandle[T]) TerraformResource {
 	return &terraformResourceImpl[T]{
@@ -72,10 +69,7 @@ func (r *terraformResourceImpl[T]) Configure(_ context.Context, req resource.Con
 func (r *terraformResourceImpl[T]) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	// Generate correlation ID for this operation
 	correlationID := util.GenerateCorrelationID()
-	
-	// Add correlation ID to client config headers
-	r.addCorrelationIDToClient(correlationID)
-	
+
 	tflog.Debug(ctx, "Starting resource creation", map[string]interface{}{
 		"correlation_id": correlationID,
 	})
@@ -186,10 +180,7 @@ func (r *terraformResourceImpl[T]) Create(ctx context.Context, req resource.Crea
 func (r *terraformResourceImpl[T]) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	// Generate correlation ID for this operation
 	correlationID := util.GenerateCorrelationID()
-	
-	// Add correlation ID to client config headers
-	r.addCorrelationIDToClient(correlationID)
-	
+
 	if r.providerMeta == nil || r.providerMeta.InstanaAPI == nil {
 		tflog.Error(ctx, "Provider not configured for resource read")
 		resp.Diagnostics.AddError(
@@ -275,10 +266,7 @@ func (r *terraformResourceImpl[T]) Read(ctx context.Context, req resource.ReadRe
 func (r *terraformResourceImpl[T]) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	// Generate correlation ID for this operation
 	correlationID := util.GenerateCorrelationID()
-	
-	// Add correlation ID to client config headers
-	r.addCorrelationIDToClient(correlationID)
-	
+
 	if r.providerMeta == nil || r.providerMeta.InstanaAPI == nil {
 		tflog.Error(ctx, "Provider not configured for resource update")
 		resp.Diagnostics.AddError(
@@ -341,10 +329,7 @@ func (r *terraformResourceImpl[T]) Update(ctx context.Context, req resource.Upda
 func (r *terraformResourceImpl[T]) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	// Generate correlation ID for this operation
 	correlationID := util.GenerateCorrelationID()
-	
-	// Add correlation ID to client config headers
-	r.addCorrelationIDToClient(correlationID)
-	
+
 	if r.providerMeta == nil || r.providerMeta.InstanaAPI == nil {
 		tflog.Error(ctx, "Provider not configured for resource deletion")
 		resp.Diagnostics.AddError(
@@ -423,15 +408,5 @@ func (r *terraformResourceImpl[T]) ImportState(ctx context.Context, req resource
 // UpgradeState handles state upgrades for resources that need schema migration
 func (r *terraformResourceImpl[T]) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
 	return r.resourceHandle.GetStateUpgraders(ctx)
-}
-
-// addCorrelationIDToClient adds the correlation ID header to the client configuration
-func (r *terraformResourceImpl[T]) addCorrelationIDToClient(correlationID string) {
-	if r.providerMeta != nil && r.providerMeta.ClientConfig != nil {
-		if r.providerMeta.ClientConfig.Headers.Custom == nil {
-			r.providerMeta.ClientConfig.Headers.Custom = make(map[string]string)
-		}
-		r.providerMeta.ClientConfig.Headers.Custom[CorrelationIDHeader] = correlationID
-	}
 }
 


### PR DESCRIPTION
**Problem**
The provider previously generated a new correlation ID inside each resource operation and wrote it into the shared client header map. When Terraform executed resource operations in parallel, multiple goroutines could write to that map at the same time, causing:

```
fatal error: concurrent map writes
provider plugin crash during plan / apply
```

**Change**
This PR switches the provider to a single correlation ID per configured provider instance by:

- setting [X-Correlation-ID] once in [Configure()
- storing it in [clientConfig.Headers.Custom]
- removing per-operation mutation of shared client headers from resource lifecycle methods


This avoids concurrent writes to the shared headers map while still preserving correlation across all API calls made by the same configured provider instance.