### PR TITLE
Add `instana_release` Terraform resource for managing Release Markers

### DIFF
--- a/docs/resources/release.md
+++ b/docs/resources/release.md
@@ -35,7 +35,7 @@ resource "instana_release" "backend_deployment" {
 
 ### Release Scoped to Services
 
-Associate a release with specific services:
+Associate a release with specific services (no scope restriction):
 
 ```hcl
 resource "instana_release" "service_release" {
@@ -49,9 +49,10 @@ resource "instana_release" "service_release" {
 }
 ```
 
-### Release Scoped to a Service in a Specific Application
+### Release Scoped to a Service in Specific Applications
 
-Restrict a service scope to a particular application perspective using `scoped_to`:
+Restrict a service scope to particular application perspectives using `scoped_to`.
+The `scoped_to.applications` list is required when `scoped_to` is set (minimum 1 entry):
 
 ```hcl
 resource "instana_release" "scoped_service_release" {
@@ -62,19 +63,19 @@ resource "instana_release" "scoped_service_release" {
     {
       name = "auth-service"
       scoped_to = {
-        application_name = "checkout-app"
+        applications = [
+          { name = "checkout-app" },
+        ]
       }
     },
   ]
 }
 ```
 
-### Release Scoped to a Service in a Specific Environment
-
-Restrict a service scope to a particular environment:
+### Service Scoped to Multiple Application Perspectives
 
 ```hcl
-resource "instana_release" "production_release" {
+resource "instana_release" "multi_scoped_release" {
   name  = "inventory/v4.0.0"
   start = 1742349976000
 
@@ -82,7 +83,10 @@ resource "instana_release" "production_release" {
     {
       name = "inventory-service"
       scoped_to = {
-        environment_name = "production"
+        applications = [
+          { name = "storefront-app" },
+          { name = "warehouse-app" },
+        ]
       }
     },
   ]
@@ -91,7 +95,7 @@ resource "instana_release" "production_release" {
 
 ### Full Release with Applications and Services
 
-Combine application perspectives, services, and full service scoping in a single release marker:
+Combine top-level application perspectives and scoped services in a single release marker:
 
 ```hcl
 resource "instana_release" "full_release" {
@@ -106,30 +110,13 @@ resource "instana_release" "full_release" {
     {
       name = "api-gateway"
       scoped_to = {
-        application_name = "platform-app"
-        environment_name = "production"
+        applications = [
+          { name = "platform-app" },
+        ]
       }
     },
     { name = "cache-service" },
   ]
-}
-```
-
-### Dynamic Release Timestamp
-
-Use Terraform's `timestamp()` function to mark a release at the time of the Terraform apply:
-
-> **Note:** Using `timestamp()` causes the resource to be recreated on every apply since the value changes each run. Use a fixed epoch millisecond value for stable releases.
-
-```hcl
-locals {
-  # Convert RFC3339 timestamp to milliseconds since epoch
-  release_time_ms = parseint(formatdate("YYYYMMDDhhmmss", timestamp()), 10)
-}
-
-resource "instana_release" "ci_deployment" {
-  name  = "ci/build-${var.build_number}"
-  start = 1742349976000  # Use a fixed value in practice
 }
 ```
 
@@ -174,22 +161,23 @@ terraform apply
 
 * `name` - Required - The name of the release. For example: `frontend/release-2000`. Maximum 256 characters.
 * `start` - Required - The timestamp (in milliseconds since epoch) for when the release occurs. Must be at least `1`. For example: `1742349976000` is Wednesday, 19 March 2025 02:06:16 UTC.
-* `applications` - Optional - A list of application perspectives where this release marker will be visible. Maximum 10 entries. Each entry contains: [Details](#application-scope-reference)
-* `services` - Optional - A list of services where this release marker will be visible. Maximum 10 entries. Each entry contains: [Details](#service-scope-reference)
+* `applications` - Optional - A list of application perspectives where this release marker will be visible (0–10 entries). Each entry: [Details](#application-scope-reference)
+* `services` - Optional - A list of services where this release marker will be visible (0–10 entries). Each entry: [Details](#service-scope-reference)
 
 ### Application Scope Reference
 
-* `name` - Required - The name of the Application Perspective. For example: `app1`. Maximum 256 characters.
+Used both in the top-level `applications` list and inside `scoped_to.applications`.
+
+* `name` - Required - The name of the Application Perspective. For example: `checkout-app`. Maximum 256 characters.
 
 ### Service Scope Reference
 
 * `name` - Required - The name of the Service. For example: `payment`. Maximum 256 characters.
-* `scoped_to` - Optional - An optional scope restriction to limit the service to a specific application or environment. [Details](#scoped-to-reference)
+* `scoped_to` - Optional - Restricts this service entry to specific application perspectives. When provided, `scoped_to.applications` is required. [Details](#scoped-to-reference)
 
 ### Scoped To Reference
 
-* `application_name` - Optional - The name of the Application Perspective to scope the service to.
-* `environment_name` - Optional - The name of the environment to scope the service to.
+* `applications` - Required (when `scoped_to` is set) - The list of application perspectives that scope this service (1–10 entries). Each entry follows the [Application Scope Reference](#application-scope-reference).
 
 ## Attributes Reference
 
@@ -209,6 +197,7 @@ $ terraform import instana_release.example Tiu16hLCTniHDtHb_uDV1w
 * The `id` and `last_updated` fields are computed by Instana and cannot be set in configuration.
 * The `start` timestamp is in **milliseconds** since the Unix epoch, not seconds.
 * `applications` and `services` each support a maximum of **10** entries per the Instana API.
+* When `scoped_to` is used, `scoped_to.applications` **must** contain at least 1 entry — the API rejects requests where `scopedTo.applications` is null or empty.
 * Release markers are visible in Instana's Application and Service dashboards when `applications` or `services` scopes are configured.
 * Deleting this resource will remove the release marker from Instana.
 * Required API token permission: `CanConfigureReleases`.

--- a/docs/resources/release.md
+++ b/docs/resources/release.md
@@ -1,0 +1,214 @@
+# Release Resource
+
+Manages release markers in Instana. Release markers allow you to annotate your monitoring timeline with deployment and release events, making it easy to correlate changes in service behaviour with specific releases or deployments.
+
+API Documentation: <https://developer.ibm.com/apis/catalog/instana--instana-rest-api/api/API--instana--instana-rest-api-documentation#postRelease>
+
+## Example Usage
+
+### Minimal Release
+
+Create a simple release marker with just a name and start timestamp:
+
+```hcl
+resource "instana_release" "deployment" {
+  name  = "frontend/release-2000"
+  start = 1742349976000
+}
+```
+
+### Release Scoped to Application Perspectives
+
+Associate a release with specific application perspectives so it is visible in those views:
+
+```hcl
+resource "instana_release" "backend_deployment" {
+  name  = "backend/v1.5.0"
+  start = 1742349976000
+
+  applications = [
+    { name = "checkout-app" },
+    { name = "payment-app" },
+  ]
+}
+```
+
+### Release Scoped to Services
+
+Associate a release with specific services:
+
+```hcl
+resource "instana_release" "service_release" {
+  name  = "payment-service/v2.0.0"
+  start = 1742349976000
+
+  services = [
+    { name = "payment" },
+    { name = "order-processor" },
+  ]
+}
+```
+
+### Release Scoped to a Service in a Specific Application
+
+Restrict a service scope to a particular application perspective using `scoped_to`:
+
+```hcl
+resource "instana_release" "scoped_service_release" {
+  name  = "auth-service/v3.1.0"
+  start = 1742349976000
+
+  services = [
+    {
+      name = "auth-service"
+      scoped_to = {
+        application_name = "checkout-app"
+      }
+    },
+  ]
+}
+```
+
+### Release Scoped to a Service in a Specific Environment
+
+Restrict a service scope to a particular environment:
+
+```hcl
+resource "instana_release" "production_release" {
+  name  = "inventory/v4.0.0"
+  start = 1742349976000
+
+  services = [
+    {
+      name = "inventory-service"
+      scoped_to = {
+        environment_name = "production"
+      }
+    },
+  ]
+}
+```
+
+### Full Release with Applications and Services
+
+Combine application perspectives, services, and full service scoping in a single release marker:
+
+```hcl
+resource "instana_release" "full_release" {
+  name  = "platform/v5.0.0"
+  start = 1742349976000
+
+  applications = [
+    { name = "platform-app" },
+  ]
+
+  services = [
+    {
+      name = "api-gateway"
+      scoped_to = {
+        application_name = "platform-app"
+        environment_name = "production"
+      }
+    },
+    { name = "cache-service" },
+  ]
+}
+```
+
+### Dynamic Release Timestamp
+
+Use Terraform's `timestamp()` function to mark a release at the time of the Terraform apply:
+
+> **Note:** Using `timestamp()` causes the resource to be recreated on every apply since the value changes each run. Use a fixed epoch millisecond value for stable releases.
+
+```hcl
+locals {
+  # Convert RFC3339 timestamp to milliseconds since epoch
+  release_time_ms = parseint(formatdate("YYYYMMDDhhmmss", timestamp()), 10)
+}
+
+resource "instana_release" "ci_deployment" {
+  name  = "ci/build-${var.build_number}"
+  start = 1742349976000  # Use a fixed value in practice
+}
+```
+
+## Generating Configuration from Existing Resources
+
+If you have already created a release in Instana and want to generate the Terraform configuration for it, you can use Terraform's import block feature with the `-generate-config-out` flag.
+
+### Steps to Generate Configuration:
+
+1. **Get the Resource ID**: Locate the ID of your release in Instana. You can find this in the Instana UI under Releases or via the API (`GET /api/releases`).
+
+2. **Create an Import Block**: Create a new `.tf` file (e.g., `import.tf`) with an import block:
+
+```hcl
+import {
+  to = instana_release.example
+  id = "resource_id"
+}
+```
+
+Replace:
+- `example` with your desired Terraform resource name
+- `resource_id` with your actual release ID from Instana (e.g., `Tiu16hLCTniHDtHb_uDV1w`)
+
+3. **Generate the Configuration**: Run the following Terraform command:
+
+```bash
+terraform plan -generate-config-out=generated.tf
+```
+
+4. **Review and Apply**:
+
+   - **To import the existing resource**: Keep the import block and run `terraform apply`. This will import the release into your Terraform state.
+
+   - **To create a new resource**: Remove the import block, modify the generated configuration as needed, and run `terraform apply` to create a new release.
+
+```bash
+terraform apply
+```
+
+## Argument Reference
+
+* `name` - Required - The name of the release. For example: `frontend/release-2000`. Maximum 256 characters.
+* `start` - Required - The timestamp (in milliseconds since epoch) for when the release occurs. Must be at least `1`. For example: `1742349976000` is Wednesday, 19 March 2025 02:06:16 UTC.
+* `applications` - Optional - A list of application perspectives where this release marker will be visible. Maximum 10 entries. Each entry contains: [Details](#application-scope-reference)
+* `services` - Optional - A list of services where this release marker will be visible. Maximum 10 entries. Each entry contains: [Details](#service-scope-reference)
+
+### Application Scope Reference
+
+* `name` - Required - The name of the Application Perspective. For example: `app1`. Maximum 256 characters.
+
+### Service Scope Reference
+
+* `name` - Required - The name of the Service. For example: `payment`. Maximum 256 characters.
+* `scoped_to` - Optional - An optional scope restriction to limit the service to a specific application or environment. [Details](#scoped-to-reference)
+
+### Scoped To Reference
+
+* `application_name` - Optional - The name of the Application Perspective to scope the service to.
+* `environment_name` - Optional - The name of the environment to scope the service to.
+
+## Attributes Reference
+
+* `id` - The unique ID of the release (auto-generated by Instana, e.g., `Tiu16hLCTniHDtHb_uDV1w`).
+* `last_updated` - The timestamp (in milliseconds since epoch) of the last update to this release (set by Instana).
+
+## Import
+
+Releases can be imported using the release `id`, e.g.:
+
+```bash
+$ terraform import instana_release.example Tiu16hLCTniHDtHb_uDV1w
+```
+
+## Notes
+
+* The `id` and `last_updated` fields are computed by Instana and cannot be set in configuration.
+* The `start` timestamp is in **milliseconds** since the Unix epoch, not seconds.
+* `applications` and `services` each support a maximum of **10** entries per the Instana API.
+* Release markers are visible in Instana's Application and Service dashboards when `applications` or `services` scopes are configured.
+* Deleting this resource will remove the release marker from Instana.
+* Required API token permission: `CanConfigureReleases`.

--- a/go.mod
+++ b/go.mod
@@ -61,3 +61,5 @@ require (
 	gopkg.in/resty.v1 v1.12.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/instana/instana-go-client => ../instana-go-client

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.18.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.36.1
-	github.com/instana/instana-go-client v1.3.0
+	github.com/instana/instana-go-client v1.4.0
 	github.com/rs/xid v1.5.0
 	github.com/stretchr/testify v1.11.1
 )
@@ -61,5 +61,3 @@ require (
 	gopkg.in/resty.v1 v1.12.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/instana/instana-go-client => ../instana-go-client

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,8 @@ github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8=
 github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
-github.com/instana/instana-go-client v1.3.0 h1:TKIuu8VWzoT3BSzM+kwh+UMUzLZIeeSbpS3e3c035Eo=
-github.com/instana/instana-go-client v1.3.0/go.mod h1:aOe+HQWz3md7VSvKrdeT+aso7sxzobWuXvyaTwIos3Q=
+github.com/instana/instana-go-client v1.4.0 h1:GKMmoYuOqVbD7ZFxptgYJUaRlBq3O5WIvEboo5KQu8w=
+github.com/instana/instana-go-client v1.4.0/go.mod h1:aOe+HQWz3md7VSvKrdeT+aso7sxzobWuXvyaTwIos3Q=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=
 github.com/jhump/protoreflect v1.17.0/go.mod h1:h9+vUUL38jiBzck8ck+6G/aeMX8Z4QUY/NiJPwPNi+8=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -43,6 +43,7 @@ import (
 	"github.com/instana/terraform-provider-instana/internal/resources/sliconfig"
 	"github.com/instana/terraform-provider-instana/internal/resources/sloalertconfig"
 	"github.com/instana/terraform-provider-instana/internal/resources/sloconfig"
+	"github.com/instana/terraform-provider-instana/internal/resources/release"
 	"github.com/instana/terraform-provider-instana/internal/resources/slocorrectionconfig"
 	"github.com/instana/terraform-provider-instana/internal/resources/syntheticalertconfig"
 	"github.com/instana/terraform-provider-instana/internal/resources/syntheticcredential"
@@ -385,6 +386,7 @@ func (p *InstanaProvider) Resources(_ context.Context) []func() resource.Resourc
 		addResouceHandle(websitealertconfig.NewWebsiteAlertConfigResourceHandle),
 		addResouceHandle(websitemonitoringconfig.NewWebsiteMonitoringConfigResourceHandle),
 		addResouceHandle(sloconfig.NewSloConfigResourceHandle),
+		addResouceHandle(release.NewReleaseResourceHandle),
 		addSingletonResourceHandle(sessionsettings.NewSessionSettingsResourceHandle),
 	}
 }

--- a/internal/resources/release/release-model.go
+++ b/internal/resources/release/release-model.go
@@ -1,0 +1,37 @@
+package release
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/instana/terraform-provider-instana/internal/resourcehandle"
+)
+
+// ReleaseModel represents the Terraform state model for a release
+type ReleaseModel struct {
+	ID           types.String `tfsdk:"id"`
+	Name         types.String `tfsdk:"name"`
+	Start        types.Int64  `tfsdk:"start"`
+	LastUpdated  types.Int64  `tfsdk:"last_updated"`
+	Applications types.List   `tfsdk:"applications"`
+	Services     types.List   `tfsdk:"services"`
+}
+
+// ApplicationModel represents a single application scope in the release
+type ApplicationModel struct {
+	Name types.String `tfsdk:"name"`
+}
+
+// ServiceModel represents a single service scope in the release
+type ServiceModel struct {
+	Name     types.String   `tfsdk:"name"`
+	ScopedTo *ScopedToModel `tfsdk:"scoped_to"`
+}
+
+// ScopedToModel represents the optional scope restriction for a service
+type ScopedToModel struct {
+	ApplicationName types.String `tfsdk:"application_name"`
+	EnvironmentName types.String `tfsdk:"environment_name"`
+}
+
+type releaseResource struct {
+	metaData resourcehandle.ResourceMetaData
+}

--- a/internal/resources/release/release-model.go
+++ b/internal/resources/release/release-model.go
@@ -15,7 +15,7 @@ type ReleaseModel struct {
 	Services     types.List   `tfsdk:"services"`
 }
 
-// ApplicationModel represents a single application scope in the release
+// ApplicationModel represents a single application scope in a release or in scoped_to
 type ApplicationModel struct {
 	Name types.String `tfsdk:"name"`
 }
@@ -26,10 +26,10 @@ type ServiceModel struct {
 	ScopedTo *ScopedToModel `tfsdk:"scoped_to"`
 }
 
-// ScopedToModel represents the optional scope restriction for a service
+// ScopedToModel restricts a service to specific application perspectives.
+// The API requires at least one application when scoped_to is present.
 type ScopedToModel struct {
-	ApplicationName types.String `tfsdk:"application_name"`
-	EnvironmentName types.String `tfsdk:"environment_name"`
+	Applications types.List `tfsdk:"applications"`
 }
 
 type releaseResource struct {

--- a/internal/resources/release/resource-release-constants.go
+++ b/internal/resources/release/resource-release-constants.go
@@ -20,10 +20,6 @@ const (
 	ReleaseFieldServices = "services"
 	// ReleaseFieldScopedTo constant value for the schema field scoped_to
 	ReleaseFieldScopedTo = "scoped_to"
-	// ReleaseFieldApplicationName constant value for the schema field application_name
-	ReleaseFieldApplicationName = "application_name"
-	// ReleaseFieldEnvironmentName constant value for the schema field environment_name
-	ReleaseFieldEnvironmentName = "environment_name"
 
 	// Description constants
 
@@ -34,32 +30,34 @@ const (
 	// ReleaseDescName description for the name field
 	ReleaseDescName = "The name of the release. For example: `frontend/release-2000`."
 	// ReleaseDescStart description for the start field
-	ReleaseDescStart = "The timestamp (in milliseconds since epoch) for when the release is created. For example: `1742349976000`."
+	ReleaseDescStart = "The timestamp (in milliseconds since epoch) for when the release is created. Must be at least 1."
 	// ReleaseDescLastUpdated description for the last_updated field
 	ReleaseDescLastUpdated = "The timestamp (in milliseconds since epoch) of the last update to this release."
-	// ReleaseDescApplications description for the applications field
-	ReleaseDescApplications = "The list of application perspectives where the release can be viewed (max 10)."
-	// ReleaseDescApplicationName description for the application name field
+	// ReleaseDescApplications description for the top-level applications field
+	ReleaseDescApplications = "The list of application perspectives where the release can be viewed (0–10 entries)."
+	// ReleaseDescApplicationName description for a name field inside an application scope
 	ReleaseDescApplicationName = "Name of the Application Perspective. For example: `app1`."
 	// ReleaseDescServices description for the services field
-	ReleaseDescServices = "The list of services where the release can be viewed (max 10)."
+	ReleaseDescServices = "The list of services where the release can be viewed (0–10 entries)."
 	// ReleaseDescServiceName description for the service name field
 	ReleaseDescServiceName = "Name of the Service. For example: `payment`."
 	// ReleaseDescScopedTo description for the scoped_to block
-	ReleaseDescScopedTo = "Optional scope restriction for the service."
-	// ReleaseDescApplicationNameScope description for the application_name scope field
-	ReleaseDescApplicationNameScope = "The application name that scopes the service."
-	// ReleaseDescEnvironmentName description for the environment_name scope field
-	ReleaseDescEnvironmentName = "The environment name that scopes the service."
+	ReleaseDescScopedTo = "Optional scope restriction: limits the service visibility to specific application perspectives."
+	// ReleaseDescScopedToApplications description for the applications list inside scoped_to
+	ReleaseDescScopedToApplications = "The list of application perspectives that scope this service (1–10 entries)."
 
 	// Validation constants
 
 	// ReleaseNameMaxLength maximum length for the name field
 	ReleaseNameMaxLength = 256
-	// ReleaseApplicationsMaxItems maximum number of application scopes
+	// ReleaseApplicationsMaxItems maximum number of application scopes at the release level
 	ReleaseApplicationsMaxItems = 10
 	// ReleaseServicesMaxItems maximum number of service scopes
 	ReleaseServicesMaxItems = 10
+	// ReleaseScopedToApplicationsMinItems minimum number of applications inside scoped_to
+	ReleaseScopedToApplicationsMinItems = 1
+	// ReleaseScopedToApplicationsMaxItems maximum number of applications inside scoped_to
+	ReleaseScopedToApplicationsMaxItems = 10
 	// ReleaseStartMinValue minimum value for the start timestamp
 	ReleaseStartMinValue = 1
 )

--- a/internal/resources/release/resource-release-constants.go
+++ b/internal/resources/release/resource-release-constants.go
@@ -1,0 +1,65 @@
+package release
+
+// ResourceInstanaRelease the name of the terraform-provider-instana resource to manage releases
+const ResourceInstanaRelease = "release"
+
+const (
+	// Field name constants
+
+	// ReleaseFieldID constant value for the schema field id
+	ReleaseFieldID = "id"
+	// ReleaseFieldName constant value for the schema field name
+	ReleaseFieldName = "name"
+	// ReleaseFieldStart constant value for the schema field start
+	ReleaseFieldStart = "start"
+	// ReleaseFieldLastUpdated constant value for the schema field last_updated
+	ReleaseFieldLastUpdated = "last_updated"
+	// ReleaseFieldApplications constant value for the schema field applications
+	ReleaseFieldApplications = "applications"
+	// ReleaseFieldServices constant value for the schema field services
+	ReleaseFieldServices = "services"
+	// ReleaseFieldScopedTo constant value for the schema field scoped_to
+	ReleaseFieldScopedTo = "scoped_to"
+	// ReleaseFieldApplicationName constant value for the schema field application_name
+	ReleaseFieldApplicationName = "application_name"
+	// ReleaseFieldEnvironmentName constant value for the schema field environment_name
+	ReleaseFieldEnvironmentName = "environment_name"
+
+	// Description constants
+
+	// ReleaseDescResource description for the resource
+	ReleaseDescResource = "This resource manages release markers in Instana."
+	// ReleaseDescID description for the ID field
+	ReleaseDescID = "The unique ID of the release."
+	// ReleaseDescName description for the name field
+	ReleaseDescName = "The name of the release. For example: `frontend/release-2000`."
+	// ReleaseDescStart description for the start field
+	ReleaseDescStart = "The timestamp (in milliseconds since epoch) for when the release is created. For example: `1742349976000`."
+	// ReleaseDescLastUpdated description for the last_updated field
+	ReleaseDescLastUpdated = "The timestamp (in milliseconds since epoch) of the last update to this release."
+	// ReleaseDescApplications description for the applications field
+	ReleaseDescApplications = "The list of application perspectives where the release can be viewed (max 10)."
+	// ReleaseDescApplicationName description for the application name field
+	ReleaseDescApplicationName = "Name of the Application Perspective. For example: `app1`."
+	// ReleaseDescServices description for the services field
+	ReleaseDescServices = "The list of services where the release can be viewed (max 10)."
+	// ReleaseDescServiceName description for the service name field
+	ReleaseDescServiceName = "Name of the Service. For example: `payment`."
+	// ReleaseDescScopedTo description for the scoped_to block
+	ReleaseDescScopedTo = "Optional scope restriction for the service."
+	// ReleaseDescApplicationNameScope description for the application_name scope field
+	ReleaseDescApplicationNameScope = "The application name that scopes the service."
+	// ReleaseDescEnvironmentName description for the environment_name scope field
+	ReleaseDescEnvironmentName = "The environment name that scopes the service."
+
+	// Validation constants
+
+	// ReleaseNameMaxLength maximum length for the name field
+	ReleaseNameMaxLength = 256
+	// ReleaseApplicationsMaxItems maximum number of application scopes
+	ReleaseApplicationsMaxItems = 10
+	// ReleaseServicesMaxItems maximum number of service scopes
+	ReleaseServicesMaxItems = 10
+	// ReleaseStartMinValue minimum value for the start timestamp
+	ReleaseStartMinValue = 1
+)

--- a/internal/resources/release/resource-release.go
+++ b/internal/resources/release/resource-release.go
@@ -1,0 +1,324 @@
+package release
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/instana/instana-go-client/api"
+	instanaClient "github.com/instana/instana-go-client/client"
+	"github.com/instana/instana-go-client/shared/rest"
+	"github.com/instana/terraform-provider-instana/internal/resourcehandle"
+)
+
+// applicationAttrTypes defines the attribute types for ApplicationModel elements in a types.List.
+var applicationAttrTypes = map[string]attr.Type{
+	ReleaseFieldName: types.StringType,
+}
+
+// scopedToAttrTypes defines the attribute types for ScopedToModel elements in a types.Object.
+var scopedToAttrTypes = map[string]attr.Type{
+	ReleaseFieldApplicationName: types.StringType,
+	ReleaseFieldEnvironmentName: types.StringType,
+}
+
+// serviceAttrTypes defines the attribute types for ServiceModel elements in a types.List.
+var serviceAttrTypes = map[string]attr.Type{
+	ReleaseFieldName:     types.StringType,
+	ReleaseFieldScopedTo: types.ObjectType{AttrTypes: scopedToAttrTypes},
+}
+
+// NewReleaseResourceHandle creates the resource handle for releases
+func NewReleaseResourceHandle() resourcehandle.ResourceHandle[*api.ReleaseWithMetadata] {
+	return &releaseResource{
+		metaData: resourcehandle.ResourceMetaData{
+			ResourceName:  ResourceInstanaRelease,
+			Schema:        buildReleaseSchema(),
+			SchemaVersion: 0,
+		},
+	}
+}
+
+func buildReleaseSchema() schema.Schema {
+	return schema.Schema{
+		Description: ReleaseDescResource,
+		Attributes: map[string]schema.Attribute{
+			ReleaseFieldID: schema.StringAttribute{
+				Computed:    true,
+				Description: ReleaseDescID,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			ReleaseFieldName: schema.StringAttribute{
+				Required:    true,
+				Description: ReleaseDescName,
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(0, ReleaseNameMaxLength),
+				},
+			},
+			ReleaseFieldStart: schema.Int64Attribute{
+				Required:    true,
+				Description: ReleaseDescStart,
+				Validators: []validator.Int64{
+					int64validator.AtLeast(ReleaseStartMinValue),
+				},
+			},
+			ReleaseFieldLastUpdated: schema.Int64Attribute{
+				Computed:    true,
+				Description: ReleaseDescLastUpdated,
+			},
+			ReleaseFieldApplications: schema.ListNestedAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: ReleaseDescApplications,
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.UseStateForUnknown(),
+				},
+				Validators: []validator.List{
+					listvalidator.SizeBetween(0, ReleaseApplicationsMaxItems),
+				},
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						ReleaseFieldName: schema.StringAttribute{
+							Required:    true,
+							Description: ReleaseDescApplicationName,
+							Validators: []validator.String{
+								stringvalidator.LengthBetween(0, ReleaseNameMaxLength),
+							},
+						},
+					},
+				},
+			},
+			ReleaseFieldServices: schema.ListNestedAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: ReleaseDescServices,
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.UseStateForUnknown(),
+				},
+				Validators: []validator.List{
+					listvalidator.SizeBetween(0, ReleaseServicesMaxItems),
+				},
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						ReleaseFieldName: schema.StringAttribute{
+							Required:    true,
+							Description: ReleaseDescServiceName,
+							Validators: []validator.String{
+								stringvalidator.LengthBetween(0, ReleaseNameMaxLength),
+							},
+						},
+						ReleaseFieldScopedTo: schema.SingleNestedAttribute{
+							Optional:    true,
+							Description: ReleaseDescScopedTo,
+							Attributes: map[string]schema.Attribute{
+								ReleaseFieldApplicationName: schema.StringAttribute{
+									Optional:    true,
+									Description: ReleaseDescApplicationNameScope,
+								},
+								ReleaseFieldEnvironmentName: schema.StringAttribute{
+									Optional:    true,
+									Description: ReleaseDescEnvironmentName,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r *releaseResource) MetaData() *resourcehandle.ResourceMetaData {
+	return &r.metaData
+}
+
+func (r *releaseResource) GetRestResource(instana instanaClient.InstanaAPI) rest.RestResource[*api.ReleaseWithMetadata] {
+	return instana.Releases()
+}
+
+func (r *releaseResource) SetComputedFields(_ context.Context, _ *tfsdk.Plan) diag.Diagnostics {
+	return nil
+}
+
+func (r *releaseResource) UpdateState(ctx context.Context, state *tfsdk.State, _ *tfsdk.Plan, release *api.ReleaseWithMetadata) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	applications, d := mapApplicationsToState(ctx, release.Applications)
+	diags.Append(d...)
+	if diags.HasError() {
+		return diags
+	}
+
+	services, d := mapServicesToState(ctx, release.Services)
+	diags.Append(d...)
+	if diags.HasError() {
+		return diags
+	}
+
+	model := ReleaseModel{
+		ID:           types.StringValue(release.ID),
+		Name:         types.StringValue(release.Name),
+		Start:        types.Int64Value(release.Start),
+		LastUpdated:  types.Int64Value(release.LastUpdated),
+		Applications: applications,
+		Services:     services,
+	}
+
+	diags.Append(state.Set(ctx, model)...)
+	return diags
+}
+
+func mapApplicationsToState(ctx context.Context, apps []*api.ReleaseApplicationScope) (types.List, diag.Diagnostics) {
+	elementType := types.ObjectType{AttrTypes: applicationAttrTypes}
+
+	if len(apps) == 0 {
+		return types.ListValueMust(elementType, []attr.Value{}), nil
+	}
+
+	elems := make([]attr.Value, len(apps))
+	for i, app := range apps {
+		obj, diags := types.ObjectValue(applicationAttrTypes, map[string]attr.Value{
+			ReleaseFieldName: types.StringValue(app.Name),
+		})
+		if diags.HasError() {
+			return types.ListNull(elementType), diags
+		}
+		elems[i] = obj
+	}
+
+	return types.ListValue(elementType, elems)
+}
+
+func mapServicesToState(ctx context.Context, services []*api.ReleaseServiceScope) (types.List, diag.Diagnostics) {
+	elementType := types.ObjectType{AttrTypes: serviceAttrTypes}
+
+	if len(services) == 0 {
+		return types.ListValueMust(elementType, []attr.Value{}), nil
+	}
+
+	elems := make([]attr.Value, len(services))
+	for i, svc := range services {
+		scopedToVal, diags := buildScopedToObject(svc.ScopedTo)
+		if diags.HasError() {
+			return types.ListNull(elementType), diags
+		}
+
+		obj, diags := types.ObjectValue(serviceAttrTypes, map[string]attr.Value{
+			ReleaseFieldName:     types.StringValue(svc.Name),
+			ReleaseFieldScopedTo: scopedToVal,
+		})
+		if diags.HasError() {
+			return types.ListNull(elementType), diags
+		}
+		elems[i] = obj
+	}
+
+	return types.ListValue(elementType, elems)
+}
+
+func buildScopedToObject(scopedTo *api.ReleaseServiceScopedTo) (attr.Value, diag.Diagnostics) {
+	if scopedTo == nil {
+		return types.ObjectNull(scopedToAttrTypes), nil
+	}
+	return types.ObjectValue(scopedToAttrTypes, map[string]attr.Value{
+		ReleaseFieldApplicationName: types.StringValue(scopedTo.ApplicationName),
+		ReleaseFieldEnvironmentName: types.StringValue(scopedTo.EnvironmentName),
+	})
+}
+
+func (r *releaseResource) MapStateToDataObject(ctx context.Context, plan *tfsdk.Plan, state *tfsdk.State) (*api.ReleaseWithMetadata, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	var model ReleaseModel
+
+	if plan != nil {
+		diags.Append(plan.Get(ctx, &model)...)
+	} else if state != nil {
+		diags.Append(state.Get(ctx, &model)...)
+	}
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	release := &api.ReleaseWithMetadata{
+		ID:    model.ID.ValueString(),
+		Name:  model.Name.ValueString(),
+		Start: model.Start.ValueInt64(),
+	}
+
+	apps, d := mapApplicationsFromState(ctx, model.Applications)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nil, diags
+	}
+	release.Applications = apps
+
+	svcs, d := mapServicesFromState(ctx, model.Services)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nil, diags
+	}
+	release.Services = svcs
+
+	return release, diags
+}
+
+func mapApplicationsFromState(ctx context.Context, list types.List) ([]*api.ReleaseApplicationScope, diag.Diagnostics) {
+	if list.IsNull() || list.IsUnknown() || len(list.Elements()) == 0 {
+		return nil, nil
+	}
+
+	var models []ApplicationModel
+	diags := list.ElementsAs(ctx, &models, false)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	result := make([]*api.ReleaseApplicationScope, len(models))
+	for i, m := range models {
+		result[i] = &api.ReleaseApplicationScope{Name: m.Name.ValueString()}
+	}
+	return result, nil
+}
+
+func mapServicesFromState(ctx context.Context, list types.List) ([]*api.ReleaseServiceScope, diag.Diagnostics) {
+	if list.IsNull() || list.IsUnknown() || len(list.Elements()) == 0 {
+		return nil, nil
+	}
+
+	var models []ServiceModel
+	diags := list.ElementsAs(ctx, &models, false)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	result := make([]*api.ReleaseServiceScope, len(models))
+	for i, svc := range models {
+		scope := &api.ReleaseServiceScope{Name: svc.Name.ValueString()}
+		if svc.ScopedTo != nil {
+			scope.ScopedTo = &api.ReleaseServiceScopedTo{
+				ApplicationName: svc.ScopedTo.ApplicationName.ValueString(),
+				EnvironmentName: svc.ScopedTo.EnvironmentName.ValueString(),
+			}
+		}
+		result[i] = scope
+	}
+	return result, nil
+}
+
+// GetStateUpgraders returns the state upgraders for this resource
+func (r *releaseResource) GetStateUpgraders(_ context.Context) map[int64]resource.StateUpgrader {
+	return nil
+}

--- a/internal/resources/release/resource-release.go
+++ b/internal/resources/release/resource-release.go
@@ -22,18 +22,18 @@ import (
 	"github.com/instana/terraform-provider-instana/internal/resourcehandle"
 )
 
-// applicationAttrTypes defines the attribute types for ApplicationModel elements in a types.List.
+// applicationAttrTypes are the attribute types for a single {name} application entry used
+// both at the top-level applications list and inside scoped_to.applications.
 var applicationAttrTypes = map[string]attr.Type{
 	ReleaseFieldName: types.StringType,
 }
 
-// scopedToAttrTypes defines the attribute types for ScopedToModel elements in a types.Object.
+// scopedToAttrTypes are the attribute types for the scoped_to object.
 var scopedToAttrTypes = map[string]attr.Type{
-	ReleaseFieldApplicationName: types.StringType,
-	ReleaseFieldEnvironmentName: types.StringType,
+	ReleaseFieldApplications: types.ListType{ElemType: types.ObjectType{AttrTypes: applicationAttrTypes}},
 }
 
-// serviceAttrTypes defines the attribute types for ServiceModel elements in a types.List.
+// serviceAttrTypes are the attribute types for a single service list element.
 var serviceAttrTypes = map[string]attr.Type{
 	ReleaseFieldName:     types.StringType,
 	ReleaseFieldScopedTo: types.ObjectType{AttrTypes: scopedToAttrTypes},
@@ -51,6 +51,13 @@ func NewReleaseResourceHandle() resourcehandle.ResourceHandle[*api.ReleaseWithMe
 }
 
 func buildReleaseSchema() schema.Schema {
+	// Reusable nested attribute for {name} entries
+	nameAttr := schema.StringAttribute{
+		Required:    true,
+		Description: ReleaseDescApplicationName,
+		Validators:  []validator.String{stringvalidator.LengthBetween(0, ReleaseNameMaxLength)},
+	}
+
 	return schema.Schema{
 		Description: ReleaseDescResource,
 		Attributes: map[string]schema.Attribute{
@@ -64,21 +71,18 @@ func buildReleaseSchema() schema.Schema {
 			ReleaseFieldName: schema.StringAttribute{
 				Required:    true,
 				Description: ReleaseDescName,
-				Validators: []validator.String{
-					stringvalidator.LengthBetween(0, ReleaseNameMaxLength),
-				},
+				Validators:  []validator.String{stringvalidator.LengthBetween(0, ReleaseNameMaxLength)},
 			},
 			ReleaseFieldStart: schema.Int64Attribute{
 				Required:    true,
 				Description: ReleaseDescStart,
-				Validators: []validator.Int64{
-					int64validator.AtLeast(ReleaseStartMinValue),
-				},
+				Validators:  []validator.Int64{int64validator.AtLeast(ReleaseStartMinValue)},
 			},
 			ReleaseFieldLastUpdated: schema.Int64Attribute{
 				Computed:    true,
 				Description: ReleaseDescLastUpdated,
 			},
+			// Top-level applications: list of {name}
 			ReleaseFieldApplications: schema.ListNestedAttribute{
 				Optional:    true,
 				Computed:    true,
@@ -91,16 +95,11 @@ func buildReleaseSchema() schema.Schema {
 				},
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
-						ReleaseFieldName: schema.StringAttribute{
-							Required:    true,
-							Description: ReleaseDescApplicationName,
-							Validators: []validator.String{
-								stringvalidator.LengthBetween(0, ReleaseNameMaxLength),
-							},
-						},
+						ReleaseFieldName: nameAttr,
 					},
 				},
 			},
+			// Services: list of {name, scoped_to?}
 			ReleaseFieldServices: schema.ListNestedAttribute{
 				Optional:    true,
 				Computed:    true,
@@ -116,21 +115,24 @@ func buildReleaseSchema() schema.Schema {
 						ReleaseFieldName: schema.StringAttribute{
 							Required:    true,
 							Description: ReleaseDescServiceName,
-							Validators: []validator.String{
-								stringvalidator.LengthBetween(0, ReleaseNameMaxLength),
-							},
+							Validators:  []validator.String{stringvalidator.LengthBetween(0, ReleaseNameMaxLength)},
 						},
+						// scoped_to: optional, contains applications list (1–10)
 						ReleaseFieldScopedTo: schema.SingleNestedAttribute{
 							Optional:    true,
 							Description: ReleaseDescScopedTo,
 							Attributes: map[string]schema.Attribute{
-								ReleaseFieldApplicationName: schema.StringAttribute{
-									Optional:    true,
-									Description: ReleaseDescApplicationNameScope,
-								},
-								ReleaseFieldEnvironmentName: schema.StringAttribute{
-									Optional:    true,
-									Description: ReleaseDescEnvironmentName,
+								ReleaseFieldApplications: schema.ListNestedAttribute{
+									Required:    true,
+									Description: ReleaseDescScopedToApplications,
+									Validators: []validator.List{
+										listvalidator.SizeBetween(ReleaseScopedToApplicationsMinItems, ReleaseScopedToApplicationsMaxItems),
+									},
+									NestedObject: schema.NestedAttributeObject{
+										Attributes: map[string]schema.Attribute{
+											ReleaseFieldName: nameAttr,
+										},
+									},
 								},
 							},
 						},
@@ -153,16 +155,18 @@ func (r *releaseResource) SetComputedFields(_ context.Context, _ *tfsdk.Plan) di
 	return nil
 }
 
+// ─── State → Terraform ───────────────────────────────────────────────────────
+
 func (r *releaseResource) UpdateState(ctx context.Context, state *tfsdk.State, _ *tfsdk.Plan, release *api.ReleaseWithMetadata) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	applications, d := mapApplicationsToState(ctx, release.Applications)
+	applications, d := buildApplicationList(release.Applications)
 	diags.Append(d...)
 	if diags.HasError() {
 		return diags
 	}
 
-	services, d := mapServicesToState(ctx, release.Services)
+	services, d := buildServiceList(ctx, release.Services)
 	diags.Append(d...)
 	if diags.HasError() {
 		return diags
@@ -181,63 +185,64 @@ func (r *releaseResource) UpdateState(ctx context.Context, state *tfsdk.State, _
 	return diags
 }
 
-func mapApplicationsToState(ctx context.Context, apps []*api.ReleaseApplicationScope) (types.List, diag.Diagnostics) {
-	elementType := types.ObjectType{AttrTypes: applicationAttrTypes}
-
+// buildApplicationList converts []*ReleaseApplicationScope into a types.List of {name} objects.
+func buildApplicationList(apps []*api.ReleaseApplicationScope) (types.List, diag.Diagnostics) {
+	elemType := types.ObjectType{AttrTypes: applicationAttrTypes}
 	if len(apps) == 0 {
-		return types.ListValueMust(elementType, []attr.Value{}), nil
+		return types.ListValueMust(elemType, []attr.Value{}), nil
 	}
-
 	elems := make([]attr.Value, len(apps))
 	for i, app := range apps {
 		obj, diags := types.ObjectValue(applicationAttrTypes, map[string]attr.Value{
 			ReleaseFieldName: types.StringValue(app.Name),
 		})
 		if diags.HasError() {
-			return types.ListNull(elementType), diags
+			return types.ListNull(elemType), diags
 		}
 		elems[i] = obj
 	}
-
-	return types.ListValue(elementType, elems)
+	return types.ListValue(elemType, elems)
 }
 
-func mapServicesToState(ctx context.Context, services []*api.ReleaseServiceScope) (types.List, diag.Diagnostics) {
-	elementType := types.ObjectType{AttrTypes: serviceAttrTypes}
-
+// buildServiceList converts []*ReleaseServiceScope into a types.List of service objects.
+func buildServiceList(ctx context.Context, services []*api.ReleaseServiceScope) (types.List, diag.Diagnostics) {
+	elemType := types.ObjectType{AttrTypes: serviceAttrTypes}
 	if len(services) == 0 {
-		return types.ListValueMust(elementType, []attr.Value{}), nil
+		return types.ListValueMust(elemType, []attr.Value{}), nil
 	}
-
 	elems := make([]attr.Value, len(services))
 	for i, svc := range services {
 		scopedToVal, diags := buildScopedToObject(svc.ScopedTo)
 		if diags.HasError() {
-			return types.ListNull(elementType), diags
+			return types.ListNull(elemType), diags
 		}
-
 		obj, diags := types.ObjectValue(serviceAttrTypes, map[string]attr.Value{
 			ReleaseFieldName:     types.StringValue(svc.Name),
 			ReleaseFieldScopedTo: scopedToVal,
 		})
 		if diags.HasError() {
-			return types.ListNull(elementType), diags
+			return types.ListNull(elemType), diags
 		}
 		elems[i] = obj
 	}
-
-	return types.ListValue(elementType, elems)
+	return types.ListValue(elemType, elems)
 }
 
+// buildScopedToObject converts *ReleaseServiceScopedTo into an attr.Value (object or null).
 func buildScopedToObject(scopedTo *api.ReleaseServiceScopedTo) (attr.Value, diag.Diagnostics) {
 	if scopedTo == nil {
 		return types.ObjectNull(scopedToAttrTypes), nil
 	}
+	appsList, diags := buildApplicationList(scopedTo.Applications)
+	if diags.HasError() {
+		return types.ObjectNull(scopedToAttrTypes), diags
+	}
 	return types.ObjectValue(scopedToAttrTypes, map[string]attr.Value{
-		ReleaseFieldApplicationName: types.StringValue(scopedTo.ApplicationName),
-		ReleaseFieldEnvironmentName: types.StringValue(scopedTo.EnvironmentName),
+		ReleaseFieldApplications: appsList,
 	})
 }
+
+// ─── Terraform → API ─────────────────────────────────────────────────────────
 
 func (r *releaseResource) MapStateToDataObject(ctx context.Context, plan *tfsdk.Plan, state *tfsdk.State) (*api.ReleaseWithMetadata, diag.Diagnostics) {
 	var diags diag.Diagnostics
@@ -258,14 +263,14 @@ func (r *releaseResource) MapStateToDataObject(ctx context.Context, plan *tfsdk.
 		Start: model.Start.ValueInt64(),
 	}
 
-	apps, d := mapApplicationsFromState(ctx, model.Applications)
+	apps, d := extractApplicationsFromList(ctx, model.Applications)
 	diags.Append(d...)
 	if diags.HasError() {
 		return nil, diags
 	}
 	release.Applications = apps
 
-	svcs, d := mapServicesFromState(ctx, model.Services)
+	svcs, d := extractServicesFromList(ctx, model.Services)
 	diags.Append(d...)
 	if diags.HasError() {
 		return nil, diags
@@ -275,17 +280,16 @@ func (r *releaseResource) MapStateToDataObject(ctx context.Context, plan *tfsdk.
 	return release, diags
 }
 
-func mapApplicationsFromState(ctx context.Context, list types.List) ([]*api.ReleaseApplicationScope, diag.Diagnostics) {
+// extractApplicationsFromList converts a types.List of {name} objects to []*ReleaseApplicationScope.
+func extractApplicationsFromList(ctx context.Context, list types.List) ([]*api.ReleaseApplicationScope, diag.Diagnostics) {
 	if list.IsNull() || list.IsUnknown() || len(list.Elements()) == 0 {
 		return nil, nil
 	}
-
 	var models []ApplicationModel
 	diags := list.ElementsAs(ctx, &models, false)
 	if diags.HasError() {
 		return nil, diags
 	}
-
 	result := make([]*api.ReleaseApplicationScope, len(models))
 	for i, m := range models {
 		result[i] = &api.ReleaseApplicationScope{Name: m.Name.ValueString()}
@@ -293,25 +297,25 @@ func mapApplicationsFromState(ctx context.Context, list types.List) ([]*api.Rele
 	return result, nil
 }
 
-func mapServicesFromState(ctx context.Context, list types.List) ([]*api.ReleaseServiceScope, diag.Diagnostics) {
+// extractServicesFromList converts a types.List of service objects to []*ReleaseServiceScope.
+func extractServicesFromList(ctx context.Context, list types.List) ([]*api.ReleaseServiceScope, diag.Diagnostics) {
 	if list.IsNull() || list.IsUnknown() || len(list.Elements()) == 0 {
 		return nil, nil
 	}
-
 	var models []ServiceModel
 	diags := list.ElementsAs(ctx, &models, false)
 	if diags.HasError() {
 		return nil, diags
 	}
-
 	result := make([]*api.ReleaseServiceScope, len(models))
 	for i, svc := range models {
 		scope := &api.ReleaseServiceScope{Name: svc.Name.ValueString()}
 		if svc.ScopedTo != nil {
-			scope.ScopedTo = &api.ReleaseServiceScopedTo{
-				ApplicationName: svc.ScopedTo.ApplicationName.ValueString(),
-				EnvironmentName: svc.ScopedTo.EnvironmentName.ValueString(),
+			apps, d := extractApplicationsFromList(ctx, svc.ScopedTo.Applications)
+			if d.HasError() {
+				return nil, d
 			}
+			scope.ScopedTo = &api.ReleaseServiceScopedTo{Applications: apps}
 		}
 		result[i] = scope
 	}

--- a/internal/resources/release/resource-release_test.go
+++ b/internal/resources/release/resource-release_test.go
@@ -1,0 +1,296 @@
+package release
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/instana/instana-go-client/api"
+	"github.com/instana/terraform-provider-instana/internal/resourcehandle"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// emptyApplicationsList returns an empty types.List with the correct element type.
+func emptyApplicationsList() types.List {
+	return types.ListValueMust(types.ObjectType{AttrTypes: applicationAttrTypes}, []attr.Value{})
+}
+
+// emptyServicesList returns an empty types.List with the correct element type.
+func emptyServicesList() types.List {
+	return types.ListValueMust(types.ObjectType{AttrTypes: serviceAttrTypes}, []attr.Value{})
+}
+
+func TestNewReleaseResourceHandle(t *testing.T) {
+	handle := NewReleaseResourceHandle()
+	require.NotNil(t, handle)
+
+	meta := handle.MetaData()
+	assert.Equal(t, ResourceInstanaRelease, meta.ResourceName)
+	assert.NotNil(t, meta.Schema)
+	assert.Equal(t, int64(0), meta.SchemaVersion)
+	assert.False(t, meta.CreateOnly)
+}
+
+func TestReleaseMetaData(t *testing.T) {
+	r := &releaseResource{
+		metaData: resourcehandle.ResourceMetaData{
+			ResourceName:  "test_release",
+			SchemaVersion: 0,
+		},
+	}
+	meta := r.MetaData()
+	assert.Equal(t, "test_release", meta.ResourceName)
+}
+
+func TestReleaseSetComputedFields(t *testing.T) {
+	r := NewReleaseResourceHandle()
+	ctx := context.Background()
+	plan := &tfsdk.Plan{Schema: r.MetaData().Schema}
+	diags := r.SetComputedFields(ctx, plan)
+	assert.False(t, diags.HasError())
+}
+
+func TestReleaseGetStateUpgraders(t *testing.T) {
+	r := NewReleaseResourceHandle()
+	upgraders := r.GetStateUpgraders(context.Background())
+	assert.Nil(t, upgraders)
+}
+
+func TestReleaseUpdateState_BasicRelease(t *testing.T) {
+	ctx := context.Background()
+	r := NewReleaseResourceHandle()
+
+	release := &api.ReleaseWithMetadata{
+		ID:          "Tiu16hLCTniHDtHb_uDV1w",
+		Name:        "demo-app/main-**",
+		Start:       1709091782000,
+		LastUpdated: 1709091782533,
+	}
+
+	state := &tfsdk.State{Schema: r.MetaData().Schema}
+	initialModel := ReleaseModel{
+		ID:           types.StringValue(""),
+		Name:         types.StringValue(""),
+		Start:        types.Int64Value(0),
+		LastUpdated:  types.Int64Value(0),
+		Applications: emptyApplicationsList(),
+		Services:     emptyServicesList(),
+	}
+	require.False(t, state.Set(ctx, initialModel).HasError())
+
+	diags := r.UpdateState(ctx, state, nil, release)
+	require.False(t, diags.HasError())
+
+	var model ReleaseModel
+	require.False(t, state.Get(ctx, &model).HasError())
+
+	assert.Equal(t, "Tiu16hLCTniHDtHb_uDV1w", model.ID.ValueString())
+	assert.Equal(t, "demo-app/main-**", model.Name.ValueString())
+	assert.Equal(t, int64(1709091782000), model.Start.ValueInt64())
+	assert.Equal(t, int64(1709091782533), model.LastUpdated.ValueInt64())
+	assert.Empty(t, model.Applications.Elements())
+	assert.Empty(t, model.Services.Elements())
+}
+
+func TestReleaseUpdateState_WithApplicationsAndServices(t *testing.T) {
+	ctx := context.Background()
+	r := NewReleaseResourceHandle()
+
+	release := &api.ReleaseWithMetadata{
+		ID:          "XK1e1TF3T9SHKugndn_soQ",
+		Name:        "frontend/release-2000",
+		Start:       1706674621000,
+		LastUpdated: 1706674621604,
+		Applications: []*api.ReleaseApplicationScope{
+			{Name: "app1"},
+		},
+		Services: []*api.ReleaseServiceScope{
+			{
+				Name: "payment",
+				ScopedTo: &api.ReleaseServiceScopedTo{
+					ApplicationName: "checkout-app",
+				},
+			},
+		},
+	}
+
+	state := &tfsdk.State{Schema: r.MetaData().Schema}
+	initialModel := ReleaseModel{
+		ID:           types.StringValue(""),
+		Name:         types.StringValue(""),
+		Start:        types.Int64Value(0),
+		LastUpdated:  types.Int64Value(0),
+		Applications: emptyApplicationsList(),
+		Services:     emptyServicesList(),
+	}
+	require.False(t, state.Set(ctx, initialModel).HasError())
+
+	diags := r.UpdateState(ctx, state, nil, release)
+	require.False(t, diags.HasError())
+
+	var model ReleaseModel
+	require.False(t, state.Get(ctx, &model).HasError())
+
+	var apps []ApplicationModel
+	require.False(t, model.Applications.ElementsAs(ctx, &apps, false).HasError())
+	require.Len(t, apps, 1)
+	assert.Equal(t, "app1", apps[0].Name.ValueString())
+
+	var svcs []ServiceModel
+	require.False(t, model.Services.ElementsAs(ctx, &svcs, false).HasError())
+	require.Len(t, svcs, 1)
+	assert.Equal(t, "payment", svcs[0].Name.ValueString())
+	require.NotNil(t, svcs[0].ScopedTo)
+	assert.Equal(t, "checkout-app", svcs[0].ScopedTo.ApplicationName.ValueString())
+}
+
+func TestReleaseMapStateToDataObject_BasicRelease(t *testing.T) {
+	ctx := context.Background()
+	r := NewReleaseResourceHandle()
+
+	model := ReleaseModel{
+		ID:           types.StringValue("release-id-1"),
+		Name:         types.StringValue("frontend/release-1000"),
+		Start:        types.Int64Value(1742349976000),
+		LastUpdated:  types.Int64Value(0),
+		Applications: emptyApplicationsList(),
+		Services:     emptyServicesList(),
+	}
+
+	plan := &tfsdk.Plan{Schema: r.MetaData().Schema}
+	require.False(t, plan.Set(ctx, model).HasError())
+
+	release, diags := r.MapStateToDataObject(ctx, plan, nil)
+	require.False(t, diags.HasError())
+	require.NotNil(t, release)
+
+	assert.Equal(t, "release-id-1", release.ID)
+	assert.Equal(t, "frontend/release-1000", release.Name)
+	assert.Equal(t, int64(1742349976000), release.Start)
+	assert.Nil(t, release.Applications)
+	assert.Nil(t, release.Services)
+}
+
+func TestReleaseMapStateToDataObject_WithApplicationsAndServices(t *testing.T) {
+	ctx := context.Background()
+	r := NewReleaseResourceHandle()
+
+	appObj, d := types.ObjectValue(applicationAttrTypes, map[string]attr.Value{
+		ReleaseFieldName: types.StringValue("my-app"),
+	})
+	require.False(t, d.HasError())
+
+	scopedToObj, d := types.ObjectValue(scopedToAttrTypes, map[string]attr.Value{
+		ReleaseFieldApplicationName: types.StringValue("my-app"),
+		ReleaseFieldEnvironmentName: types.StringValue("production"),
+	})
+	require.False(t, d.HasError())
+
+	svcObj, d := types.ObjectValue(serviceAttrTypes, map[string]attr.Value{
+		ReleaseFieldName:     types.StringValue("my-service"),
+		ReleaseFieldScopedTo: scopedToObj,
+	})
+	require.False(t, d.HasError())
+
+	appsList, d := types.ListValue(types.ObjectType{AttrTypes: applicationAttrTypes}, []attr.Value{appObj})
+	require.False(t, d.HasError())
+
+	svcsList, d := types.ListValue(types.ObjectType{AttrTypes: serviceAttrTypes}, []attr.Value{svcObj})
+	require.False(t, d.HasError())
+
+	model := ReleaseModel{
+		ID:           types.StringValue("release-id-2"),
+		Name:         types.StringValue("backend/release-5"),
+		Start:        types.Int64Value(1742349976000),
+		LastUpdated:  types.Int64Value(0),
+		Applications: appsList,
+		Services:     svcsList,
+	}
+
+	plan := &tfsdk.Plan{Schema: r.MetaData().Schema}
+	require.False(t, plan.Set(ctx, model).HasError())
+
+	release, diags := r.MapStateToDataObject(ctx, plan, nil)
+	require.False(t, diags.HasError())
+	require.NotNil(t, release)
+
+	require.Len(t, release.Applications, 1)
+	assert.Equal(t, "my-app", release.Applications[0].Name)
+
+	require.Len(t, release.Services, 1)
+	assert.Equal(t, "my-service", release.Services[0].Name)
+	require.NotNil(t, release.Services[0].ScopedTo)
+	assert.Equal(t, "my-app", release.Services[0].ScopedTo.ApplicationName)
+	assert.Equal(t, "production", release.Services[0].ScopedTo.EnvironmentName)
+}
+
+func TestReleaseMapStateToDataObject_WithStateWhenNoPlan(t *testing.T) {
+	ctx := context.Background()
+	r := NewReleaseResourceHandle()
+
+	model := ReleaseModel{
+		ID:           types.StringValue("release-id-3"),
+		Name:         types.StringValue("state-read-release"),
+		Start:        types.Int64Value(1742349976000),
+		LastUpdated:  types.Int64Value(0),
+		Applications: emptyApplicationsList(),
+		Services:     emptyServicesList(),
+	}
+
+	state := &tfsdk.State{Schema: r.MetaData().Schema}
+	require.False(t, state.Set(ctx, model).HasError())
+
+	release, diags := r.MapStateToDataObject(ctx, nil, state)
+	require.False(t, diags.HasError())
+	require.NotNil(t, release)
+
+	assert.Equal(t, "state-read-release", release.Name)
+}
+
+func TestMapApplicationsToState_Empty(t *testing.T) {
+	ctx := context.Background()
+	result, diags := mapApplicationsToState(ctx, nil)
+	require.False(t, diags.HasError())
+	assert.False(t, result.IsNull())
+	assert.Empty(t, result.Elements())
+}
+
+func TestMapServicesToState_Empty(t *testing.T) {
+	ctx := context.Background()
+	result, diags := mapServicesToState(ctx, nil)
+	require.False(t, diags.HasError())
+	assert.False(t, result.IsNull())
+	assert.Empty(t, result.Elements())
+}
+
+func TestMapApplicationsFromState_Empty(t *testing.T) {
+	ctx := context.Background()
+	result, diags := mapApplicationsFromState(ctx, emptyApplicationsList())
+	require.False(t, diags.HasError())
+	assert.Nil(t, result)
+}
+
+func TestMapServicesFromState_Empty(t *testing.T) {
+	ctx := context.Background()
+	result, diags := mapServicesFromState(ctx, emptyServicesList())
+	require.False(t, diags.HasError())
+	assert.Nil(t, result)
+}
+
+func TestMapServicesToState_NoScopedTo(t *testing.T) {
+	ctx := context.Background()
+	services := []*api.ReleaseServiceScope{
+		{Name: "plain-service"},
+	}
+	result, diags := mapServicesToState(ctx, services)
+	require.False(t, diags.HasError())
+	require.Len(t, result.Elements(), 1)
+
+	var svcs []ServiceModel
+	require.False(t, result.ElementsAs(ctx, &svcs, false).HasError())
+	assert.Equal(t, "plain-service", svcs[0].Name.ValueString())
+	assert.Nil(t, svcs[0].ScopedTo)
+}

--- a/internal/resources/release/resource-release_test.go
+++ b/internal/resources/release/resource-release_test.go
@@ -13,15 +13,92 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// emptyApplicationsList returns an empty types.List with the correct element type.
-func emptyApplicationsList() types.List {
-	return types.ListValueMust(types.ObjectType{AttrTypes: applicationAttrTypes}, []attr.Value{})
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+func emptyReleaseModel() ReleaseModel {
+	appElemType := types.ObjectType{AttrTypes: applicationAttrTypes}
+	svcElemType := types.ObjectType{AttrTypes: serviceAttrTypes}
+	return ReleaseModel{
+		ID:           types.StringValue(""),
+		Name:         types.StringValue(""),
+		Start:        types.Int64Value(0),
+		LastUpdated:  types.Int64Value(0),
+		Applications: types.ListValueMust(appElemType, []attr.Value{}),
+		Services:     types.ListValueMust(svcElemType, []attr.Value{}),
+	}
 }
 
-// emptyServicesList returns an empty types.List with the correct element type.
-func emptyServicesList() types.List {
-	return types.ListValueMust(types.ObjectType{AttrTypes: serviceAttrTypes}, []attr.Value{})
+func setState(t *testing.T, state *tfsdk.State, model ReleaseModel) {
+	t.Helper()
+	require.False(t, state.Set(context.Background(), model).HasError())
 }
+
+func setPlan(t *testing.T, plan *tfsdk.Plan, model ReleaseModel) {
+	t.Helper()
+	require.False(t, plan.Set(context.Background(), model).HasError())
+}
+
+func getModel(t *testing.T, state *tfsdk.State) ReleaseModel {
+	t.Helper()
+	var m ReleaseModel
+	require.False(t, state.Get(context.Background(), &m).HasError())
+	return m
+}
+
+// buildScopedToValue creates a types.Object for scoped_to from a list of app names.
+func buildScopedToValue(t *testing.T, appNames []string) attr.Value {
+	t.Helper()
+	appElemType := types.ObjectType{AttrTypes: applicationAttrTypes}
+	appElems := make([]attr.Value, len(appNames))
+	for i, n := range appNames {
+		obj, diags := types.ObjectValue(applicationAttrTypes, map[string]attr.Value{
+			ReleaseFieldName: types.StringValue(n),
+		})
+		require.False(t, diags.HasError())
+		appElems[i] = obj
+	}
+	appsList, diags := types.ListValue(appElemType, appElems)
+	require.False(t, diags.HasError())
+	scopedTo, diags := types.ObjectValue(scopedToAttrTypes, map[string]attr.Value{
+		ReleaseFieldApplications: appsList,
+	})
+	require.False(t, diags.HasError())
+	return scopedTo
+}
+
+// buildServiceModel creates a ReleaseModel with one service (optionally scoped).
+func buildServiceModel(t *testing.T, svcName string, scopedToAppNames []string) ReleaseModel {
+	t.Helper()
+	appElemType := types.ObjectType{AttrTypes: applicationAttrTypes}
+	svcElemType := types.ObjectType{AttrTypes: serviceAttrTypes}
+
+	var scopedToVal attr.Value
+	if len(scopedToAppNames) > 0 {
+		scopedToVal = buildScopedToValue(t, scopedToAppNames)
+	} else {
+		scopedToVal = types.ObjectNull(scopedToAttrTypes)
+	}
+
+	svcObj, diags := types.ObjectValue(serviceAttrTypes, map[string]attr.Value{
+		ReleaseFieldName:     types.StringValue(svcName),
+		ReleaseFieldScopedTo: scopedToVal,
+	})
+	require.False(t, diags.HasError())
+
+	svcList, diags := types.ListValue(svcElemType, []attr.Value{svcObj})
+	require.False(t, diags.HasError())
+
+	return ReleaseModel{
+		ID:           types.StringValue("id-1"),
+		Name:         types.StringValue("release"),
+		Start:        types.Int64Value(1742349976000),
+		LastUpdated:  types.Int64Value(0),
+		Applications: types.ListValueMust(appElemType, []attr.Value{}),
+		Services:     svcList,
+	}
+}
+
+// ─── NewReleaseResourceHandle ─────────────────────────────────────────────────
 
 func TestNewReleaseResourceHandle(t *testing.T) {
 	handle := NewReleaseResourceHandle()
@@ -36,137 +113,137 @@ func TestNewReleaseResourceHandle(t *testing.T) {
 
 func TestReleaseMetaData(t *testing.T) {
 	r := &releaseResource{
-		metaData: resourcehandle.ResourceMetaData{
-			ResourceName:  "test_release",
-			SchemaVersion: 0,
-		},
+		metaData: resourcehandle.ResourceMetaData{ResourceName: "test_release"},
 	}
-	meta := r.MetaData()
-	assert.Equal(t, "test_release", meta.ResourceName)
+	assert.Equal(t, "test_release", r.MetaData().ResourceName)
 }
 
 func TestReleaseSetComputedFields(t *testing.T) {
 	r := NewReleaseResourceHandle()
-	ctx := context.Background()
 	plan := &tfsdk.Plan{Schema: r.MetaData().Schema}
-	diags := r.SetComputedFields(ctx, plan)
+	diags := r.SetComputedFields(context.Background(), plan)
 	assert.False(t, diags.HasError())
 }
 
 func TestReleaseGetStateUpgraders(t *testing.T) {
-	r := NewReleaseResourceHandle()
-	upgraders := r.GetStateUpgraders(context.Background())
-	assert.Nil(t, upgraders)
+	assert.Nil(t, NewReleaseResourceHandle().GetStateUpgraders(context.Background()))
 }
 
-func TestReleaseUpdateState_BasicRelease(t *testing.T) {
+// ─── UpdateState ─────────────────────────────────────────────────────────────
+
+func TestUpdateState_BasicRelease(t *testing.T) {
 	ctx := context.Background()
 	r := NewReleaseResourceHandle()
 
 	release := &api.ReleaseWithMetadata{
-		ID:          "Tiu16hLCTniHDtHb_uDV1w",
-		Name:        "demo-app/main-**",
-		Start:       1709091782000,
-		LastUpdated: 1709091782533,
+		ID: "Tiu16hLCTniHDtHb_uDV1w", Name: "demo-app/main-**",
+		Start: 1709091782000, LastUpdated: 1709091782533,
 	}
 
 	state := &tfsdk.State{Schema: r.MetaData().Schema}
-	initialModel := ReleaseModel{
-		ID:           types.StringValue(""),
-		Name:         types.StringValue(""),
-		Start:        types.Int64Value(0),
-		LastUpdated:  types.Int64Value(0),
-		Applications: emptyApplicationsList(),
-		Services:     emptyServicesList(),
-	}
-	require.False(t, state.Set(ctx, initialModel).HasError())
+	setState(t, state, emptyReleaseModel())
 
-	diags := r.UpdateState(ctx, state, nil, release)
-	require.False(t, diags.HasError())
+	require.False(t, r.UpdateState(ctx, state, nil, release).HasError())
 
-	var model ReleaseModel
-	require.False(t, state.Get(ctx, &model).HasError())
-
-	assert.Equal(t, "Tiu16hLCTniHDtHb_uDV1w", model.ID.ValueString())
-	assert.Equal(t, "demo-app/main-**", model.Name.ValueString())
-	assert.Equal(t, int64(1709091782000), model.Start.ValueInt64())
-	assert.Equal(t, int64(1709091782533), model.LastUpdated.ValueInt64())
-	assert.Empty(t, model.Applications.Elements())
-	assert.Empty(t, model.Services.Elements())
+	m := getModel(t, state)
+	assert.Equal(t, "Tiu16hLCTniHDtHb_uDV1w", m.ID.ValueString())
+	assert.Equal(t, "demo-app/main-**", m.Name.ValueString())
+	assert.Equal(t, int64(1709091782000), m.Start.ValueInt64())
+	assert.Equal(t, int64(1709091782533), m.LastUpdated.ValueInt64())
+	assert.Equal(t, 0, len(m.Applications.Elements()))
+	assert.Equal(t, 0, len(m.Services.Elements()))
 }
 
-func TestReleaseUpdateState_WithApplicationsAndServices(t *testing.T) {
+func TestUpdateState_WithApplications(t *testing.T) {
 	ctx := context.Background()
 	r := NewReleaseResourceHandle()
 
 	release := &api.ReleaseWithMetadata{
-		ID:          "XK1e1TF3T9SHKugndn_soQ",
-		Name:        "frontend/release-2000",
-		Start:       1706674621000,
-		LastUpdated: 1706674621604,
-		Applications: []*api.ReleaseApplicationScope{
-			{Name: "app1"},
-		},
+		ID: "id-1", Name: "backend/v1", Start: 1709091782000, LastUpdated: 1709091782533,
+		Applications: []*api.ReleaseApplicationScope{{Name: "app1"}, {Name: "app2"}},
+	}
+
+	state := &tfsdk.State{Schema: r.MetaData().Schema}
+	setState(t, state, emptyReleaseModel())
+
+	require.False(t, r.UpdateState(ctx, state, nil, release).HasError())
+
+	m := getModel(t, state)
+	assert.Equal(t, 2, len(m.Applications.Elements()))
+}
+
+func TestUpdateState_WithServiceNoScopedTo(t *testing.T) {
+	ctx := context.Background()
+	r := NewReleaseResourceHandle()
+
+	release := &api.ReleaseWithMetadata{
+		ID: "id-1", Name: "svc/v1", Start: 1709091782000, LastUpdated: 1709091782533,
+		Services: []*api.ReleaseServiceScope{{Name: "payment"}},
+	}
+
+	state := &tfsdk.State{Schema: r.MetaData().Schema}
+	setState(t, state, emptyReleaseModel())
+
+	require.False(t, r.UpdateState(ctx, state, nil, release).HasError())
+
+	m := getModel(t, state)
+	assert.Equal(t, 1, len(m.Services.Elements()))
+}
+
+func TestUpdateState_WithServiceAndScopedTo(t *testing.T) {
+	ctx := context.Background()
+	r := NewReleaseResourceHandle()
+
+	release := &api.ReleaseWithMetadata{
+		ID: "id-2", Name: "svc/v2", Start: 1709091782000, LastUpdated: 1709091782533,
 		Services: []*api.ReleaseServiceScope{
 			{
 				Name: "payment",
 				ScopedTo: &api.ReleaseServiceScopedTo{
-					ApplicationName: "checkout-app",
+					Applications: []*api.ReleaseApplicationScope{{Name: "checkout-app"}},
 				},
 			},
 		},
 	}
 
 	state := &tfsdk.State{Schema: r.MetaData().Schema}
-	initialModel := ReleaseModel{
-		ID:           types.StringValue(""),
-		Name:         types.StringValue(""),
-		Start:        types.Int64Value(0),
-		LastUpdated:  types.Int64Value(0),
-		Applications: emptyApplicationsList(),
-		Services:     emptyServicesList(),
-	}
-	require.False(t, state.Set(ctx, initialModel).HasError())
+	setState(t, state, emptyReleaseModel())
 
-	diags := r.UpdateState(ctx, state, nil, release)
-	require.False(t, diags.HasError())
+	require.False(t, r.UpdateState(ctx, state, nil, release).HasError())
 
-	var model ReleaseModel
-	require.False(t, state.Get(ctx, &model).HasError())
+	m := getModel(t, state)
+	assert.Equal(t, 1, len(m.Services.Elements()))
 
-	var apps []ApplicationModel
-	require.False(t, model.Applications.ElementsAs(ctx, &apps, false).HasError())
-	require.Len(t, apps, 1)
-	assert.Equal(t, "app1", apps[0].Name.ValueString())
-
+	// Inspect the service object directly
 	var svcs []ServiceModel
-	require.False(t, model.Services.ElementsAs(ctx, &svcs, false).HasError())
+	require.False(t, m.Services.ElementsAs(ctx, &svcs, false).HasError())
 	require.Len(t, svcs, 1)
 	assert.Equal(t, "payment", svcs[0].Name.ValueString())
 	require.NotNil(t, svcs[0].ScopedTo)
-	assert.Equal(t, "checkout-app", svcs[0].ScopedTo.ApplicationName.ValueString())
+
+	var scopedApps []ApplicationModel
+	require.False(t, svcs[0].ScopedTo.Applications.ElementsAs(ctx, &scopedApps, false).HasError())
+	require.Len(t, scopedApps, 1)
+	assert.Equal(t, "checkout-app", scopedApps[0].Name.ValueString())
 }
 
-func TestReleaseMapStateToDataObject_BasicRelease(t *testing.T) {
+// ─── MapStateToDataObject ─────────────────────────────────────────────────────
+
+func TestMapStateToDataObject_BasicFromPlan(t *testing.T) {
 	ctx := context.Background()
 	r := NewReleaseResourceHandle()
 
-	model := ReleaseModel{
-		ID:           types.StringValue("release-id-1"),
-		Name:         types.StringValue("frontend/release-1000"),
-		Start:        types.Int64Value(1742349976000),
-		LastUpdated:  types.Int64Value(0),
-		Applications: emptyApplicationsList(),
-		Services:     emptyServicesList(),
-	}
+	model := emptyReleaseModel()
+	model.ID = types.StringValue("release-id-1")
+	model.Name = types.StringValue("frontend/release-1000")
+	model.Start = types.Int64Value(1742349976000)
 
 	plan := &tfsdk.Plan{Schema: r.MetaData().Schema}
-	require.False(t, plan.Set(ctx, model).HasError())
+	setPlan(t, plan, model)
 
 	release, diags := r.MapStateToDataObject(ctx, plan, nil)
 	require.False(t, diags.HasError())
 	require.NotNil(t, release)
-
 	assert.Equal(t, "release-id-1", release.ID)
 	assert.Equal(t, "frontend/release-1000", release.Name)
 	assert.Equal(t, int64(1742349976000), release.Start)
@@ -174,123 +251,123 @@ func TestReleaseMapStateToDataObject_BasicRelease(t *testing.T) {
 	assert.Nil(t, release.Services)
 }
 
-func TestReleaseMapStateToDataObject_WithApplicationsAndServices(t *testing.T) {
+func TestMapStateToDataObject_BasicFromState(t *testing.T) {
 	ctx := context.Background()
 	r := NewReleaseResourceHandle()
 
-	appObj, d := types.ObjectValue(applicationAttrTypes, map[string]attr.Value{
-		ReleaseFieldName: types.StringValue("my-app"),
-	})
-	require.False(t, d.HasError())
-
-	scopedToObj, d := types.ObjectValue(scopedToAttrTypes, map[string]attr.Value{
-		ReleaseFieldApplicationName: types.StringValue("my-app"),
-		ReleaseFieldEnvironmentName: types.StringValue("production"),
-	})
-	require.False(t, d.HasError())
-
-	svcObj, d := types.ObjectValue(serviceAttrTypes, map[string]attr.Value{
-		ReleaseFieldName:     types.StringValue("my-service"),
-		ReleaseFieldScopedTo: scopedToObj,
-	})
-	require.False(t, d.HasError())
-
-	appsList, d := types.ListValue(types.ObjectType{AttrTypes: applicationAttrTypes}, []attr.Value{appObj})
-	require.False(t, d.HasError())
-
-	svcsList, d := types.ListValue(types.ObjectType{AttrTypes: serviceAttrTypes}, []attr.Value{svcObj})
-	require.False(t, d.HasError())
-
-	model := ReleaseModel{
-		ID:           types.StringValue("release-id-2"),
-		Name:         types.StringValue("backend/release-5"),
-		Start:        types.Int64Value(1742349976000),
-		LastUpdated:  types.Int64Value(0),
-		Applications: appsList,
-		Services:     svcsList,
-	}
-
-	plan := &tfsdk.Plan{Schema: r.MetaData().Schema}
-	require.False(t, plan.Set(ctx, model).HasError())
-
-	release, diags := r.MapStateToDataObject(ctx, plan, nil)
-	require.False(t, diags.HasError())
-	require.NotNil(t, release)
-
-	require.Len(t, release.Applications, 1)
-	assert.Equal(t, "my-app", release.Applications[0].Name)
-
-	require.Len(t, release.Services, 1)
-	assert.Equal(t, "my-service", release.Services[0].Name)
-	require.NotNil(t, release.Services[0].ScopedTo)
-	assert.Equal(t, "my-app", release.Services[0].ScopedTo.ApplicationName)
-	assert.Equal(t, "production", release.Services[0].ScopedTo.EnvironmentName)
-}
-
-func TestReleaseMapStateToDataObject_WithStateWhenNoPlan(t *testing.T) {
-	ctx := context.Background()
-	r := NewReleaseResourceHandle()
-
-	model := ReleaseModel{
-		ID:           types.StringValue("release-id-3"),
-		Name:         types.StringValue("state-read-release"),
-		Start:        types.Int64Value(1742349976000),
-		LastUpdated:  types.Int64Value(0),
-		Applications: emptyApplicationsList(),
-		Services:     emptyServicesList(),
-	}
+	model := emptyReleaseModel()
+	model.Name = types.StringValue("state-read-release")
+	model.Start = types.Int64Value(1742349976000)
 
 	state := &tfsdk.State{Schema: r.MetaData().Schema}
-	require.False(t, state.Set(ctx, model).HasError())
+	setState(t, state, model)
 
 	release, diags := r.MapStateToDataObject(ctx, nil, state)
 	require.False(t, diags.HasError())
-	require.NotNil(t, release)
-
 	assert.Equal(t, "state-read-release", release.Name)
 }
 
-func TestMapApplicationsToState_Empty(t *testing.T) {
+func TestMapStateToDataObject_WithApplications(t *testing.T) {
 	ctx := context.Background()
-	result, diags := mapApplicationsToState(ctx, nil)
+	r := NewReleaseResourceHandle()
+
+	appElemType := types.ObjectType{AttrTypes: applicationAttrTypes}
+	appObj, _ := types.ObjectValue(applicationAttrTypes, map[string]attr.Value{
+		ReleaseFieldName: types.StringValue("my-app"),
+	})
+	appList, _ := types.ListValue(appElemType, []attr.Value{appObj})
+
+	model := emptyReleaseModel()
+	model.Name = types.StringValue("app-release")
+	model.Start = types.Int64Value(1742349976000)
+	model.Applications = appList
+
+	plan := &tfsdk.Plan{Schema: r.MetaData().Schema}
+	setPlan(t, plan, model)
+
+	release, diags := r.MapStateToDataObject(ctx, plan, nil)
 	require.False(t, diags.HasError())
-	assert.False(t, result.IsNull())
-	assert.Empty(t, result.Elements())
+	require.Len(t, release.Applications, 1)
+	assert.Equal(t, "my-app", release.Applications[0].Name)
 }
 
-func TestMapServicesToState_Empty(t *testing.T) {
+func TestMapStateToDataObject_WithServiceNoScopedTo(t *testing.T) {
 	ctx := context.Background()
-	result, diags := mapServicesToState(ctx, nil)
+	r := NewReleaseResourceHandle()
+
+	model := buildServiceModel(t, "my-service", nil)
+	plan := &tfsdk.Plan{Schema: r.MetaData().Schema}
+	setPlan(t, plan, model)
+
+	release, diags := r.MapStateToDataObject(ctx, plan, nil)
 	require.False(t, diags.HasError())
-	assert.False(t, result.IsNull())
-	assert.Empty(t, result.Elements())
+	require.Len(t, release.Services, 1)
+	assert.Equal(t, "my-service", release.Services[0].Name)
+	assert.Nil(t, release.Services[0].ScopedTo)
 }
 
-func TestMapApplicationsFromState_Empty(t *testing.T) {
+func TestMapStateToDataObject_WithServiceAndScopedTo(t *testing.T) {
 	ctx := context.Background()
-	result, diags := mapApplicationsFromState(ctx, emptyApplicationsList())
+	r := NewReleaseResourceHandle()
+
+	model := buildServiceModel(t, "payment", []string{"checkout-app"})
+	plan := &tfsdk.Plan{Schema: r.MetaData().Schema}
+	setPlan(t, plan, model)
+
+	release, diags := r.MapStateToDataObject(ctx, plan, nil)
 	require.False(t, diags.HasError())
-	assert.Nil(t, result)
+	require.Len(t, release.Services, 1)
+	assert.Equal(t, "payment", release.Services[0].Name)
+	require.NotNil(t, release.Services[0].ScopedTo)
+	require.Len(t, release.Services[0].ScopedTo.Applications, 1)
+	assert.Equal(t, "checkout-app", release.Services[0].ScopedTo.Applications[0].Name)
 }
 
-func TestMapServicesFromState_Empty(t *testing.T) {
+func TestMapStateToDataObject_WithServiceAndMultipleScopedToApps(t *testing.T) {
 	ctx := context.Background()
-	result, diags := mapServicesFromState(ctx, emptyServicesList())
+	r := NewReleaseResourceHandle()
+
+	model := buildServiceModel(t, "payment", []string{"app-a", "app-b"})
+	plan := &tfsdk.Plan{Schema: r.MetaData().Schema}
+	setPlan(t, plan, model)
+
+	release, diags := r.MapStateToDataObject(ctx, plan, nil)
 	require.False(t, diags.HasError())
-	assert.Nil(t, result)
+	require.NotNil(t, release.Services[0].ScopedTo)
+	require.Len(t, release.Services[0].ScopedTo.Applications, 2)
+	assert.Equal(t, "app-a", release.Services[0].ScopedTo.Applications[0].Name)
+	assert.Equal(t, "app-b", release.Services[0].ScopedTo.Applications[1].Name)
 }
 
-func TestMapServicesToState_NoScopedTo(t *testing.T) {
-	ctx := context.Background()
-	services := []*api.ReleaseServiceScope{
-		{Name: "plain-service"},
+// ─── helper functions ─────────────────────────────────────────────────────────
+
+func TestBuildApplicationList_Empty(t *testing.T) {
+	list, diags := buildApplicationList(nil)
+	require.False(t, diags.HasError())
+	assert.Equal(t, 0, len(list.Elements()))
+}
+
+func TestBuildApplicationList_OneEntry(t *testing.T) {
+	list, diags := buildApplicationList([]*api.ReleaseApplicationScope{{Name: "app1"}})
+	require.False(t, diags.HasError())
+	assert.Equal(t, 1, len(list.Elements()))
+}
+
+func TestBuildScopedToObject_Nil(t *testing.T) {
+	val, diags := buildScopedToObject(nil)
+	require.False(t, diags.HasError())
+	obj, ok := val.(types.Object)
+	require.True(t, ok)
+	assert.True(t, obj.IsNull())
+}
+
+func TestBuildScopedToObject_WithApplications(t *testing.T) {
+	scopedTo := &api.ReleaseServiceScopedTo{
+		Applications: []*api.ReleaseApplicationScope{{Name: "app1"}},
 	}
-	result, diags := mapServicesToState(ctx, services)
+	val, diags := buildScopedToObject(scopedTo)
 	require.False(t, diags.HasError())
-	require.Len(t, result.Elements(), 1)
-
-	var svcs []ServiceModel
-	require.False(t, result.ElementsAs(ctx, &svcs, false).HasError())
-	assert.Equal(t, "plain-service", svcs[0].Name.ValueString())
-	assert.Nil(t, svcs[0].ScopedTo)
+	obj, ok := val.(types.Object)
+	require.True(t, ok)
+	assert.False(t, obj.IsNull())
 }

--- a/testutils/mock-instana-api.go
+++ b/testutils/mock-instana-api.go
@@ -179,3 +179,8 @@ func (m *MockInstanaAPI) GroupMappings() rest.RestResource[*api.GroupMapping] {
 func (m *MockInstanaAPI) SessionSettings() rest.SingletonRestResource[*api.SessionSettings] {
 	return nil
 }
+
+// Releases mock implementation
+func (m *MockInstanaAPI) Releases() rest.RestResource[*api.ReleaseWithMetadata] {
+	return nil
+}


### PR DESCRIPTION
# Summary

This pull request introduces a new Terraform resource for managing **Instana Release Markers** (`instana_release`). Release Markers allow you to annotate your Instana monitoring timeline with deployment or release events, making it easier to correlate application behaviour changes with specific releases. You can scope releases to specific applications and services, giving teams clear visibility into which parts of the system were affected by a given deployment.

With this change, Terraform users can now declaratively manage release markers as part of their infrastructure-as-code workflows — creating, updating, and deleting releases directly through the `instana_release` resource, without needing to interact with the Instana UI or API manually.

The Instana Go client dependency is also bumped from `v1.3.0` to `v1.4.0` to support the new Releases API endpoint.

## What This Means for You

- **New resource: `instana_release`** — Define release markers in your Terraform configuration to track deployments on your Instana dashboards and timelines.
- **Application and service scoping** — Optionally associate a release with up to 10 applications and any number of services, with optional perspective restrictions via `scoped_to`.
- **Timeline correlation** — Once a release marker is created, Instana will display it on your monitoring charts, helping you quickly identify if a deployment caused a spike in errors, latency, or other anomalies.
- **Fully declarative** — Manage the full lifecycle of release markers (create, read, update, delete) through Terraform, keeping your observability configuration in sync with your deployment pipeline.