### PR TITLE
feat : new resource for slo credentials

### DIFF
--- a/docs/resources/synthetic_credential.md
+++ b/docs/resources/synthetic_credential.md
@@ -1,0 +1,146 @@
+# Synthetic Credential Resource
+
+Manages synthetic credentials in Instana. Synthetic credentials store encrypted secret values (such as passwords, API tokens, or other sensitive strings) that can be referenced inside synthetic API script tests without exposing them in plain text.
+
+API Documentation: [Synthetic credentials](https://developer.ibm.com/apis/catalog/instana--instana-rest-api/api/API--instana--instana-rest-api-documentation#createSyntheticCredential)
+
+## Example Usage
+
+### Basic Credential
+
+Create a simple credential with a name and a secret value:
+
+```hcl
+resource "instana_synthetic_credential" "api_token" {
+  credential_name  = "api_token"
+  credential_value = "my-secret-token" # use a secret store or variable in practice
+}
+```
+
+### Credential Scoped to Applications
+
+Restrict which Application Perspectives can use this credential:
+
+```hcl
+resource "instana_synthetic_credential" "db_password" {
+  credential_name  = "db_password"
+  credential_value = var.db_password
+
+  applications = [
+    "NQIAsj1tSJm2zxMQx78MSA", # replace with actual application IDs
+    "ZpQrTs2uVJn3axNRy89LTA",
+  ]
+}
+```
+
+### Credential with RBAC Tags
+
+Control which teams can view and manage the credential:
+
+```hcl
+resource "instana_synthetic_credential" "service_key" {
+  credential_name  = "service_key"
+  credential_value = var.service_key
+
+  rbac_tags = [
+    {
+      id           = "team-id-1234"  # replace with actual team ID
+      display_name = "Platform Team" # replace with actual team display name
+    }
+  ]
+}
+```
+
+## Generating Configuration from Existing Resources
+
+If you have already created a synthetic credential in Instana and want to generate the Terraform configuration for it, you can use Terraform's import block feature with the `-generate-config-out` flag.
+
+This approach is also helpful when you're unsure about the correct Terraform structure for a specific resource configuration. Simply create the resource in Instana first, then use this functionality to automatically generate the corresponding Terraform configuration.
+
+### Steps to Generate Configuration:
+
+1. **Get the Credential Name**: Locate the name of your synthetic credential in Instana. You can find this in the Instana UI under **Synthetic Settings → Credentials** or via the API.
+
+2. **Create an Import Block**: Create a new `.tf` file (e.g., `import.tf`) with an import block:
+
+```hcl
+import {
+  to = instana_synthetic_credential.example
+  id = "my_credential_name"
+}
+```
+
+Replace:
+- `example` with your desired Terraform block name
+- `my_credential_name` with the actual credential name from Instana
+
+3. **Generate the Configuration**: Run the following Terraform command:
+
+```bash
+terraform plan -generate-config-out=generated.tf
+```
+
+This will:
+- Import the existing resource state
+- Generate the complete Terraform configuration in `generated.tf`
+- Show you what will be imported
+
+4. **Add the Credential Value**: Because the credential value is **write-only** (the API never returns it after creation), the generated configuration will not contain `credential_value`. You must add it manually before running `terraform apply`:
+
+```hcl
+# generated.tf — add credential_value before applying
+resource "instana_synthetic_credential" "example" {
+  credential_name  = "my_credential_name"
+  credential_value = var.my_credential_value # add this line
+}
+```
+
+5. **Review and Apply**: Review the configuration and run:
+
+```bash
+terraform apply
+```
+
+## Argument Reference
+
+* `credential_name` - **Required** - The unique name that identifies the credential. Used as the resource ID. Must start with a letter and can only contain letters, numbers and underscores. Maximum length is 64 characters. **Changing this value forces the resource to be destroyed and re-created.**
+* `credential_value` - **Optional (Required on create/update)** - The secret value of the credential. This field is **write-only**: Instana stores it encrypted and never returns it via the API. The field must be provided when creating or updating the resource. After an `import`, add this attribute to your configuration and run `terraform apply` to complete the import. See [Write-Only Credential Value](#write-only-credential-value) for details.
+* `applications` - Optional - Set of Application Perspective IDs that are allowed to use this credential. When empty, the credential is not scoped to any application. Computed: the API returns the current list on read.
+* `mobile_apps` - Optional - Set of mobile app IDs that are allowed to use this credential. Computed: preserved from state on read as the API does not return this field.
+* `websites` - Optional - Set of website IDs that are allowed to use this credential. Computed: preserved from state on read as the API does not return this field.
+* `rbac_tags` - Optional - Set of RBAC tags for access control. Computed: preserved from state on read as the API does not return this field. [Details](#rbac-tags-reference)
+
+### RBAC Tags Reference
+
+* `id` - Required - The ID of the RBAC tag (team).
+* `display_name` - Required - The display name of the RBAC tag (team).
+
+## Attributes Reference
+
+* `credential_name` - The name of the synthetic credential (also serves as the resource ID).
+
+## Write-Only Credential Value
+
+The `credential_value` attribute is **write-only**. Instana stores the value encrypted and never exposes it through the API. As a result:
+
+* Terraform cannot detect drift on `credential_value` — if the value is changed in Instana outside of Terraform, a plan will show no diff.
+* After `terraform import`, the `credential_value` field will be absent from state. Add it to your configuration and run `terraform apply` to populate it.
+* Store sensitive values in a secrets manager or use Terraform input variables marked `sensitive = true` rather than hardcoding them in your configuration.
+
+## Import
+
+Synthetic credentials can be imported using the credential name as the `id`, e.g.:
+
+```bash
+$ terraform import instana_synthetic_credential.example my_credential_name
+```
+
+After importing, add `credential_value` to your configuration and run `terraform apply` to complete the import.
+
+## Notes
+
+* The credential name serves as both the resource identifier and the Terraform resource ID — changing it forces a destroy and re-create.
+* Credential names must start with a letter and may only contain letters, numbers, and underscores (max 64 characters).
+* The credential value is encrypted at rest by Instana and is never returned by the API.
+* The `applications`, `mobile_apps`, `websites`, and `rbac_tags` fields control the scope and visibility of the credential.
+* The `applications` field is returned and refreshed on every read; `mobile_apps`, `websites`, and `rbac_tags` are preserved from state because the API does not return them.

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.18.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.36.1
-	github.com/instana/instana-go-client v1.2.0
+	github.com/instana/instana-go-client v1.3.0
 	github.com/rs/xid v1.5.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,8 @@ github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8=
 github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
-github.com/instana/instana-go-client v1.2.0 h1:5mgX6nNWBWefZyElas5vIE75V8OlOJzjvdE4gp5ABq8=
-github.com/instana/instana-go-client v1.2.0/go.mod h1:aOe+HQWz3md7VSvKrdeT+aso7sxzobWuXvyaTwIos3Q=
+github.com/instana/instana-go-client v1.3.0 h1:TKIuu8VWzoT3BSzM+kwh+UMUzLZIeeSbpS3e3c035Eo=
+github.com/instana/instana-go-client v1.3.0/go.mod h1:aOe+HQWz3md7VSvKrdeT+aso7sxzobWuXvyaTwIos3Q=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=
 github.com/jhump/protoreflect v1.17.0/go.mod h1:h9+vUUL38jiBzck8ck+6G/aeMX8Z4QUY/NiJPwPNi+8=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -44,6 +44,7 @@ import (
 	"github.com/instana/terraform-provider-instana/internal/resources/sloconfig"
 	"github.com/instana/terraform-provider-instana/internal/resources/slocorrectionconfig"
 	"github.com/instana/terraform-provider-instana/internal/resources/syntheticalertconfig"
+	"github.com/instana/terraform-provider-instana/internal/resources/syntheticcredential"
 	"github.com/instana/terraform-provider-instana/internal/resources/synthetictest"
 	"github.com/instana/terraform-provider-instana/internal/resources/team"
 	"github.com/instana/terraform-provider-instana/internal/resources/websitealertconfig"
@@ -370,6 +371,7 @@ func (p *InstanaProvider) Resources(_ context.Context) []func() resource.Resourc
 		addResouceHandle(sloalertconfig.NewSloAlertConfigResourceHandle),
 		addResouceHandle(slocorrectionconfig.NewSloCorrectionConfigResourceHandle),
 		addResouceHandle(syntheticalertconfig.NewSyntheticAlertConfigResourceHandle),
+		addResouceHandle(syntheticcredential.NewSyntheticCredentialResourceHandle),
 		addResouceHandle(synthetictest.NewSyntheticTestResourceHandle),
 		addResouceHandle(websitealertconfig.NewWebsiteAlertConfigResourceHandle),
 		addResouceHandle(websitemonitoringconfig.NewWebsiteMonitoringConfigResourceHandle),

--- a/internal/resources/roles/resource-roles.go
+++ b/internal/resources/roles/resource-roles.go
@@ -49,6 +49,7 @@ func buildRoleSchema() schema.Schema {
 			RoleFieldMembers: schema.SetNestedAttribute{
 				Description:  RoleDescMembers,
 				Optional:     true,
+				Computed:     true,
 				NestedObject: buildMemberNestedObject(),
 			},
 			RoleFieldPermissions: schema.SetAttribute{

--- a/internal/resources/syntheticcredential/resource-synthetic-credential-constants.go
+++ b/internal/resources/syntheticcredential/resource-synthetic-credential-constants.go
@@ -1,0 +1,27 @@
+package syntheticcredential
+
+// ResourceInstanaSyntheticCredential the name of the terraform-provider-instana resource to manage synthetic credentials
+const ResourceInstanaSyntheticCredential = "synthetic_credential"
+
+const (
+	// Field name constants
+	SyntheticCredentialFieldCredentialName  = "credential_name"
+	SyntheticCredentialFieldCredentialValue = "credential_value"
+	SyntheticCredentialFieldApplications    = "applications"
+	SyntheticCredentialFieldMobileApps      = "mobile_apps"
+	SyntheticCredentialFieldWebsites        = "websites"
+	SyntheticCredentialFieldRbacTags        = "rbac_tags"
+	SyntheticCredentialFieldRbacTagID       = "id"
+	SyntheticCredentialFieldRbacTagName     = "display_name"
+
+	// Description constants
+	SyntheticCredentialDescResource       = "This resource manages Synthetic Credentials in Instana."
+	SyntheticCredentialDescCredentialName = "The unique name of the credential. This serves as the identifier for the resource."
+	SyntheticCredentialDescCredentialValue = "The secret value of the credential. This field is write-only and will not be read back from the API."
+	SyntheticCredentialDescApplications   = "List of application IDs the credential is scoped to."
+	SyntheticCredentialDescMobileApps     = "List of mobile app IDs the credential is scoped to."
+	SyntheticCredentialDescWebsites       = "List of website IDs the credential is scoped to."
+	SyntheticCredentialDescRbacTags       = "RBAC tags for access control."
+	SyntheticCredentialDescRbacTagID      = "The ID of the RBAC tag."
+	SyntheticCredentialDescRbacTagName    = "The display name of the RBAC tag."
+)

--- a/internal/resources/syntheticcredential/resource-synthetic-credential-model.go
+++ b/internal/resources/syntheticcredential/resource-synthetic-credential-model.go
@@ -1,0 +1,19 @@
+package syntheticcredential
+
+import "github.com/hashicorp/terraform-plugin-framework/types"
+
+// SyntheticCredentialModel is the Terraform state model for a Synthetic Credential
+type SyntheticCredentialModel struct {
+	CredentialName  types.String `tfsdk:"credential_name"`
+	CredentialValue types.String `tfsdk:"credential_value"`
+	Applications    types.Set    `tfsdk:"applications"`
+	MobileApps      types.Set    `tfsdk:"mobile_apps"`
+	Websites        types.Set    `tfsdk:"websites"`
+	RbacTags        types.Set    `tfsdk:"rbac_tags"`
+}
+
+// SyntheticCredentialRbacTagModel represents an RBAC tag within the credential resource
+type SyntheticCredentialRbacTagModel struct {
+	ID          types.String `tfsdk:"id"`
+	DisplayName types.String `tfsdk:"display_name"`
+}

--- a/internal/resources/syntheticcredential/resource-synthetic-credential.go
+++ b/internal/resources/syntheticcredential/resource-synthetic-credential.go
@@ -1,0 +1,288 @@
+package syntheticcredential
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/instana/instana-go-client/api"
+	"github.com/instana/instana-go-client/client"
+	"github.com/instana/instana-go-client/shared/rest"
+	"github.com/instana/terraform-provider-instana/internal/resourcehandle"
+)
+
+// NewSyntheticCredentialResourceHandle creates the resource handle for Synthetic Credentials
+func NewSyntheticCredentialResourceHandle() resourcehandle.ResourceHandle[*api.SyntheticCredential] {
+	return &syntheticCredentialResource{
+		metaData: resourcehandle.ResourceMetaData{
+			ResourceName:     ResourceInstanaSyntheticCredential,
+			Schema:           buildSyntheticCredentialSchema(),
+			SchemaVersion:    1,
+			SkipIDGeneration: true,
+			ResourceIDField:  strPtr(SyntheticCredentialFieldCredentialName),
+		},
+	}
+}
+
+func strPtr(s string) *string {
+	return &s
+}
+
+func buildSyntheticCredentialSchema() schema.Schema {
+	return schema.Schema{
+		Description: SyntheticCredentialDescResource,
+		Attributes: map[string]schema.Attribute{
+			SyntheticCredentialFieldCredentialName: schema.StringAttribute{
+				Required:    true,
+				Description: SyntheticCredentialDescCredentialName,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			SyntheticCredentialFieldCredentialValue: schema.StringAttribute{
+				Optional:  true,
+				Sensitive: true,
+				Description: SyntheticCredentialDescCredentialValue,
+				// The API never returns this value. UseStateForUnknown keeps the existing
+				// value in state across reads so no spurious diff is produced.
+				// Optional (not Required) so that `terraform import` succeeds — import
+				// only populates credential_name; the user must add credential_value to
+				// their config and run `terraform apply` afterwards.
+				// Enforcement that the value is present happens in MapStateToDataObject
+				// (called only during apply, not plan) so that post-import plans succeed.
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			SyntheticCredentialFieldApplications: schema.SetAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: SyntheticCredentialDescApplications,
+				ElementType: types.StringType,
+			},
+			SyntheticCredentialFieldMobileApps: schema.SetAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: SyntheticCredentialDescMobileApps,
+				ElementType: types.StringType,
+			},
+			SyntheticCredentialFieldWebsites: schema.SetAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: SyntheticCredentialDescWebsites,
+				ElementType: types.StringType,
+			},
+			SyntheticCredentialFieldRbacTags: schema.SetNestedAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: SyntheticCredentialDescRbacTags,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						SyntheticCredentialFieldRbacTagID: schema.StringAttribute{
+							Required:    true,
+							Description: SyntheticCredentialDescRbacTagID,
+						},
+						SyntheticCredentialFieldRbacTagName: schema.StringAttribute{
+							Required:    true,
+							Description: SyntheticCredentialDescRbacTagName,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+type syntheticCredentialResource struct {
+	metaData resourcehandle.ResourceMetaData
+}
+
+func (r *syntheticCredentialResource) MetaData() *resourcehandle.ResourceMetaData {
+	return &r.metaData
+}
+
+func (r *syntheticCredentialResource) GetRestResource(instanaAPI client.InstanaAPI) rest.RestResource[*api.SyntheticCredential] {
+	return instanaAPI.SyntheticCredentials()
+}
+
+func (r *syntheticCredentialResource) SetComputedFields(_ context.Context, _ *tfsdk.Plan) diag.Diagnostics {
+	return nil
+}
+
+func (r *syntheticCredentialResource) GetStateUpgraders(_ context.Context) map[int64]resource.StateUpgrader {
+	return nil
+}
+
+// MapStateToDataObject maps the Terraform plan/state to the API model
+func (r *syntheticCredentialResource) MapStateToDataObject(ctx context.Context, plan *tfsdk.Plan, state *tfsdk.State) (*api.SyntheticCredential, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	var model SyntheticCredentialModel
+
+	if plan != nil {
+		diags.Append(plan.Get(ctx, &model)...)
+	} else if state != nil {
+		diags.Append(state.Get(ctx, &model)...)
+	}
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	cred := &api.SyntheticCredential{
+		CredentialName: model.CredentialName.ValueString(),
+	}
+	// credential_value is write-only: the API never returns it. We only include it
+	// in the payload when the user has actually provided it in their config.
+	// If it is null here during a create/update (plan is non-nil), the user omitted
+	// it from their config — return an error rather than silently sending an empty
+	// value to the API.
+	// During delete (state is non-nil, plan is nil) the value may be null if the
+	// resource was imported without it; that is fine because delete only needs the name.
+	if !model.CredentialValue.IsNull() && !model.CredentialValue.IsUnknown() {
+		cred.CredentialValue = model.CredentialValue.ValueString()
+	} else if plan != nil {
+		// plan != nil means this is a create or update — value is required.
+		diags.AddAttributeError(
+			path.Root(SyntheticCredentialFieldCredentialValue),
+			"Missing required attribute",
+			fmt.Sprintf(
+				"%s must be set before applying. Add it to your configuration and run terraform apply again.",
+				SyntheticCredentialFieldCredentialValue,
+			),
+		)
+		return nil, diags
+	}
+
+	// Applications
+	if !model.Applications.IsNull() && !model.Applications.IsUnknown() {
+		var apps []string
+		diags.Append(model.Applications.ElementsAs(ctx, &apps, false)...)
+		cred.Applications = apps
+	}
+
+	// MobileApps
+	if !model.MobileApps.IsNull() && !model.MobileApps.IsUnknown() {
+		var mobileApps []string
+		diags.Append(model.MobileApps.ElementsAs(ctx, &mobileApps, false)...)
+		cred.MobileApps = mobileApps
+	}
+
+	// Websites
+	if !model.Websites.IsNull() && !model.Websites.IsUnknown() {
+		var websites []string
+		diags.Append(model.Websites.ElementsAs(ctx, &websites, false)...)
+		cred.Websites = websites
+	}
+
+	// RbacTags
+	if !model.RbacTags.IsNull() && !model.RbacTags.IsUnknown() {
+		var tagModels []SyntheticCredentialRbacTagModel
+		diags.Append(model.RbacTags.ElementsAs(ctx, &tagModels, false)...)
+		if !diags.HasError() {
+			for _, t := range tagModels {
+				cred.RbacTags = append(cred.RbacTags, api.RbacTag{
+					ID:          t.ID.ValueString(),
+					DisplayName: t.DisplayName.ValueString(),
+				})
+			}
+		}
+	}
+
+	return cred, diags
+}
+
+// UpdateState maps the API response back to the Terraform state.
+//
+// The associations GET endpoint returns only credentialName, applications, applicationLabels,
+// createdAt and modifiedAt — it does NOT return credentialValue, rbacTags, mobileApps or
+// websites. Those fields are preserved verbatim from the plan (after create/update) or the
+// previous state (after read) so that Terraform does not see a spurious diff.
+func (r *syntheticCredentialResource) UpdateState(ctx context.Context, state *tfsdk.State, plan *tfsdk.Plan, apiObject *api.SyntheticCredential) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	// src is the plan when called after create/update, or the prior state when called after read.
+	type stateGetter interface {
+		GetAttribute(context.Context, path.Path, interface{}) diag.Diagnostics
+	}
+	var src stateGetter
+	if plan != nil {
+		src = plan
+	} else if state != nil {
+		src = state
+	}
+
+	// Preserve fields that the API never echoes back.
+	var credentialValue types.String
+	var rbacTags types.Set
+	var mobileApps types.Set
+	var websites types.Set
+
+	if src != nil {
+		diags.Append(src.GetAttribute(ctx, path.Root(SyntheticCredentialFieldCredentialValue), &credentialValue)...)
+		diags.Append(src.GetAttribute(ctx, path.Root(SyntheticCredentialFieldRbacTags), &rbacTags)...)
+		diags.Append(src.GetAttribute(ctx, path.Root(SyntheticCredentialFieldMobileApps), &mobileApps)...)
+		diags.Append(src.GetAttribute(ctx, path.Root(SyntheticCredentialFieldWebsites), &websites)...)
+	}
+	if diags.HasError() {
+		return diags
+	}
+
+	// Ensure preserved sets are never null/unknown to avoid framework type errors.
+	if rbacTags.IsNull() || rbacTags.IsUnknown() {
+		rbacTags = emptyRbacTagSet()
+	}
+	if mobileApps.IsNull() || mobileApps.IsUnknown() {
+		mobileApps = types.SetValueMust(types.StringType, nil)
+	}
+	if websites.IsNull() || websites.IsUnknown() {
+		websites = types.SetValueMust(types.StringType, nil)
+	}
+
+	model := SyntheticCredentialModel{
+		CredentialName:  types.StringValue(apiObject.CredentialName),
+		CredentialValue: credentialValue,
+		// applications is returned by the associations endpoint — use the API value.
+		Applications: stringSliceToSet(apiObject.Applications),
+		// The remaining fields are not returned by the API — preserve from plan/state.
+		MobileApps: mobileApps,
+		Websites:   websites,
+		RbacTags:   rbacTags,
+	}
+
+	diags.Append(state.Set(ctx, &model)...)
+	return diags
+}
+
+// emptyRbacTagSet returns an empty set typed for the rbac_tag nested object.
+func emptyRbacTagSet() types.Set {
+	return types.SetValueMust(types.ObjectType{AttrTypes: rbacTagAttrTypes()}, nil)
+}
+
+// stringSliceToSet converts a string slice to a types.Set
+func stringSliceToSet(items []string) types.Set {
+	if len(items) == 0 {
+		return types.SetValueMust(types.StringType, []attr.Value{})
+	}
+	vals := make([]attr.Value, len(items))
+	for i, s := range items {
+		vals[i] = types.StringValue(s)
+	}
+	set, _ := types.SetValue(types.StringType, vals)
+	return set
+}
+
+// rbacTagAttrTypes returns the attribute types map for the rbac_tag nested object
+func rbacTagAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		SyntheticCredentialFieldRbacTagID:   types.StringType,
+		SyntheticCredentialFieldRbacTagName: types.StringType,
+	}
+}
+

--- a/testutils/mock-instana-api.go
+++ b/testutils/mock-instana-api.go
@@ -120,6 +120,11 @@ func (m *MockInstanaAPI) SyntheticLocations() rest.ReadOnlyRestResource[*api.Syn
 	return nil
 }
 
+// SyntheticCredentials mock implementation
+func (m *MockInstanaAPI) SyntheticCredentials() rest.RestResource[*api.SyntheticCredential] {
+	return nil
+}
+
 // SyntheticAlertConfigs mock implementation
 func (m *MockInstanaAPI) SyntheticAlertConfigs() rest.RestResource[*api.SyntheticAlertConfig] {
 	return nil


### PR DESCRIPTION
## Summary

This pull request introduces a new Terraform resource for managing **Instana Synthetic Credentials**. It bumps the `instana-go-client` dependency to `v1.3.0` (which adds the `SyntheticCredentials` API client), implements the full resource lifecycle (create, read, update, delete, and import), and wires the new resource into the provider registration. The resource uses `credential_name` as its unique identifier and treats `credential_value` as a write-only sensitive field, since the Instana API never returns it in responses.

---

## Description
This PR adds a new Terraform resource, instana_synthetic_credential, which enables users to manage Synthetic Credentials in Instana through Terraform.

Synthetic Credentials allow teams to store encrypted secret values — such as passwords, API tokens, or other sensitive strings — that can be referenced inside Synthetic tests without exposing them in plain text.