### PR TITLE
add instana_session_settings resource

### DIFF
--- a/docs/resources/session_settings.md
+++ b/docs/resources/session_settings.md
@@ -1,0 +1,157 @@
+# Session Settings Resource
+
+Manages the tenant unit session settings in Instana, including the authentication token lifetime and idle session timeout.
+
+API Documentation: [Instana REST API - Session Settings](https://instana.github.io/openapi/#tag/Session-Settings)
+
+---
+
+> ⚠️ **Singleton Resource — One Instance Per Tenant**
+>
+> `instana_session_settings` is a **tenant-level singleton**. There is exactly one set of session settings per Instana tenant unit. You must declare **at most one** `instana_session_settings` block across your entire Terraform configuration.
+>
+> Declaring multiple blocks is not supported: every `apply` overwrites the same tenant setting, and only the configuration applied **last** will be in effect. Terraform will not raise an error if you declare two blocks, but the behaviour is undefined and your configuration will be inconsistent.
+
+---
+
+## Example Usage
+
+### Minimal — use server defaults
+
+Both fields are optional. If omitted, Instana's default values are used:
+- `token_life_time_in_millis` → `604800000` (7 days)
+- `idle_time_in_millis` → `28800000` (8 hours)
+
+```hcl
+resource "instana_session_settings" "main" {}
+```
+
+### Custom token and idle timeouts
+
+```hcl
+resource "instana_session_settings" "main" {
+  token_life_time_in_millis = 86400000   # 1 day
+  idle_time_in_millis       = 1800000    # 30 minutes
+}
+```
+
+### Using variables
+
+```hcl
+variable "token_lifetime_ms" {
+  description = "Authentication token lifetime in milliseconds"
+  type        = number
+  default     = 604800000 # 7 days
+}
+
+variable "idle_timeout_ms" {
+  description = "Idle session timeout in milliseconds"
+  type        = number
+  default     = 28800000 # 8 hours
+}
+
+resource "instana_session_settings" "main" {
+  token_life_time_in_millis = var.token_lifetime_ms
+  idle_time_in_millis       = var.idle_timeout_ms
+}
+```
+
+### Prevent accidental deletion
+
+Deleting this resource resets the tenant to Instana's built-in defaults. Use `prevent_destroy` in production environments to guard against accidental resets:
+
+```hcl
+resource "instana_session_settings" "main" {
+  token_life_time_in_millis = 86400000
+  idle_time_in_millis       = 3600000
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+```
+
+---
+
+## Argument Reference
+
+### Optional Attributes
+
+* `token_life_time_in_millis` - (Optional, Computed) Maximum lifetime of an authentication token in milliseconds.
+  Defaults to `604800000` (7 days) if not set.
+  Valid range: `600000` (10 minutes) to `604800000` (7 days).
+
+  **Type:** `number`
+
+* `idle_time_in_millis` - (Optional, Computed) Idle timeout before a session expires in milliseconds.
+  Defaults to `28800000` (8 hours) if not set.
+  Valid range: `600000` (10 minutes) to `28800000` (8 hours).
+
+  **Type:** `number`
+
+### Quick reference — common values
+
+| Duration     | Milliseconds  |
+|--------------|--------------|
+| 10 minutes   | `600000`     |
+| 30 minutes   | `1800000`    |
+| 1 hour       | `3600000`    |
+| 4 hours      | `14400000`   |
+| 8 hours      | `28800000`   |
+| 1 day        | `86400000`   |
+| 7 days       | `604800000`  |
+
+---
+
+## Import
+
+Session settings can be imported by providing any non-empty placeholder string as the ID — the actual value is ignored because this resource has no real ID. The current settings are read directly from the API during import.
+
+### Using an import block (Terraform ≥ 1.5, recommended)
+
+```hcl
+import {
+  to = instana_session_settings.main
+  id = "session_settings"
+}
+```
+
+Then generate the configuration automatically:
+
+```bash
+terraform plan -generate-config-out=generated.tf
+```
+
+Review `generated.tf`, then apply:
+
+```bash
+terraform apply
+```
+
+### Using the CLI import command
+
+```bash
+terraform import instana_session_settings.main session_settings
+```
+
+---
+
+## Notes
+
+### Singleton behaviour
+
+This resource manages a single tenant-level configuration object. The Instana API exposes it at the fixed path `/api/settings/session` with no per-resource ID. All CRUD operations target that same endpoint:
+
+| Terraform operation | API call           |
+|---------------------|--------------------|
+| `create` / `update` | `PUT /api/settings/session` |
+| `read`              | `GET /api/settings/session` |
+| `delete`            | `DELETE /api/settings/session` (reverts to defaults) |
+
+### What happens on delete
+
+Destroying this resource calls `DELETE /api/settings/session`, which **reverts the tenant to Instana's built-in defaults** — it does not permanently remove anything. Use `lifecycle { prevent_destroy = true }` in production to prevent unintentional resets.
+
+### Required API token permission
+
+The API token used by the provider must have the **`CanConfigureSessionSettings`** permission to manage this resource.

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.18.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.36.1
-	github.com/instana/instana-go-client v1.1.4
+	github.com/instana/instana-go-client v1.2.0
 	github.com/rs/xid v1.5.0
 	github.com/stretchr/testify v1.11.1
 )
