### PR TITLE
fix(log-alert-config): default alert_type to "log.count" when omitted

### DIFF
--- a/internal/resources/logalertconfig/resource-log-alert-config.go
+++ b/internal/resources/logalertconfig/resource-log-alert-config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -159,12 +160,14 @@ func buildRulesSchema() schema.SingleNestedAttribute {
 				Description: LogAlertConfigDescMetricName,
 			},
 			LogAlertConfigFieldAlertType: schema.StringAttribute{
-				Optional:    true,
-				Description: LogAlertConfigDescAlertType,
-				Validators: []validator.String{
-					stringvalidator.OneOf(LogAlertTypeLogCount),
+					Optional:    true,
+					Computed:    true,
+					Default:     stringdefault.StaticString(LogAlertTypeLogCount),
+					Description: LogAlertConfigDescAlertType,
+					Validators: []validator.String{
+						stringvalidator.OneOf(LogAlertTypeLogCount),
+					},
 				},
-			},
 			LogAlertConfigFieldAggregation: schema.StringAttribute{
 				Optional:    true,
 				Computed:    true,


### PR DESCRIPTION
## Description

Fixes #111

Previously, omitting alert_type in a rules block of instana_log_alert_config would silently send an empty value to the Instana API, causing the resource creation or update to fail with a generic HTTP 400 error that gave no hint about which field was the problem.

Since "log.count" is the only accepted value for this field, the provider now defaults it automatically — so users don't need to set it explicitly in their configuration.