### PR TITLE
 fix(slo): fix decimal precision loss in threshold state mapping

### DIFF
--- a/internal/resources/sloalertconfig/resource-slo-alert-config.go
+++ b/internal/resources/sloalertconfig/resource-slo-alert-config.go
@@ -390,14 +390,10 @@ func (r *sloAlertConfigResource) mapThresholdToState(threshold *api.SloAlertThre
 		thresholdType = ThresholdTypeStaticThreshold
 	}
 
-	// Round to 2 decimal places to avoid floating-point precision issues
-	formatted := strconv.FormatFloat(threshold.Value, 'f', 2, 64)
-	parsed, _ := strconv.ParseFloat(formatted, 64)
-
 	return &SloAlertThresholdModel{
 		Type:     types.StringValue(thresholdType),
 		Operator: types.StringValue(threshold.Operator),
-		Value:    types.Float64Value(parsed),
+		Value:    types.Float64Value(threshold.Value),
 	}
 }
 
@@ -449,7 +445,7 @@ func (r *sloAlertConfigResource) mapBurnRateConfigsToState(burnRateConfigs *[]ap
 			Duration:          types.StringValue(fmt.Sprintf("%d", cfg.Duration)),
 			DurationUnitType:  types.StringValue(cfg.DurationUnitType),
 			ThresholdOperator: types.StringValue(cfg.Threshold.Operator),
-			ThresholdValue:    types.StringValue(fmt.Sprintf("%.2f", cfg.Threshold.Value)),
+			ThresholdValue:    types.StringValue(strconv.FormatFloat(cfg.Threshold.Value, 'f', -1, 64)),
 		})
 	}
 

--- a/internal/resources/sloalertconfig/resource-slo-alert-config_test.go
+++ b/internal/resources/sloalertconfig/resource-slo-alert-config_test.go
@@ -71,6 +71,57 @@ func TestUpdateState_StatusAlertType(t *testing.T) {
 	assert.Equal(t, int64(600000), model.TimeThreshold.CoolDown.ValueInt64())
 }
 