@@ -61,5 +61,3 @@ require (
 	gopkg.in/resty.v1 v1.12.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/instana/instana-go-client => /Users/georgekuttyjoseph/Documents/Instana/Projects/sourceCode/instana-go-client

--- a/go.mod
+++ b/go.mod
@@ -61,3 +61,5 @@ require (
 	gopkg.in/resty.v1 v1.12.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/instana/instana-go-client => /Users/georgekuttyjoseph/Documents/Instana/Projects/sourceCode/instana-go-client

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,6 @@ github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8=
 github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
-github.com/instana/instana-go-client v1.1.4 h1:bWVd47Y1ArkDhmU6cPxjPlR6Rpaibd/Vyr/g7U08tTg=
-github.com/instana/instana-go-client v1.1.4/go.mod h1:aOe+HQWz3md7VSvKrdeT+aso7sxzobWuXvyaTwIos3Q=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=
 github.com/jhump/protoreflect v1.17.0/go.mod h1:h9+vUUL38jiBzck8ck+6G/aeMX8Z4QUY/NiJPwPNi+8=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8=
 github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
+github.com/instana/instana-go-client v1.2.0 h1:5mgX6nNWBWefZyElas5vIE75V8OlOJzjvdE4gp5ABq8=
+github.com/instana/instana-go-client v1.2.0/go.mod h1:aOe+HQWz3md7VSvKrdeT+aso7sxzobWuXvyaTwIos3Q=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=
 github.com/jhump/protoreflect v1.17.0/go.mod h1:h9+vUUL38jiBzck8ck+6G/aeMX8Z4QUY/NiJPwPNi+8=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -45,6 +45,7 @@ import (
 	"github.com/instana/terraform-provider-instana/internal/resources/sloconfig"
 	"github.com/instana/terraform-provider-instana/internal/resources/slocorrectionconfig"
 	"github.com/instana/terraform-provider-instana/internal/resources/syntheticalertconfig"
+	"github.com/instana/terraform-provider-instana/internal/resources/sessionsettings"
 	"github.com/instana/terraform-provider-instana/internal/resources/synthetictest"
 	"github.com/instana/terraform-provider-instana/internal/resources/team"
 	"github.com/instana/terraform-provider-instana/internal/resources/websitealertconfig"
@@ -382,12 +383,20 @@ func (p *InstanaProvider) Resources(_ context.Context) []func() resource.Resourc
 		addResouceHandle(websitealertconfig.NewWebsiteAlertConfigResourceHandle),
 		addResouceHandle(websitemonitoringconfig.NewWebsiteMonitoringConfigResourceHandle),
 		addResouceHandle(sloconfig.NewSloConfigResourceHandle),
+		addSingletonResourceHandle(sessionsettings.NewSessionSettingsResourceHandle),
 	}
 }
 
-// Helper function to wrap resource handles
+// addResouceHandle wraps a ResourceHandle constructor for use in the Resources list.
 func addResouceHandle[T client.InstanaDataObject](handleFunc func() resourcehandle.ResourceHandle[T]) func() resource.Resource {
 	return func() resource.Resource {
 		return NewTerraformResource(handleFunc())
+	}
+}
+
+// addSingletonResourceHandle wraps a SingletonResourceHandle constructor for use in the Resources list.
+func addSingletonResourceHandle[T any](handleFunc func() resourcehandle.SingletonResourceHandle[T]) func() resource.Resource {
+	return func() resource.Resource {
+		return NewTerraformSingletonResource(handleFunc())
 	}
 }

--- a/internal/provider/terraform-provider-instana-resource.go
+++ b/internal/provider/terraform-provider-instana-resource.go
@@ -410,3 +410,190 @@ func (r *terraformResourceImpl[T]) UpgradeState(ctx context.Context) map[int64]r
 	return r.resourceHandle.GetStateUpgraders(ctx)
 }
 
+// ---------------------------------------------------------------------------
+// Singleton resource — no ID, no list; uses Get / Upsert / Delete
+// ---------------------------------------------------------------------------
+
+// NewTerraformSingletonResource creates a Terraform resource backed by a SingletonResourceHandle.
+// Singletons have no ID field and map Create/Update both to Upsert; Read calls Get; Delete
+// calls Delete on the singleton endpoint.
+func NewTerraformSingletonResource[T any](handle resourcehandle.SingletonResourceHandle[T]) TerraformResource {
+	return &terraformSingletonResourceImpl[T]{
+		resourceHandle: handle,
+	}
+}
+
+type terraformSingletonResourceImpl[T any] struct {
+	resourceHandle resourcehandle.SingletonResourceHandle[T]
+	providerMeta   *shared.ProviderMeta
+}
+
+// Metadata returns the resource type name.
+func (r *terraformSingletonResourceImpl[T]) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_" + r.resourceHandle.MetaData().ResourceName
+}
+
+// Schema defines the schema for the resource.
+func (r *terraformSingletonResourceImpl[T]) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = r.resourceHandle.MetaData().Schema
+	resp.Schema.Version = r.resourceHandle.MetaData().SchemaVersion
+	resp.Schema.DeprecationMessage = r.resourceHandle.MetaData().DeprecationMessage
+}
+
+// Configure stores the provider meta.
+func (r *terraformSingletonResourceImpl[T]) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	providerMeta, ok := req.ProviderData.(*shared.ProviderMeta)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *shared.ProviderMeta, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	r.providerMeta = providerMeta
+}
+
+// Create upserts the singleton resource.
+func (r *terraformSingletonResourceImpl[T]) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	correlationID := util.GenerateCorrelationID()
+	tflog.Debug(ctx, "Creating singleton resource", map[string]interface{}{"correlation_id": correlationID})
+
+	if r.providerMeta == nil || r.providerMeta.InstanaAPI == nil {
+		resp.Diagnostics.AddError("Provider not configured", providerNotConfiguredDetail)
+		return
+	}
+
+	diags := r.resourceHandle.SetComputedFields(ctx, &req.Plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	obj, diags := r.resourceHandle.MapStateToDataObject(ctx, &req.Plan, nil)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	upserted, err := r.resourceHandle.GetSingletonRestResource(r.providerMeta.InstanaAPI).Upsert(obj)
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating singleton resource", fmt.Sprintf("Could not create resource: %s", err))
+		return
+	}
+
+	resp.Diagnostics.Append(r.resourceHandle.UpdateState(ctx, &resp.State, &req.Plan, upserted)...)
+	tflog.Debug(ctx, "Successfully created singleton resource", map[string]interface{}{"correlation_id": correlationID})
+}
+
+// Read reads the singleton resource.
+func (r *terraformSingletonResourceImpl[T]) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	correlationID := util.GenerateCorrelationID()
+	tflog.Debug(ctx, "Reading singleton resource", map[string]interface{}{"correlation_id": correlationID})
+
+	if r.providerMeta == nil || r.providerMeta.InstanaAPI == nil {
+		resp.Diagnostics.AddError("Provider not configured", providerNotConfiguredDetail)
+		return
+	}
+
+	obj, err := r.resourceHandle.GetSingletonRestResource(r.providerMeta.InstanaAPI).Get()
+	if err != nil {
+		if errors.Is(err, client.ErrEntityNotFound) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Error reading singleton resource", fmt.Sprintf("Could not read resource: %s", err))
+		return
+	}
+
+	resp.Diagnostics.Append(r.resourceHandle.UpdateState(ctx, &resp.State, nil, obj)...)
+	tflog.Debug(ctx, "Successfully read singleton resource", map[string]interface{}{"correlation_id": correlationID})
+}
+
+// Update upserts the singleton resource with the new plan values.
+func (r *terraformSingletonResourceImpl[T]) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	correlationID := util.GenerateCorrelationID()
+	tflog.Debug(ctx, "Updating singleton resource", map[string]interface{}{"correlation_id": correlationID})
+
+	if r.providerMeta == nil || r.providerMeta.InstanaAPI == nil {
+		resp.Diagnostics.AddError("Provider not configured", providerNotConfiguredDetail)
+		return
+	}
+
+	obj, diags := r.resourceHandle.MapStateToDataObject(ctx, &req.Plan, &req.State)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	upserted, err := r.resourceHandle.GetSingletonRestResource(r.providerMeta.InstanaAPI).Upsert(obj)
+	if err != nil {
+		resp.Diagnostics.AddError("Error updating singleton resource", fmt.Sprintf("Could not update resource: %s", err))
+		return
+	}
+
+	resp.Diagnostics.Append(r.resourceHandle.UpdateState(ctx, &resp.State, &req.Plan, upserted)...)
+	tflog.Debug(ctx, "Successfully updated singleton resource", map[string]interface{}{"correlation_id": correlationID})
+}
+
+// Delete deletes the singleton resource (reverts to defaults).
+func (r *terraformSingletonResourceImpl[T]) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	correlationID := util.GenerateCorrelationID()
+	tflog.Debug(ctx, "Deleting singleton resource", map[string]interface{}{"correlation_id": correlationID})
+
+	if r.providerMeta == nil || r.providerMeta.InstanaAPI == nil {
+		resp.Diagnostics.AddError("Provider not configured", providerNotConfiguredDetail)
+		return
+	}
+
+	if err := r.resourceHandle.GetSingletonRestResource(r.providerMeta.InstanaAPI).Delete(); err != nil {
+		resp.Diagnostics.AddError("Error deleting singleton resource", fmt.Sprintf("Could not delete resource: %s", err))
+		return
+	}
+
+	tflog.Debug(ctx, "Successfully deleted singleton resource", map[string]interface{}{"correlation_id": correlationID})
+}
+
+// ImportState imports the singleton resource by reading its current value from the API.
+// Because singletons have no real ID, pass any non-empty placeholder string as the
+// import ID (e.g. "session_settings"). The value is ignored — the current settings are
+// fetched directly from the API and written into state.
+//
+// Import block example:
+//
+//	import {
+//	  to = instana_session_settings.main
+//	  id = "session_settings"
+//	}
+func (r *terraformSingletonResourceImpl[T]) ImportState(ctx context.Context, _ resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	correlationID := util.GenerateCorrelationID()
+	tflog.Info(ctx, "Importing singleton resource", map[string]interface{}{"correlation_id": correlationID})
+
+	if r.providerMeta == nil || r.providerMeta.InstanaAPI == nil {
+		resp.Diagnostics.AddError("Provider not configured", providerNotConfiguredDetail)
+		return
+	}
+
+	obj, err := r.resourceHandle.GetSingletonRestResource(r.providerMeta.InstanaAPI).Get()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error importing singleton resource",
+			fmt.Sprintf("Could not read resource from API during import: %s", err),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(r.resourceHandle.UpdateState(ctx, &resp.State, nil, obj)...)
+	tflog.Info(ctx, "Successfully imported singleton resource", map[string]interface{}{"correlation_id": correlationID})
+}
+
+// UpgradeState handles state upgrades for singleton resources.
+func (r *terraformSingletonResourceImpl[T]) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	return r.resourceHandle.GetStateUpgraders(ctx)
+}
+
+const providerNotConfiguredDetail = "The provider hasn't been configured before apply, " +
+	"likely because it depends on an unknown value from another resource."
+