+// TestUpdateState_ThresholdHighPrecisionDecimal verifies that floating-point values with more
+// than 2 decimal places (e.g. 0.9995) are preserved exactly in state and are not rounded,
+// which would produce an inconsistent-result error from Terraform.
+func TestUpdateState_ThresholdHighPrecisionDecimal(t *testing.T) {
+	ctx := context.Background()
+	resource := NewSloAlertConfigResourceHandle()
+
+	apiConfig := &api.SloAlertConfig{
+		ID:          "test-id-precision",
+		Name:        "Precision Test Alert",
+		Description: "Precision Test Description",
+		Severity:    5,
+		Triggering:  false,
+		Enabled:     true,
+		Rule: api.SloAlertRule{
+			AlertType: "SERVICE_LEVELS_OBJECTIVE",
+			Metric:    "STATUS",
+		},
+		Threshold: &api.SloAlertThreshold{
+			Type:     "staticThreshold",
+			Operator: ">=",
+			Value:    0.9995,
+		},
+		TimeThreshold: api.SloAlertTimeThreshold{
+			TimeWindow: 300000,
+			Expiry:     0,
+		},
+		SloIds:                []string{"slo-1"},
+		AlertChannelIds:       []string{"channel-1"},
+		CustomerPayloadFields: []common.CustomPayloadField[any]{},
+		BurnRateConfigs:       &[]api.BurnRateConfig{},
+	}
+
+	state := tfsdk.State{
+		Schema: resource.MetaData().Schema,
+	}
+	initializeEmptyState(ctx, &state)
+
+	diags := resource.UpdateState(ctx, &state, nil, apiConfig)
+	require.False(t, diags.HasError())
+
+	var model SloAlertConfigModel
+	diags = state.Get(ctx, &model)
+	require.False(t, diags.HasError())
+
+	require.NotNil(t, model.Threshold)
+	assert.Equal(t, 0.9995, model.Threshold.Value.ValueFloat64(), "threshold value must not be rounded")
+}
+
+
+
 func TestUpdateState_ErrorBudgetAlertType(t *testing.T) {
 	ctx := context.Background()
 	resource := NewSloAlertConfigResourceHandle()
@@ -194,7 +245,7 @@ func TestUpdateState_BurnRateV2AlertType(t *testing.T) {
 	assert.Equal(t, "60", model.BurnRateConfig[0].Duration.ValueString())
 	assert.Equal(t, "MINUTES", model.BurnRateConfig[0].DurationUnitType.ValueString())
 	assert.Equal(t, ">", model.BurnRateConfig[0].ThresholdOperator.ValueString())
-	assert.Equal(t, "2.50", model.BurnRateConfig[0].ThresholdValue.ValueString())
+	assert.Equal(t, "2.5", model.BurnRateConfig[0].ThresholdValue.ValueString())
 
 	// Check second burn rate config
 	assert.Equal(t, "LONG", model.BurnRateConfig[1].AlertWindowType.ValueString())

--- a/internal/resources/sloconfig/resource-slo-config.go
+++ b/internal/resources/sloconfig/resource-slo-config.go
@@ -3,7 +3,6 @@ package sloconfig
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
@@ -1745,12 +1744,8 @@ func (r *sloConfigResource) mapIndicatorToState(apiObject *api.SloConfig, sloCon
 
 // createTimeBasedLatencyModel creates time-based latency indicator model
 func (r *sloConfigResource) createTimeBasedLatencyModel(indicator api.SloIndicator) *TimeBasedLatencyIndicatorModel {
-	// Round to 2 decimal places to avoid floating-point precision issues
-	formatted := strconv.FormatFloat(indicator.Threshold, 'f', 2, 64)
-	parsed, _ := strconv.ParseFloat(formatted, 64)
-
 	return &TimeBasedLatencyIndicatorModel{
-		Threshold:   types.Float64Value(parsed),
+		Threshold:   types.Float64Value(indicator.Threshold),
 		Aggregation: util.SetStringPointerToState(indicator.Aggregation),
 		Metric:      r.mapEntityMetricToModel(indicator.Metric),
 	}
@@ -1758,24 +1753,16 @@ func (r *sloConfigResource) createTimeBasedLatencyModel(indicator api.SloIndicat
 
 // createEventBasedLatencyModel creates event-based latency indicator model
 func (r *sloConfigResource) createEventBasedLatencyModel(indicator api.SloIndicator) *EventBasedLatencyIndicatorModel {
-	// Round to 2 decimal places to avoid floating-point precision issues
-	formatted := strconv.FormatFloat(indicator.Threshold, 'f', 2, 64)
-	parsed, _ := strconv.ParseFloat(formatted, 64)
-
 	return &EventBasedLatencyIndicatorModel{
-		Threshold: types.Float64Value(parsed),
+		Threshold: types.Float64Value(indicator.Threshold),
 		Metric:    r.mapEntityMetricToModel(indicator.Metric),
 	}
 }
 
 // createTimeBasedAvailabilityModel creates time-based availability indicator model
 func (r *sloConfigResource) createTimeBasedAvailabilityModel(indicator api.SloIndicator) *TimeBasedAvailabilityIndicatorModel {
-	// Round to 2 decimal places to avoid floating-point precision issues
-	formatted := strconv.FormatFloat(indicator.Threshold, 'f', 2, 64)
-	parsed, _ := strconv.ParseFloat(formatted, 64)
-
 	return &TimeBasedAvailabilityIndicatorModel{
-		Threshold:   types.Float64Value(parsed),
+		Threshold:   types.Float64Value(indicator.Threshold),
 		Aggregation: util.SetStringPointerToState(indicator.Aggregation),
 		Metric:      r.mapEntityMetricToModel(indicator.Metric),
 	}
@@ -1783,10 +1770,8 @@ func (r *sloConfigResource) createTimeBasedAvailabilityModel(indicator api.SloIn
 
 // createEventBasedAvailabilityModel creates event-based availability indicator model
 func (r *sloConfigResource) createEventBasedAvailabilityModel(indicator api.SloIndicator) *EventBasedAvailabilityIndicatorModel {
-	formatted := strconv.FormatFloat(indicator.Threshold, 'f', 2, 64)
-	parsed, _ := strconv.ParseFloat(formatted, 64)
 	return &EventBasedAvailabilityIndicatorModel{
-		Threshold:   types.Float64Value(parsed),
+		Threshold:   types.Float64Value(indicator.Threshold),
 		Aggregation: util.SetStringPointerToState(indicator.Aggregation),
 		Metric:      r.mapEntityMetricToModel(indicator.Metric),
 	}
@@ -1794,13 +1779,9 @@ func (r *sloConfigResource) createEventBasedAvailabilityModel(indicator api.SloI
 
 // createTrafficModel creates traffic indicator model
 func (r *sloConfigResource) createTrafficModel(indicator api.SloIndicator, existingVal *IndicatorModel) *TrafficIndicatorModel {
-	// Round to 2 decimal places to avoid floating-point precision issues
-	formatted := strconv.FormatFloat(indicator.Threshold, 'f', 2, 64)
-	parsed, _ := strconv.ParseFloat(formatted, 64)
-
 	trafficIndicatorModel := &TrafficIndicatorModel{
 		TrafficType: util.SetStringPointerToState(indicator.TrafficType),
-		Threshold:   types.Float64Value(parsed),
+		Threshold:   types.Float64Value(indicator.Threshold),
 		Metric:      r.mapEntityMetricToModel(indicator.Metric),
 	}
 	// Always prefer the API-returned operator; fall back to existing state value
@@ -1834,13 +1815,9 @@ func (r *sloConfigResource) createCustomModel(indicator api.SloIndicator) (*Cust
 
 // createTimeBasedSaturationModel creates saturation indicator model
 func (r *sloConfigResource) createTimeBasedSaturationModel(indicator api.SloIndicator) *TimeBasedSaturationIndicatorModel {
-	// Round to 2 decimal places to avoid floating-point precision issues
-	formatted := strconv.FormatFloat(indicator.Threshold, 'f', 2, 64)
-	parsed, _ := strconv.ParseFloat(formatted, 64)
-
 	return &TimeBasedSaturationIndicatorModel{
 		MetricName:  util.SetStringPointerToState(indicator.MetricName),
-		Threshold:   types.Float64Value(parsed),
+		Threshold:   types.Float64Value(indicator.Threshold),
 		Aggregation: util.SetStringPointerToState(indicator.Aggregation),
 		Operator:    util.SetStringPointerToState(indicator.Operator),
 		Metric:      r.mapEntityMetricToModel(indicator.Metric),
@@ -1849,13 +1826,9 @@ func (r *sloConfigResource) createTimeBasedSaturationModel(indicator api.SloIndi
 
 // createEventBasedSaturationModel creates saturation indicator model
 func (r *sloConfigResource) createEventBasedSaturationModel(indicator api.SloIndicator) *EventBasedSaturationIndicatorModel {
-	// Round to 2 decimal places to avoid floating-point precision issues
-	formatted := strconv.FormatFloat(indicator.Threshold, 'f', 2, 64)
-	parsed, _ := strconv.ParseFloat(formatted, 64)
-
 	return &EventBasedSaturationIndicatorModel{
 		MetricName: util.SetStringPointerToState(indicator.MetricName),
-		Threshold:  types.Float64Value(parsed),
+		Threshold:  types.Float64Value(indicator.Threshold),
 		Operator:   util.SetStringPointerToState(indicator.Operator),
 		Metric:     r.mapEntityMetricToModel(indicator.Metric),
 	}

--- a/internal/resources/sloconfig/resource-slo-config_test.go
+++ b/internal/resources/sloconfig/resource-slo-config_test.go
@@ -982,7 +982,7 @@ func TestMapIndicatorToState(t *testing.T) {
 			Indicator: api.SloIndicator{
 				Blueprint:   SloConfigAPIIndicatorBlueprintAvailability,
 				Type:        SloConfigAPIIndicatorMeasurementTypeEventBased,
-				Threshold:   0.0,
+				Threshold:   0.9995,
 				Aggregation: &aggregation,
 			},
 		}
@@ -991,7 +991,7 @@ func TestMapIndicatorToState(t *testing.T) {
 
 		assert.False(t, diags.HasError())
 		assert.NotNil(t, result.EventBasedAvailabilityIndicatorModel)
-		assert.Equal(t, 0.0, result.EventBasedAvailabilityIndicatorModel.Threshold.ValueFloat64())
+		assert.Equal(t, 0.9995, result.EventBasedAvailabilityIndicatorModel.Threshold.ValueFloat64(), "threshold must not be rounded to 2 decimal places")
 		assert.Equal(t, "MEAN", result.EventBasedAvailabilityIndicatorModel.Aggregation.ValueString())
 	})
 


### PR DESCRIPTION
### Description
Remove FormatFloat/ParseFloat round-trips that truncated threshold values to 2 decimal places. Values like 0.9995 were being rounded to 1.0, causing Terraform's "inconsistent result after apply" error.

Fixes #95 