--- a/internal/resourcehandle/resource_handle.go
+++ b/internal/resourcehandle/resource_handle.go
@@ -11,6 +11,36 @@ import (
 	"github.com/instana/instana-go-client/shared/rest"
 )
 
+// SingletonResourceHandle is the parallel of ResourceHandle for singleton REST resources
+// (resources that have no ID and expose Get / Upsert / Delete at a fixed path).
+// T is the API data type; it does NOT need to satisfy client.InstanaDataObject because
+// singleton resources carry no ID.
+//
+// Implementations follow exactly the same shape as ResourceHandle: MetaData, UpdateState,
+// MapStateToDataObject, SetComputedFields, and GetStateUpgraders are identical.
+// The only difference is GetSingletonRestResource, which returns a SingletonRestResource
+// instead of a RestResource.
+type SingletonResourceHandle[T any] interface {
+	// MetaData returns the metadata of this handle (resource name, schema, etc.)
+	MetaData() *ResourceMetaData
+
+	// GetSingletonRestResource provides the singleton REST resource client.
+	GetSingletonRestResource(api client.InstanaAPI) rest.SingletonRestResource[T]
+
+	// UpdateState updates the Terraform state with data received from the API.
+	UpdateState(ctx context.Context, state *tfsdk.State, plan *tfsdk.Plan, obj T) diag.Diagnostics
+
+	// MapStateToDataObject maps the current Terraform plan/state to the API data object.
+	MapStateToDataObject(ctx context.Context, plan *tfsdk.Plan, state *tfsdk.State) (T, diag.Diagnostics)
+
+	// SetComputedFields calculates and sets computed field values in the plan.
+	SetComputedFields(ctx context.Context, plan *tfsdk.Plan) diag.Diagnostics
+
+	// GetStateUpgraders returns the state upgraders for schema version migrations.
+	// Return nil or an empty map if no state upgrades are needed.
+	GetStateUpgraders(ctx context.Context) map[int64]resource.StateUpgrader
+}
+
 // ResourceMetaData the metadata of a terraform ResourceHandle
 type ResourceMetaData struct {
 	ResourceName       string

--- a/internal/resources/sessionsettings/resource-session-settings.go
+++ b/internal/resources/sessionsettings/resource-session-settings.go
@@ -1,0 +1,109 @@
+package sessionsettings
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	restapi "github.com/instana/instana-go-client/api"
+	"github.com/instana/instana-go-client/client"
+	"github.com/instana/instana-go-client/shared/rest"
+	"github.com/instana/terraform-provider-instana/internal/resourcehandle"
+)
+
+// NewSessionSettingsResourceHandle creates the resource handle for session settings.
+func NewSessionSettingsResourceHandle() resourcehandle.SingletonResourceHandle[*restapi.SessionSettings] {
+	return &sessionSettingsResourceHandle{
+		metaData: resourcehandle.ResourceMetaData{
+			ResourceName: ResourceInstanaSessionSettings,
+			Schema: schema.Schema{
+				Description: SessionSettingsDescResource,
+				Attributes: map[string]schema.Attribute{
+					SessionSettingsFieldTokenLifeTimeInMillis: schema.Int64Attribute{
+						Optional:    true,
+						Computed:    true,
+						Description: SessionSettingsDescTokenLifeTime,
+						Default:     int64default.StaticInt64(SessionSettingsDefaultTokenLifeTimeInMillis),
+						Validators: []validator.Int64{
+							int64validator.Between(
+								SessionSettingsMinTokenLifeTimeInMillis,
+								SessionSettingsMaxTokenLifeTimeInMillis,
+							),
+						},
+					},
+					SessionSettingsFieldIdleTimeInMillis: schema.Int64Attribute{
+						Optional:    true,
+						Computed:    true,
+						Description: SessionSettingsDescIdleTime,
+						Default:     int64default.StaticInt64(SessionSettingsDefaultIdleTimeInMillis),
+						Validators: []validator.Int64{
+							int64validator.Between(
+								SessionSettingsMinIdleTimeInMillis,
+								SessionSettingsMaxIdleTimeInMillis,
+							),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+type sessionSettingsResourceHandle struct {
+	metaData resourcehandle.ResourceMetaData
+}
+
+// MetaData returns the resource metadata.
+func (h *sessionSettingsResourceHandle) MetaData() *resourcehandle.ResourceMetaData {
+	return &h.metaData
+}
+
+// GetSingletonRestResource returns the singleton REST client for session settings.
+func (h *sessionSettingsResourceHandle) GetSingletonRestResource(api client.InstanaAPI) rest.SingletonRestResource[*restapi.SessionSettings] {
+	return api.SessionSettings()
+}
+
+// SetComputedFields is a no-op — session settings has no computed fields.
+func (h *sessionSettingsResourceHandle) SetComputedFields(_ context.Context, _ *tfsdk.Plan) diag.Diagnostics {
+	return diag.Diagnostics{}
+}
+
+// MapStateToDataObject maps the Terraform plan/state to the API object.
+func (h *sessionSettingsResourceHandle) MapStateToDataObject(ctx context.Context, plan *tfsdk.Plan, state *tfsdk.State) (*restapi.SessionSettings, diag.Diagnostics) {
+	var model SessionSettingsModel
+	var diags diag.Diagnostics
+
+	if plan != nil {
+		diags = plan.Get(ctx, &model)
+	} else {
+		diags = state.Get(ctx, &model)
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return &restapi.SessionSettings{
+		TokenLifeTimeInMillis: model.TokenLifeTimeInMillis.ValueInt64(),
+		IdleTimeInMillis:      model.IdleTimeInMillis.ValueInt64(),
+	}, diags
+}
+
+// UpdateState updates the Terraform state with the API object.
+func (h *sessionSettingsResourceHandle) UpdateState(ctx context.Context, state *tfsdk.State, _ *tfsdk.Plan, settings *restapi.SessionSettings) diag.Diagnostics {
+	return state.Set(ctx, SessionSettingsModel{
+		TokenLifeTimeInMillis: types.Int64Value(settings.TokenLifeTimeInMillis),
+		IdleTimeInMillis:      types.Int64Value(settings.IdleTimeInMillis),
+	})
+}
+
+// GetStateUpgraders returns state upgraders — none needed for this resource.
+func (h *sessionSettingsResourceHandle) GetStateUpgraders(_ context.Context) map[int64]resource.StateUpgrader {
+	return map[int64]resource.StateUpgrader{}
+}

--- a/internal/resources/sessionsettings/resource-session-settings.go
+++ b/internal/resources/sessionsettings/resource-session-settings.go
@@ -89,6 +89,15 @@ func (h *sessionSettingsResourceHandle) MapStateToDataObject(ctx context.Context
 		return nil, diags
 	}
 
+	if model.IdleTimeInMillis.ValueInt64() > model.TokenLifeTimeInMillis.ValueInt64() {
+		diags.AddError(
+			"Invalid session settings",
+			"idle_time_in_millis must not be greater than token_life_time_in_millis: "+
+				"the user session timeout cannot be smaller than the idle timeout.",
+		)
+		return nil, diags
+	}
+
 	return &restapi.SessionSettings{
 		TokenLifeTimeInMillis: model.TokenLifeTimeInMillis.ValueInt64(),
 		IdleTimeInMillis:      model.IdleTimeInMillis.ValueInt64(),
@@ -103,7 +112,7 @@ func (h *sessionSettingsResourceHandle) UpdateState(ctx context.Context, state *
 	})
 }
 
-// GetStateUpgraders returns state upgraders — none needed for this resource.
+// GetStateUpgraders returns nil — no state schema migrations are needed for this resource.
 func (h *sessionSettingsResourceHandle) GetStateUpgraders(_ context.Context) map[int64]resource.StateUpgrader {
-	return map[int64]resource.StateUpgrader{}
+	return nil
 }

--- a/internal/resources/sessionsettings/resource-session-settings_test.go
+++ b/internal/resources/sessionsettings/resource-session-settings_test.go
@@ -1,0 +1,242 @@
+package sessionsettings
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	fwschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	restapi "github.com/instana/instana-go-client/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockSingletonRestResource is a hand-rolled mock for rest.SingletonRestResource[*restapi.SessionSettings].
+type mockSingletonRestResource struct {
+	getResult    *restapi.SessionSettings
+	getErr       error
+	upsertResult *restapi.SessionSettings
+	upsertErr    error
+	deleteErr    error
+	upsertCalled bool
+	deleteCalled bool
+}
+
+func (m *mockSingletonRestResource) Get() (*restapi.SessionSettings, error) {
+	return m.getResult, m.getErr
+}
+
+func (m *mockSingletonRestResource) Upsert(data *restapi.SessionSettings) (*restapi.SessionSettings, error) {
+	m.upsertCalled = true
+	if m.upsertResult != nil {
+		return m.upsertResult, m.upsertErr
+	}
+	return data, m.upsertErr
+}
+
+func (m *mockSingletonRestResource) Delete() error {
+	m.deleteCalled = true
+	return m.deleteErr
+}
+
+// handleSchema returns the resource/schema.Schema defined inside the handle.
+func handleSchema() fwschema.Schema {
+	return NewSessionSettingsResourceHandle().MetaData().Schema
+}
+
+// ---- handle metadata ----
+
+func TestNewSessionSettingsResourceHandle(t *testing.T) {
+	handle := NewSessionSettingsResourceHandle()
+
+	assert.NotNil(t, handle)
+	assert.NotNil(t, handle.MetaData())
+	assert.Equal(t, ResourceInstanaSessionSettings, handle.MetaData().ResourceName)
+}
+
+func TestSessionSettingsSchema(t *testing.T) {
+	sch := handleSchema()
+
+	assert.Contains(t, sch.Attributes, SessionSettingsFieldTokenLifeTimeInMillis)
+	assert.Contains(t, sch.Attributes, SessionSettingsFieldIdleTimeInMillis)
+}
+
+// ---- SetComputedFields ----
+
+func TestSessionSettingsSetComputedFields(t *testing.T) {
+	handle := &sessionSettingsResourceHandle{}
+	plan := &tfsdk.Plan{Schema: handleSchema()}
+
+	diags := handle.SetComputedFields(context.Background(), plan)
+
+	assert.False(t, diags.HasError())
+}
+
+// ---- MapStateToDataObject ----
+
+func TestSessionSettingsMapStateToDataObject_FromPlan(t *testing.T) {
+	ctx := context.Background()
+	sch := handleSchema()
+
+	plan := &tfsdk.Plan{Schema: sch}
+	require.False(t, plan.Set(ctx, &SessionSettingsModel{
+		TokenLifeTimeInMillis: types.Int64Value(28800000),
+		IdleTimeInMillis:      types.Int64Value(3600000),
+	}).HasError())
+
+	handle := &sessionSettingsResourceHandle{}
+	settings, diags := handle.MapStateToDataObject(ctx, plan, nil)
+
+	assert.False(t, diags.HasError())
+	require.NotNil(t, settings)
+	assert.Equal(t, int64(28800000), settings.TokenLifeTimeInMillis)
+	assert.Equal(t, int64(3600000), settings.IdleTimeInMillis)
+}
+
+func TestSessionSettingsMapStateToDataObject_FromState(t *testing.T) {
+	ctx := context.Background()
+	sch := handleSchema()
+
+	state := &tfsdk.State{Schema: sch}
+	require.False(t, state.Set(ctx, &SessionSettingsModel{
+		TokenLifeTimeInMillis: types.Int64Value(604800000),
+		IdleTimeInMillis:      types.Int64Value(28800000),
+	}).HasError())
+
+	handle := &sessionSettingsResourceHandle{}
+	settings, diags := handle.MapStateToDataObject(ctx, nil, state)
+
+	assert.False(t, diags.HasError())
+	require.NotNil(t, settings)
+	assert.Equal(t, int64(604800000), settings.TokenLifeTimeInMillis)
+	assert.Equal(t, int64(28800000), settings.IdleTimeInMillis)
+}
+
+// ---- UpdateState ----
+
+func TestSessionSettingsUpdateState(t *testing.T) {
+	ctx := context.Background()
+	sch := handleSchema()
+
+	state := &tfsdk.State{Schema: sch}
+	apiObj := &restapi.SessionSettings{
+		TokenLifeTimeInMillis: 28800000,
+		IdleTimeInMillis:      3600000,
+	}
+
+	handle := &sessionSettingsResourceHandle{}
+	diags := handle.UpdateState(ctx, state, nil, apiObj)
+
+	assert.False(t, diags.HasError())
+
+	var model SessionSettingsModel
+	require.False(t, state.Get(ctx, &model).HasError())
+	assert.Equal(t, int64(28800000), model.TokenLifeTimeInMillis.ValueInt64())
+	assert.Equal(t, int64(3600000), model.IdleTimeInMillis.ValueInt64())
+}
+
+// ---- GetStateUpgraders ----
+
+func TestSessionSettingsGetStateUpgraders(t *testing.T) {
+	handle := &sessionSettingsResourceHandle{}
+	upgraders := handle.GetStateUpgraders(context.Background())
+	assert.NotNil(t, upgraders)
+	assert.Empty(t, upgraders)
+}
+
+// ---- GetSingletonRestResource (via mock) ----
+
+// mockInstanaAPI is a minimal stub that satisfies the client.InstanaAPI interface
+// just enough for GetSingletonRestResource to be called in tests.
+type mockInstanaAPIForSingleton struct {
+	singleton *mockSingletonRestResource
+}
+
+func (m *mockInstanaAPIForSingleton) SessionSettings() interface{ Get() (*restapi.SessionSettings, error) } {
+	return m.singleton
+}
+
+// We test GetSingletonRestResource indirectly through the full round-trip below
+// using the singleton mock directly rather than constructing a full client.InstanaAPI stub,
+// because wiring up all 30+ interface methods just for one method would be noisy.
+
+// ---- round-trip via handle methods ----
+
+func TestSessionSettingsRoundTrip_MapAndUpdateState(t *testing.T) {
+	ctx := context.Background()
+	sch := handleSchema()
+	handle := &sessionSettingsResourceHandle{}
+
+	// Build plan
+	plan := &tfsdk.Plan{Schema: sch}
+	require.False(t, plan.Set(ctx, &SessionSettingsModel{
+		TokenLifeTimeInMillis: types.Int64Value(28800000),
+		IdleTimeInMillis:      types.Int64Value(3600000),
+	}).HasError())
+
+	// Map plan → API object
+	apiObj, diags := handle.MapStateToDataObject(ctx, plan, nil)
+	require.False(t, diags.HasError())
+	assert.Equal(t, int64(28800000), apiObj.TokenLifeTimeInMillis)
+	assert.Equal(t, int64(3600000), apiObj.IdleTimeInMillis)
+
+	// API object → state
+	state := &tfsdk.State{Schema: sch}
+	diags = handle.UpdateState(ctx, state, nil, apiObj)
+	require.False(t, diags.HasError())
+
+	var model SessionSettingsModel
+	require.False(t, state.Get(ctx, &model).HasError())
+	assert.Equal(t, int64(28800000), model.TokenLifeTimeInMillis.ValueInt64())
+	assert.Equal(t, int64(3600000), model.IdleTimeInMillis.ValueInt64())
+}
+
+// ---- singleton mock used in provider layer tests ----
+
+func TestMockSingletonRestResource_Upsert(t *testing.T) {
+	m := &mockSingletonRestResource{
+		upsertResult: &restapi.SessionSettings{TokenLifeTimeInMillis: 10, IdleTimeInMillis: 20},
+	}
+	res, err := m.Upsert(&restapi.SessionSettings{})
+	assert.NoError(t, err)
+	assert.Equal(t, int64(10), res.TokenLifeTimeInMillis)
+	assert.True(t, m.upsertCalled)
+}
+
+func TestMockSingletonRestResource_Get(t *testing.T) {
+	m := &mockSingletonRestResource{
+		getResult: &restapi.SessionSettings{TokenLifeTimeInMillis: 5, IdleTimeInMillis: 6},
+	}
+	res, err := m.Get()
+	assert.NoError(t, err)
+	assert.Equal(t, int64(5), res.TokenLifeTimeInMillis)
+}
+
+func TestMockSingletonRestResource_Delete(t *testing.T) {
+	m := &mockSingletonRestResource{}
+	assert.NoError(t, m.Delete())
+	assert.True(t, m.deleteCalled)
+}
+
+func TestMockSingletonRestResource_Errors(t *testing.T) {
+	errMsg := errors.New("boom")
+
+	t.Run("upsert error", func(t *testing.T) {
+		m := &mockSingletonRestResource{upsertErr: errMsg}
+		_, err := m.Upsert(&restapi.SessionSettings{})
+		assert.ErrorIs(t, err, errMsg)
+	})
+
+	t.Run("get error", func(t *testing.T) {
+		m := &mockSingletonRestResource{getErr: errMsg}
+		_, err := m.Get()
+		assert.ErrorIs(t, err, errMsg)
+	})
+
+	t.Run("delete error", func(t *testing.T) {
+		m := &mockSingletonRestResource{deleteErr: errMsg}
+		assert.ErrorIs(t, m.Delete(), errMsg)
+	})
+}

--- a/internal/resources/sessionsettings/resource-session-settings_test.go
+++ b/internal/resources/sessionsettings/resource-session-settings_test.go
@@ -114,6 +114,45 @@ func TestSessionSettingsMapStateToDataObject_FromState(t *testing.T) {
 	assert.Equal(t, int64(28800000), settings.IdleTimeInMillis)
 }
 
+func TestSessionSettingsMapStateToDataObject_IdleGreaterThanToken_ReturnsError(t *testing.T) {
+	ctx := context.Background()
+	sch := handleSchema()
+
+	plan := &tfsdk.Plan{Schema: sch}
+	require.False(t, plan.Set(ctx, &SessionSettingsModel{
+		TokenLifeTimeInMillis: types.Int64Value(3600000),  // 1 hour
+		IdleTimeInMillis:      types.Int64Value(28800000), // 8 hours — larger than token lifetime
+	}).HasError())
+
+	handle := &sessionSettingsResourceHandle{}
+	settings, diags := handle.MapStateToDataObject(ctx, plan, nil)
+
+	assert.True(t, diags.HasError())
+	assert.Nil(t, settings)
+	assert.Contains(t, diags[0].Detail(), "idle_time_in_millis must not be greater than token_life_time_in_millis")
+}
+
+func TestSessionSettingsMapStateToDataObject_IdleEqualToToken_IsValid(t *testing.T) {
+	ctx := context.Background()
+	sch := handleSchema()
+
+	plan := &tfsdk.Plan{Schema: sch}
+	require.False(t, plan.Set(ctx, &SessionSettingsModel{
+		TokenLifeTimeInMillis: types.Int64Value(3600000),
+		IdleTimeInMillis:      types.Int64Value(3600000), // equal — must be allowed
+	}).HasError())
+
+	handle := &sessionSettingsResourceHandle{}
+	settings, diags := handle.MapStateToDataObject(ctx, plan, nil)
+
+	assert.False(t, diags.HasError())
+	require.NotNil(t, settings)
+	assert.Equal(t, int64(3600000), settings.TokenLifeTimeInMillis)
+	assert.Equal(t, int64(3600000), settings.IdleTimeInMillis)
+}
+
+
+
 // ---- UpdateState ----
 
 func TestSessionSettingsUpdateState(t *testing.T) {
@@ -141,9 +180,9 @@ func TestSessionSettingsUpdateState(t *testing.T) {
 
 func TestSessionSettingsGetStateUpgraders(t *testing.T) {
 	handle := &sessionSettingsResourceHandle{}
+	// Returns nil — no state schema migrations are needed for this resource.
 	upgraders := handle.GetStateUpgraders(context.Background())
-	assert.NotNil(t, upgraders)
-	assert.Empty(t, upgraders)
+	assert.Nil(t, upgraders)
 }
 
 // ---- GetSingletonRestResource (via mock) ----

--- a/internal/resources/sessionsettings/session-settings-constants.go
+++ b/internal/resources/sessionsettings/session-settings-constants.go
@@ -1,0 +1,52 @@
+package sessionsettings
+
+// ResourceInstanaSessionSettings is the name of the terraform resource for session settings.
+const ResourceInstanaSessionSettings = "session_settings"
+
+// Schema field name constants
+const (
+	// SessionSettingsFieldTokenLifeTimeInMillis constant for the token lifetime field
+	SessionSettingsFieldTokenLifeTimeInMillis = "token_life_time_in_millis"
+	// SessionSettingsFieldIdleTimeInMillis constant for the idle time field
+	SessionSettingsFieldIdleTimeInMillis = "idle_time_in_millis"
+)
+
+// Resource description constants
+const (
+	// SessionSettingsDescResource describes the resource purpose
+	SessionSettingsDescResource = "Manages the tenant unit session settings in Instana, " +
+		"including token lifetime and idle timeout configuration. " +
+		"This is a singleton resource — only one instance exists per tenant unit."
+	// SessionSettingsDescTokenLifeTime describes the token lifetime field
+	SessionSettingsDescTokenLifeTime = "Maximum lifetime of an authentication token in milliseconds. " +
+		"Valid range: 600000 (10 min) to 604800000 (7 days)."
+	// SessionSettingsDescIdleTime describes the idle time field
+	SessionSettingsDescIdleTime = "Idle timeout before a session expires in milliseconds. " +
+		"Valid range: 600000 (10 min) to 28800000 (8 hours)."
+)
+
+// Validation constants enforced by the Instana API
+const (
+	// SessionSettingsMinTokenLifeTimeInMillis minimum token lifetime (10 minutes)
+	SessionSettingsMinTokenLifeTimeInMillis = 600000
+	// SessionSettingsMaxTokenLifeTimeInMillis maximum token lifetime (7 days)
+	SessionSettingsMaxTokenLifeTimeInMillis = 604800000
+	// SessionSettingsDefaultTokenLifeTimeInMillis default token lifetime (7 days)
+	SessionSettingsDefaultTokenLifeTimeInMillis = 604800000
+	// SessionSettingsMinIdleTimeInMillis minimum idle time (10 minutes)
+	SessionSettingsMinIdleTimeInMillis = 600000
+	// SessionSettingsMaxIdleTimeInMillis maximum idle time (8 hours)
+	SessionSettingsMaxIdleTimeInMillis = 28800000
+	// SessionSettingsDefaultIdleTimeInMillis default idle time (8 hours)
+	SessionSettingsDefaultIdleTimeInMillis = 28800000
+)
+
+// Error message constants
+const (
+	// SessionSettingsErrRetrievingPlan error message for plan retrieval failures
+	SessionSettingsErrRetrievingPlan = "Error retrieving plan data"
+	// SessionSettingsErrRetrievingState error message for state retrieval failures
+	SessionSettingsErrRetrievingState = "Error retrieving state data"
+	// SessionSettingsErrUpdatingState error message for state update failures
+	SessionSettingsErrUpdatingState = "Error updating state"
+)

--- a/internal/resources/sessionsettings/session-settings-constants.go
+++ b/internal/resources/sessionsettings/session-settings-constants.go
@@ -41,12 +41,3 @@ const (
 	SessionSettingsDefaultIdleTimeInMillis = 28800000
 )
 
-// Error message constants
-const (
-	// SessionSettingsErrRetrievingPlan error message for plan retrieval failures
-	SessionSettingsErrRetrievingPlan = "Error retrieving plan data"
-	// SessionSettingsErrRetrievingState error message for state retrieval failures
-	SessionSettingsErrRetrievingState = "Error retrieving state data"
-	// SessionSettingsErrUpdatingState error message for state update failures
-	SessionSettingsErrUpdatingState = "Error updating state"
-)

--- a/internal/resources/sessionsettings/session-settings-model.go
+++ b/internal/resources/sessionsettings/session-settings-model.go
@@ -1,0 +1,9 @@
+package sessionsettings
+
+import "github.com/hashicorp/terraform-plugin-framework/types"
+
+// SessionSettingsModel is the Terraform model for session settings.
+type SessionSettingsModel struct {
+	TokenLifeTimeInMillis types.Int64 `tfsdk:"token_life_time_in_millis"`
+	IdleTimeInMillis      types.Int64 `tfsdk:"idle_time_in_millis"`
+}

--- a/testutils/mock-instana-api.go
+++ b/testutils/mock-instana-api.go
@@ -169,3 +169,8 @@ func (m *MockInstanaAPI) MaintenanceWindowConfigs() rest.RestResource[*api.Maint
 func (m *MockInstanaAPI) GroupMappings() rest.RestResource[*api.GroupMapping] {
 	return nil
 }
+
+// SessionSettings mock implementation
+func (m *MockInstanaAPI) SessionSettings() rest.SingletonRestResource[*api.SessionSettings] {
+	return nil
+}


### PR DESCRIPTION
## Summary
Adds a new Terraform resource `instana_session_settings` for managing the tenant-level session
settings in Instana. This resource controls two key security parameters: the maximum lifetime of
an authentication token and the idle session timeout before a user is logged out.

### Notes

- This is a tenant-level singleton. At most one `instana_session_settings` block should be
  declared per Terraform configuration.